### PR TITLE
Update gRPC port for testnet

### DIFF
--- a/docs/networks/README.md
+++ b/docs/networks/README.md
@@ -7,7 +7,7 @@ These following API's are recommended for development purposes. For maximun cont
 | Network | Mainnet | Testnet | Docs |
 | -------- | -------- | -------- | -------- | 
 | **Chain ID**  | osmosis-1 | osmo-test-4  |
-| **gRPC endpoint**  | grpc.osmosis.zone:9090 | grpc-test.osmosis.zone:443 |
+| **gRPC endpoint**  | grpc.osmosis.zone:9090 | grpc-test.osmosis.zone:9090 |
 | **gRPC-gateway**  | rpc.osmosis.zone  | rpc-test.osmosis.zone |
 | **RPC API Reference**  |  [API Reference](/api) | [API Reference](/api) |
 | **LCD API Reference**  |  [API Reference](/api/?v=LCD) | [API Reference](/api/?v=LCD) |


### PR DESCRIPTION
From my testing, it appears that the endpoint is actually listening on port 9090. Basic testing seemed to work. One other thing that may be useful is to clarify that the endpoint is listening on plaintext gRPC instead of SSL. I'd be happy to update this PR to include `http://` if that would be acceptable.

## What is the purpose of the change

Fix port number for gRPC endpoint for testnet.

## Brief change log

  - Change endpoint to port 9090 for gRPC testnet

## Verifying this change

I've run local code that uses the updated port number.