### PR TITLE
[ISSUE-N/A] Add dRPC to infrastructure providers (Osmosis docs)

### DIFF
--- a/docs/overview/endpoints/index.mdx
+++ b/docs/overview/endpoints/index.mdx
@@ -103,4 +103,12 @@ The following is a list of explorers available.
 - [DataHub](https://datahub.figment.io) : `https://datahub.figment.io`
 - [NOWNodes](https://nownodes.io/osmosis-osmo) is a Web3 development tool that provides shared and dedicated access to Osmosis RPC Full Node and Osmosis Tendermint endpoint on free and paid plans. The Osmosis Node API endpoint: `https://osmo.nownodes.io`
 - [OnFinality](https://onfinality.io/) is a blockchain infrastructure platform that saves Web3 builders time and makes their lives easier. OnFinality delivers scalable API endpoints for the biggest blockchain networks and empowers developers to automatically test, deploy, scale and monitor their own blockchain nodes in minutes. OnFinality offers free and premium (Pay-as-you-go or subsription-based) API [services for Osmosis](https://onfinality.io/networks/osmosis). Public RPC Endpoint for Osmosis: `https://osmosis.api.onfinality.io/public`
+- [dRPC NodeCloud](https://drpc.org/chainlist/osmosis-mainnet-rpc) : `https://drpc.org/chainlist/osmosis-mainnet-rpc`
+  - Features
+    - https and websocket
+    - AI-powered load balancer
+    - 40+ distributed providers accross 8 geoclusters
+    - 180+ network APIs
+    - advance key and team features
+    - PAYG flat-fee CU pricing
 


### PR DESCRIPTION
Adds dRPC as an infrastructure provider with the Osmosis RPC endpoint page.

<!--
*Thank you very much for contributing to Osmosis - we are happy that you want to help us improve Osmosis and its docs. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Osmosis a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Name the pull request in the form "[ISSUE-XXXX] [component] Title of the pull request", where *XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add dRPC NodeCloud to the list of infrastructure providers


## Brief change log

Added dRPC entry to https://docs.osmosis.zone/overview/endpoints/#infrastructure-providers


## Verifying this change

This change has not been tested locally, because it is a documentation-only update that adds a provider link and does not modify site logic or rendering behavior.

