### PR TITLE
Add OnFinality Public RPC Endpoint for Osmosis

### DIFF
--- a/docs/networks/README.md
+++ b/docs/networks/README.md
@@ -43,3 +43,5 @@ Did you know there is also an NPM package that fetch chain-registry data? <br/>
     - Technical support
 
 - [DataHub](https://datahub.figment.io) : `https://datahub.figment.io`
+
+- [OnFinality](https://onfinality.io/) is a blockchain infrastructure platform that saves Web3 builders time and makes their lives easier. OnFinality delivers scalable API endpoints for the biggest blockchain networks and empowers developers to automatically test, deploy, scale and monitor their own blockchain nodes in minutes. OnFinality offers free and premium (Pay-as-you-go or subsription-based) API [services for Osmosis](https://onfinality.io/networks/osmosis). Public RPC Endpoint for Osmosis: `https://osmosis.api.onfinality.io/public`


### PR DESCRIPTION
## What is the purpose of the change
This pull request improves documation of area Networks/Other Providers by adding public RPC endpoint for Osmosis served by OnFinality.

## Brief change log
  - Added content in page Networks in section Other Providers: OnFinality short description, link to Osmosis Network Page on OnFinality website and the endpoint address.

## Verifying this change
This change has not been tested locally, because I only altered the text via the GitHub web app. 