### PR TITLE
Replace deprecated testnet RPC endpoint with current

### DIFF
--- a/docs/apis/interact-cli.mdx
+++ b/docs/apis/interact-cli.mdx
@@ -65,7 +65,7 @@ osmosisd status
 ```bash
 osmosisd config
 ```
-Output: 
+Output:
 ```json
 {
 	"chain-id": "osmosis-1",
@@ -76,7 +76,7 @@ Output:
 	"grpc-concurrency": false
 }
 ```
-In this example when we install osmosisd as a client with the [installer](../osmosis-core/osmosisd), it connects to the `http://osmosis.artifact-staking.io:26657`. 
+In this example when we install osmosisd as a client with the [installer](../osmosis-core/osmosisd), it connects to the `http://osmosis.artifact-staking.io:26657`.
 
 ### Change node
 
@@ -87,7 +87,7 @@ osmosis config node https://rpc.osmosis.zone:443
 ### Connect to the testnet
 
 ```bash
-osmosisd config node https://rpc-test.osmosis.zone:443
+osmosisd config node https://rpc.testnet.osmosis.zone:443
 osmosisd config chain-id osmo-test-4
 ```
 
@@ -99,14 +99,14 @@ osmosisd keys add testaccount --keyring-backend test
 MYACCOUNT=$(osmosisd keys show testaccount -a --keyring-backend test)
 ```
 
-The command above creates a local key-pair that is not yet registered on the chain. An account is created the first time it receives tokens from another account. 
+The command above creates a local key-pair that is not yet registered on the chain. An account is created the first time it receives tokens from another account.
  You can now send some tokens to this enw account. If you are connected to the testnet, you can get tokens from [https://faucet.osmosis.zone](https://faucet.osmosis.zone)
 
 ```bash
 # Check that the testaccount account did receive the tokens.
 osmosisd query bank balances $MYACCOUNT
 ```
-![](../assets/query-balance.png)  
+![](../assets/query-balance.png)
 
 For more information about querying osmosisd via the CLI visit the [Cosmos documentation](https://hub.cosmos.network/main/hub-tutorials/gaiad.html).
 

--- a/docs/beaker/config/README.md
+++ b/docs/beaker/config/README.md
@@ -24,7 +24,7 @@ rpc_endpoint = 'http://localhost:26657'
 chain_id = 'osmo-test-4'
 network_variant = 'Shared'
 grpc_endpoint = 'https://grpc-test.osmosis.zone:9090'
-rpc_endpoint = 'https://rpc-test.osmosis.zone'
+rpc_endpoint = 'https://rpc.testnet.osmosis.zone'
 
 [networks.mainnet]
 chain_id = 'osmosis-1'

--- a/docs/beaker/config/global.md
+++ b/docs/beaker/config/global.md
@@ -150,7 +150,7 @@ rpc_endpoint = 'http://localhost:26657'
 chain_id = 'osmo-test-4'
 network_variant = 'Shared'
 grpc_endpoint = 'https://grpc-test.osmosis.zone:443'
-rpc_endpoint = 'https://rpc-test.osmosis.zone'
+rpc_endpoint = 'https://rpc.testnet.osmosis.zone'
 
 [networks.mainnet]
 chain_id = 'osmosis-1'

--- a/docs/cosmwasm/cosmwasm-verify-contract.md
+++ b/docs/cosmwasm/cosmwasm-verify-contract.md
@@ -30,7 +30,7 @@ Output:
 ### Contract version
 Get the contract version by running the following command
 ```
-osmosisd query wasm contract-state raw osmo1mpf0guu0t363xrshhedandypq003ahzaxvsxzgu69n3ej03mh2zqx5gk8l 636F6E74726163745F696E666F --node https://rpc-test.osmosis.zone:443 --output json | jq  -r .data | base64 -d | jq
+osmosisd query wasm contract-state raw osmo1mpf0guu0t363xrshhedandypq003ahzaxvsxzgu69n3ej03mh2zqx5gk8l 636F6E74726163745F696E666F --node https://rpc.testnet.osmosis.zone:443 --output json | jq  -r .data | base64 -d | jq
 ```
 What in the world is `636F6E74726163745F696E666F`? 😕 
 
@@ -43,7 +43,7 @@ Output:
 ### Downloading the Contract from the network
 
 ```
-osmosisd query wasm code 205 205_code.wasm --node https://rpc-test.osmosis.zone:443
+osmosisd query wasm code 205 205_code.wasm --node https://rpc.testnet.osmosis.zone:443
 ```
 Output:
 

--- a/docs/networks/README.md
+++ b/docs/networks/README.md
@@ -8,7 +8,7 @@ These following API's are recommended for development purposes. For maximun cont
 | -------- | -------- | -------- | -------- | 
 | **Chain ID**  | osmosis-1 | osmo-test-4  |
 | **gRPC endpoint**  | grpc.osmosis.zone:9090 | grpc-test.osmosis.zone:443 |
-| **gRPC-gateway**  | https://rpc.osmosis.zone:443  | https://rpc-test.osmosis.zone:443 |
+| **gRPC-gateway**  | https://rpc.osmosis.zone:443  | https://rpc.testnet.osmosis.zone:443 |
 | **RPC API Reference**  |  [API Reference](/api) | [API Reference](/api) |
 | **LCD API Reference**  |  [API Reference](/api/?v=LCD) | [API Reference](/api/?v=LCD) |
 | **LCD endpoint**  | https://lcd.osmosis.zone | https://lcd-test.osmosis.zone  |

--- a/static/api/RPC.yaml
+++ b/static/api/RPC.yaml
@@ -61,7 +61,7 @@ info:
 servers:
   - url: https://rpc.osmosis.zone
     description: Osmosis mainnet node to interact with the Tendermint RPC
-  - url: https://rpc-test.osmosis.zone
+  - url: https://rpc.testnet.osmosis.zone
     description: Osmosis testnet node to interact with the Tendermint RPC
   - url: https://rpc.cosmos.network
     description: Cosmos mainnet node to interact with the Tendermint RPC


### PR DESCRIPTION
Simple PR to update the testnet endpoint. During discussions, found out the one in docs and chain-registry is deprecated, so tryna help out and lean in a little.

<img width="549" alt="Screen Shot 2023-03-12 at 8 37 23 PM" src="https://user-images.githubusercontent.com/1042667/224602692-723f18e4-5d7a-45ee-9304-d6f759ab5d34.png">

Related: https://github.com/cosmos/chain-registry/pull/1580