### PR TITLE
Add QuickNode infra provider

### DIFF
--- a/docs/overview/endpoints/index.mdx
+++ b/docs/overview/endpoints/index.mdx
@@ -93,16 +93,14 @@ The following is a list of explorers available.
 
 ## Infrastructure Providers
 
+- [QuickNode](https://www.quicknode.com/chains/osmosis) is the fastest and most reliable way to build and scale web3 applications. [Sign in](https://dashboard.quicknode.com/) and launch an Osmosis RPC endpoint now.
 - [All That Node](https://www.allthatnode.com/osmosis.dsrv) : `https://www.allthatnode.com/osmosis.dsrv`
   - Features
     - Unlimited access to archive data
     - Faucet available
     - Automated updates
     - Technical support
-
 - [DataHub](https://datahub.figment.io) : `https://datahub.figment.io`
-
 - [NOWNodes](https://nownodes.io/osmosis-osmo) is a Web3 development tool that provides shared and dedicated access to Osmosis RPC Full Node and Osmosis Tendermint endpoint on free and paid plans. The Osmosis Node API endpoint: `https://osmo.nownodes.io`
-
 - [OnFinality](https://onfinality.io/) is a blockchain infrastructure platform that saves Web3 builders time and makes their lives easier. OnFinality delivers scalable API endpoints for the biggest blockchain networks and empowers developers to automatically test, deploy, scale and monitor their own blockchain nodes in minutes. OnFinality offers free and premium (Pay-as-you-go or subsription-based) API [services for Osmosis](https://onfinality.io/networks/osmosis). Public RPC Endpoint for Osmosis: `https://osmosis.api.onfinality.io/public`
 

--- a/docs/overview/endpoints/index.mdx
+++ b/docs/overview/endpoints/index.mdx
@@ -93,7 +93,7 @@ The following is a list of explorers available.
 
 ## Infrastructure Providers
 
-- [QuickNode](https://www.quicknode.com/chains/osmosis) is the fastest and most reliable way to build and scale web3 applications. [Sign in](https://dashboard.quicknode.com/) and launch an Osmosis RPC endpoint now.
+- [QuickNode](https://www.quicknode.com/chains/osmosis) is a developer tooling platform offering a wide range of services including RPC APIs, data streams, cloud functions, a marketplace of third-party services, and more. [Sign in](https://dashboard.quicknode.com/) to launch an Osmosis RPC endpoint.
 - [All That Node](https://www.allthatnode.com/osmosis.dsrv) : `https://www.allthatnode.com/osmosis.dsrv`
   - Features
     - Unlimited access to archive data


### PR DESCRIPTION
## What is the purpose of the change

This pull request improves the documentation of infrastructure providers that support Osmosis by adding QuickNode to the list.


## Brief change log
  - *Added QuickNode to the infra provider list on page /overview/endpoints*


## Verifying this change
This change has been tested locally by rebuilding the doc website and verified content and links are expected

