### PR TITLE
Updated Site Links for IBC Website and Documentation

### DIFF
--- a/docs/osmosis-core/guides/create-ibc-pool.md
+++ b/docs/osmosis-core/guides/create-ibc-pool.md
@@ -28,8 +28,8 @@ Note that IBC transfers can be enabled via:
 To ensure a smooth user experience, Osmosis assumes all tokens will be transferred through a single designated IBC channel between Osmosis and the counterparty zone.
 
 Recommended readings:
-* [IBC Overview](https://docs.cosmos.network/v0.43/ibc/overview.html) - To understand IBC clients, connections, 
-* [How to Upgrade IBC Chains and their Clients](https://docs.cosmos.network/v0.43/ibc/upgrades/quick-guide.html)
+* [IBC Overview](https://ibc.cosmos.network/main/ibc/overview) - To understand IBC components, including clients, connections, proofs, paths, and channels.
+* [How to Upgrade IBC Chains and their Clients](https://ibc.cosmos.network/main/ibc/upgrades/quick-guide)
 
 ### 1. Add your chain to cosmos/chain-registry and SLIP-0173
 

--- a/docs/osmosis-core/relaying/README.mdx
+++ b/docs/osmosis-core/relaying/README.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 # Relaying
 
 In IBC, blockchains do not directly pass messages to each other over the network. This is where `relayer` comes in. 
-A relayer process monitors for updates on opens paths between sets of [IBC](https://ibcprotocol.org/) enabled chains.
+A relayer process monitors for updates on opens paths between sets of [IBC](https://www.ibcprotocol.dev/) enabled chains.
 The relayer submits these updates in the form of specific message types to the counterparty chain. Clients are then used to 
 track and verify the consensus state.
 

--- a/docs/overview/educate/osmosis.md
+++ b/docs/overview/educate/osmosis.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 ---
 # What is Osmosis?
 
-Osmosis is the premier cross-chain DeFi hub. As the liquidity center and primary trading venue of Cosmos – the open, emergent ecosystem of sovereign Layer 1s connected with the [Inter-Blockchain Communication protocol](https://ibcprotocol.org/) (IBC) – it is the access point for the wide world of appchains, the gateway to the interchain.
+Osmosis is the premier cross-chain DeFi hub. As the liquidity center and primary trading venue of Cosmos – the open, emergent ecosystem of sovereign Layer 1s connected with the [Inter-Blockchain Communication protocol](https://www.ibcprotocol.dev/) (IBC) – it is the access point for the wide world of appchains, the gateway to the interchain.
 As IBC continues to explode – with more than 50 blockchains connected and dozens more in development, including [dYdX chain](https://dydx.exchange/blog/dydx-chain), and with teams working to enable IBC on [Avalanche](https://www.landslide.network/), [Polkadot](https://docs.composable.finance/products/centauri-overview/), [NEAR](https://medium.com/composable-finance/near-foundation-issues-grant-to-composable-for-extending-ibc-to-near-via-the-centauri-bridge-e1d6c291ffb8), and others, potentially even [Ethereum](https://ethresear.ch/t/bringing-ibc-to-ethereum-using-zk-snarks/13634) – Osmosis will be there to welcome new users, developers, and protocols to the Internet of Blockchains.
 
 ![](../../assets/welcome.png)

--- a/docs/overview/integrate/transfer.md
+++ b/docs/overview/integrate/transfer.md
@@ -26,8 +26,8 @@ IBC transfers can be enabled:
 To ensure a smooth user experience, Osmosis assumes all tokens will be transferred through a single designated IBC channel between Osmosis and the counterparty zone.
 
 Recommended readings:
-* [IBC Overview](https://docs.cosmos.network/master/ibc/overview.html) - To understand IBC clients, connections, 
-* [How to Upgrade IBC Chains and their Clients](https://docs.cosmos.network/master/ibc/upgrades/quick-guide.html)
+* [IBC Overview](https://ibc.cosmos.network/main/ibc/overview) - To understand IBC components, including clients, connections, proofs, paths, and channels.
+* [How to Upgrade IBC Chains and their Clients](https://ibc.cosmos.network/main/ibc/upgrades/quick-guide)
 
 ### Not on a Cosmos-SDK chain?
 Several intermediary chains are in use or being developed that link the IBC enabled Cosmos with other ecosystems.


### PR DESCRIPTION
Updated links referring to the IBC site from the previous ibcprotocol.org website to the new ibcprotocol.dev website, as the .org site is no longer supported. Also, updated 404 links going to old IBC documentation to direct to the correct IBC docs site at https://ibc.cosmos.network/.