### PR TITLE
bug: fix incorrect cosmovisor command for latest version

### DIFF
--- a/docs/networks/join-mainnet.mdx
+++ b/docs/networks/join-mainnet.mdx
@@ -219,7 +219,7 @@ Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
 Environment="DAEMON_LOG_BUFFER_SIZE=512"
 Environment="UNSAFE_SKIP_BACKUP=true"
 User=$USER
-ExecStart=${HOME}/go/bin/cosmovisor start
+ExecStart=${HOME}/go/bin/cosmovisor run start
 Restart=always
 RestartSec=3
 LimitNOFILE=infinity

--- a/docs/networks/join-testnet.md
+++ b/docs/networks/join-testnet.md
@@ -172,7 +172,7 @@ Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
 Environment="DAEMON_LOG_BUFFER_SIZE=512"
 Environment="UNSAFE_SKIP_BACKUP=true"
 User=$USER
-ExecStart=${HOME}/go/bin/cosmovisor start
+ExecStart=${HOME}/go/bin/cosmovisor run start
 Restart=always
 RestartSec=3
 LimitNOFILE=infinity


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Osmosis - we are happy that you want to help us improve Osmosis and its docs. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Osmosis a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Name the pull request in the form "[ISSUE-XXXX] [component] Title of the pull request", where *XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Since the docs encourage the latest usage of cosmovisor - cosmovisor now requires `run` to be appended to all new commands.

## Verifying this change

This change has not been tested locally, because it is a minor change in the copy.

