### PR TITLE
[ISSUE-192] [ide-guide] Use copilot instead

### DIFF
--- a/docs/osmosis-core/ide-guide.md
+++ b/docs/osmosis-core/ide-guide.md
@@ -32,11 +32,12 @@ Finally, add the Cosmos SDK to your workspace by selecting it in `File -> Add Fo
 Both Osmosis and the Cosmos SDK should now show up on the same VSCode page!
 
 ## Add Relevant VSCode Extensions
-Add the following extensions to your VSCode:
+These are the VSCode extensions that are in daily use by the teams working on Osmosis, you can feel free to mix and match, but these are what is in common use.  
+
 1. [Go by Google](https://marketplace.visualstudio.com/items?itemName=golang.Go)
 2. [VSCode Proto 3 by zxh404](https://marketplace.visualstudio.com/items?itemName=zxh404.vscode-proto3)
 3. [Git Lens by GitKraken](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
-4. [Tabnine AI by Tabnine](https://marketplace.visualstudio.com/items?itemName=TabNine.tabnine-vscode)
+4. [Github Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilotvs)
 
 ## Vscode configuration
 


### PR DESCRIPTION
## What is the purpose of the change

Github copilot seems to be better than tabnine, so we'll specify that in the setup guide instead of tabnine.  

## Brief change log

Replaced tabnine link with a link to github copilot.  


## Verifying this change

The ide-guide page should show copilot instead of tabnine.  

