### PR TITLE
Update wget for golang version from `1.17.2` » `1.19.9`

### DIFF
--- a/docs/osmosis-core/osmosisd.md
+++ b/docs/osmosis-core/osmosisd.md
@@ -59,7 +59,7 @@ sudo apt install git build-essential ufw curl jq snapd --yes
 Install go:
 
 ```bash
-wget -q -O - https://git.io/vQhTU | bash -s -- --version 1.17.2
+wget -q -O - https://git.io/vQhTU | bash -s -- --version 1.19.9
 ```
 
 After installed, open new terminal to properly load go


### PR DESCRIPTION
Followed the directions and realized we need to update the command to support the version required for the current `osmosisd` binary.

Werked:

<img width="1359" alt="Screen Shot 2023-05-15 at 8 28 47 AM" src="https://github.com/osmosis-labs/docs/assets/1042667/6ac49c1e-4449-4a53-8007-3575e0b5ff10">
