### PR TITLE
[ISSUE #209]Wrong command edited (pool-incentive -> poolincentive)

### DIFF
--- a/docs/osmosis-core/modules/pool-incentives/README.md
+++ b/docs/osmosis-core/modules/pool-incentives/README.md
@@ -229,13 +229,13 @@ An example output:
 Query externally incentivized gauges (gauges distributing rewards on top of the normal OSMO rewards)
 
 ```sh
-osmosisd query pool-incentives external-incentivized-gauges
+osmosisd query poolincentives external-incentivized-gauges
 ```
 
 ::: details Example
 
 ```bash
-osmosisd query pool-incentives external-incentivized-gauges
+osmosisd query poolincentives external-incentivized-gauges
 ```
 
 An example output:


### PR DESCRIPTION
## What is the purpose of the change

Solves Issue #209 correcting a typo in the command in `pool-incentive` to `poolincentive`.

## Verifying this change

This change has been tested locally.