### PR TITLE
[issue-67] add PR template for Osmosis docs repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!--
+*Thank you very much for contributing to Osmosis - we are happy that you want to help us improve Osmosis and its docs. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*
+
+*Please understand that we do not do this to make contributions to Osmosis a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*
+
+## Contribution Checklist
+
+  - Name the pull request in the form "[ISSUE-XXXX] [component] Title of the pull request", where *XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
+
+  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
+
+  - Each pull request should address only one issue, not mix up code from multiple issues.
+  
+  - Each commit in the pull request has a meaningful commit message
+
+  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
+
+
+**(The sections below can be removed for hotfixes of typos)**
+-->
+
+## What is the purpose of the change
+
+*(For example: This pull request improves documation of area A by adding ....*
+
+
+## Brief change log
+
+*(for example:)*
+  - *Added content in page XXX*
+  - *Updated cross reference link in YYY*
+
+
+## Verifying this change
+
+*(Please pick either of the following options)*
+
+This change has been tested locally by rebuilding the doc website and verified content and links are expected
+
+*(or)*
+
+This change has not been tested locally, because (to-be-explained-why...)
+


### PR DESCRIPTION
## What is the purpose of the change

for https://github.com/osmosis-labs/docs/issues/67

add a PR template for osmosis docs repo, the PR template will ask requesters to fill in necessary info which will help reviewers to learn the context faster. The template will also force following the same standard going forward

To demonstrate the effect, I'm creating this PR in the exact format that should look like with the template

## Brief change log

- added PR template in .github, such that github will use this as a template whenever a new PR is created going forward


## Verifying this change

This change has not been tested locally, because it can only be tested in github