### PR TITLE
Remove frontend logos directive

### DIFF
--- a/docs/overview/integrate/registration.md
+++ b/docs/overview/integrate/registration.md
@@ -162,8 +162,6 @@ Asset Data
 1. Review the [Osmosis Frontend Repo](https://github.com/osmosis-labs/osmosis-frontend) docs:
     1. [README.md](https://github.com/osmosis-labs/osmosis-frontend/blob/master/README.md)
 2. Submit a pull request branch with necessary changes to the following:
-    - `osmosis-frontend/packages/web/public/tokens/`:
-        - Add token logo images
     - `osmosis-frontend/packages/web/config/chain-infos.ts`:
         - Add chain data to the `chainInfos` onject
             - Include the optimal RPC and REST endpoints


### PR DESCRIPTION
## What is the purpose of the change

Fix integration docs

## Brief change log

- Remove a directive to add logos to the frontend repo when integrating. These were moved out in 364b3b94b6f201685aa8dc6b05ceeb936a8b780d

## Verifying this change
This change has not been tested locally, because this PR is housekeeping as I attempt the integration.