### PR TITLE
Update docs to Go version 1.22

### DIFF
--- a/docs/osmosis-core/build.md
+++ b/docs/osmosis-core/build.md
@@ -6,17 +6,17 @@ sidebar_position: 2
 # Build and Test Osmosis Source Code
 
 
-## Install Go 1.18
+## Install Go 1.22
 
-Currently, Osmosis uses Go 1.18 to compile the code.
+Currently, Osmosis uses Go 1.22 to compile the code.
 
-Install [Go 1.18](https://go.dev/doc/install) by following instructions there.
+Install [Go 1.22](https://go.dev/doc/install) by following instructions there.
 
 Verify the installation by typing `go version` in your terminal.
 
 ```sh
 $ go version
-go version go1.18.1 darwin/amd64
+go version go1.22.4 darwin/amd64
 ```
 
 ## Build Osmosis


### PR DESCRIPTION
This pull request updates Go version on docs from 1.18 to 1.22.
The documentation is published here: https://docs.osmosis.zone/osmosis-core/build
I think this project uses go 1.22.4 because this is the version specified in **go.work** file in the root of this repository: https://github.com/osmosis-labs/osmosis