### PR TITLE
Fixes to broken docs

### DIFF
--- a/developing/network/join-mainnet.md
+++ b/developing/network/join-mainnet.md
@@ -2,9 +2,9 @@
 
 ## Install Osmosis Binary
 
-Make sure you have [installed the Osmosis Binary (CLI)](../tools/osmosisd#manual-installation) prior to following the below instructions.
+Make sure you have [installed the Osmosis Binary (CLI)](https://docs.osmosis.zone/developing/tools/osmosisd.html#minimum-requirements) prior to following the below instructions.
 
-You may also [use the Osmosis installer](../tools/osmosisd#quick-start) if you want everything to be done automatically.
+You may also [use the Osmosis installer](https://docs.osmosis.zone/developing/tools/osmosisd.html#quick-start) if you want everything to be done automatically.
 
 ## Initialize Osmosis Node
 


### PR DESCRIPTION
## What is the purpose of the change

https://docs.osmosis.zone/developing/network/join-testnet.html#install-osmosis-binary
The “installed the osmosis binary” and “use the osmosis installer” are both broken

## Brief change log

Fixed broken links as described


## Verifying this change

*(Please pick either of the following options)*

**This change has been tested locally by rebuilding the doc website and verified content and links are expected**

*(or)*

This change has not been tested locally, because (to-be-explained-why...)

