### PR TITLE
update installation command for new cosmovisor versions

### DIFF
--- a/docs/networks/join-mainnet.mdx
+++ b/docs/networks/join-mainnet.mdx
@@ -61,8 +61,10 @@ As always, we recommend having 64GB of memory.
 Set up cosmovisor to ensure any future upgrades happen flawlessly. To install Cosmovisor:
 
 ```bash
-go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0
+go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
 ```
+
+(You may also refer to the Cosmovisor [installation instructions](https://github.com/cosmos/cosmos-sdk/tree/main/tools/cosmovisor#installation).)
 
 Create the required directories:
 


### PR DESCRIPTION
## What is the purpose of the change

To update the installation instructions for Cosmovisor, which have recently changed paths.

I noticed some updates in Cosmovisor here:

https://github.com/cosmos/cosmos-sdk/releases/tag/tools%2Fcosmovisor%2Fv1.4.0

and here

https://github.com/cosmos/cosmos-sdk/tree/main/tools/cosmovisor#installation

Looks like it's moving to a different location and the path is a bit different now.

In the second link they note:

> IMPORTANT: Chains that use Cosmos-SDK v0.44.3 or earlier (eg v0.44.2) and want to use auto-download feature MUST use cosmovisor v0.1.0

but it seems like we're good, I'm guessing because this is our version:
https://github.com/osmosis-labs/osmosis/blob/d9273e7a302c354061fea8d3167a7d5ece53ad5a/go.mod#L8

## Brief change log

- *Updated Cosmovisor installation path*

## Verifying this change

This change has not been tested locally, because (to-be-explained-why...)

Actually, even after building and `npm run start` I was not seeing this change locally, no idea why that'd be. Also tried `npm run clear` and trying again but didn't work.

