### PR TITLE
Change cosmovisor unit file to /etc/… instead of /lib/…

### DIFF
--- a/docs/networks/join-mainnet.mdx
+++ b/docs/networks/join-mainnet.mdx
@@ -232,8 +232,16 @@ WantedBy=multi-user.target
 Move this new file to the systemd directory:
 
 ```bash
-sudo mv cosmovisor.service /lib/systemd/system/cosmovisor.service
+sudo mv cosmovisor.service /etc/systemd/system/cosmovisor.service
 ```
+
+:::note
+Previously, this documentation suggested to move the systemd unit file to:
+
+    /lib/systemd/system/cosmovisor.service
+
+If dealing with a server that may have followed older instructions, you may consider looking there.
+:::
 
 ## Start Osmosis Service
 

--- a/docs/networks/join-testnet.md
+++ b/docs/networks/join-testnet.md
@@ -185,8 +185,16 @@ WantedBy=multi-user.target
 Move this new file to the systemd directory:
 
 ```bash
-sudo mv cosmovisor.service /lib/systemd/system/cosmovisor.service
+sudo mv cosmovisor.service /etc/systemd/system/cosmovisor.service
 ```
+
+:::note
+Previously, this documentation suggested to move the systemd unit file to:
+
+    /lib/systemd/system/cosmovisor.service
+
+If dealing with a server that may have followed older instructions, you may consider looking there.
+:::
 
 ## Start Osmosis Service
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes a minor modification to the docs, particularly the part where you create a `systemd` unit file for cosmovisor.

## Brief change log

  - Updated preferred location of systemd unit files for testnet and mainnet sections
  - Added a Docusaurus "[admonition](https://docusaurus.io/docs/next/markdown-features/admonitions)" noting where the docs used to instruct users to put the unit file, for folks in the ecosystem who might inherit server access and need to know that information.

## Verifying this change

✅  This change has been tested locally by rebuilding the doc website and verified content and links are expected

## More details

According to this article, the `/lib/systemd/…` directory is not the best place to make modifications for unit files.

>In Red Hat-based systems like CentOS, unit files are located in two places. The main location is /lib/systemd/system/. **Custom-created unit files or existing unit files modified by system administrators will live under /etc/systemd/system.**

https://www.digitalocean.com/community/tutorials/how-to-configure-a-linux-service-to-start-automatically-after-a-crash-or-reboot-part-1-practical-examples#https:/www.digitalocean.com/community/tutorials/how-to-configure-a-linux-service-to-start-automatically-after-a-crash-or-reboot-part-1-practical-examples#examining-a-systemd-unit-file#directory-structure

Perhaps another helpful link regarding system paths:
https://www.freedesktop.org/software/systemd/man/file-hierarchy.html#System%20Packages

I also know from recent experience that Stargaze and Juno both instruct users to use `/etc/systemd` (as suggested in this PR) and think it'd be great to have the Osmosis docs changed.

I recently migrated three validators, which is a somewhat high-intensity task, since double-signing can happen if a person is not careful. Having these instructions exactly the same and following best practices may help reduce some cognitive overhead to future folks.