### PR TITLE
Fix typo

### DIFF
--- a/developing/network/join-testnet.md
+++ b/developing/network/join-testnet.md
@@ -74,7 +74,7 @@ Download and replace the genesis file:
 
 ```bash
 cd $HOME/.osmosisd/config
-wget wget https://github.com/osmosis-labs/networks/raw/main/osmo-test-4/genesis.tar.bz2
+wget https://github.com/osmosis-labs/networks/raw/main/osmo-test-4/genesis.tar.bz2
 tar -xjf genesis.tar.bz2 && rm genesis.tar.bz2
 ```
 


### PR DESCRIPTION
## What is the purpose of the change
- `wget` is written twice when downloading genesis file for the testnet.

## Brief change log
- Remove `wget` in this [section](https://docs.osmosis.zone/developing/network/join-testnet.html#set-up-cosmovisor)

## Verifying this change
This change has been tested locally by rebuilding the doc website and verified content and links are expected