### PR TITLE
add celatone to list of explorers

### DIFF
--- a/docs/networks/explorers.md
+++ b/docs/networks/explorers.md
@@ -5,9 +5,13 @@ The explorers in the Cosmos ecosystem are rapidily growing. The following is a l
 
 ## Mainnet
 
-#### Block explorers
+#### Block Explorers
 - [Mintscan](https://www.mintscan.io/osmosis)
 - [Bigdipper](https://osmosis.bigdipper.live/)
+
+#### Contract Explorers
+
+- [Celatone](https://celatone.osmosis.zone/mainnet)
 
 
 ## Testnet
@@ -15,4 +19,5 @@ The explorers in the Cosmos ecosystem are rapidily growing. The following is a l
 - [Mintscan](https://testnet.mintscan.io/osmosis-testnet)
 
 #### Contract Explorers
+- [Celatone](https://celatone.osmosis.zone/testnet)
 - [Code-explorer](https://osmosis-contracts.web.app/#/codes)


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds [Celatone](https://celatone.osmosis.zone) to the list of available contract explorers for Osmosis mainnet (osmosis-1) and testnet (osmo-test-4)

## Brief change log

- Adds Celatone to the list of available contract explorers for Osmosis testnet and mainnet

## Verifying this change

This change has been tested locally by rebuilding the doc website and verified content and links are expected.