### PR TITLE
typo fix localtesting.md

### DIFF
--- a/docs/osmosis-core/localtesting.md
+++ b/docs/osmosis-core/localtesting.md
@@ -26,7 +26,7 @@ LocalOsmosis has the following advantages over a public testnet:
 - [`docker-compose`](https://github.com/docker/compose)
 - [`Osmosisd`](https://get.osmosis.zone)
   * Select option 3 (localosmosis), the installer will configure everything for you. 
-  * The osmosisd dameon on your local computer is used to communicate with the localosmosis daemin running inside the Docker container. 
+  * The osmosisd dameon on your local computer is used to communicate with the localosmosis daemon running inside the Docker container. 
 - Supported known architecture: x86_64
 - 16+ GB of RAM is recommended
 


### PR DESCRIPTION
# Fix Typo in `localtesting.md`

## Description
This pull request corrects two typos in the `docs/osmosis-core/localtesting.md` file:
- **Line 26:** Fixed "dameon" to "daemon".

