### PR TITLE
Clarify asset registration and auto-listing flow

### DIFF
--- a/docs/osmosis-core/modules/concentrated-liquidity/README.md
+++ b/docs/osmosis-core/modules/concentrated-liquidity/README.md
@@ -731,7 +731,7 @@ section.
 - `MsgSwapExactIn`
 - `MsgSwapExactOut`
 
-Once a message is received by the `x/poolmanager`, it is propageted into a
+Once a message is received by the `x/poolmanager`, it is propagated into a
 corresponding keeper
 in `x/concentrated-liquidity`.
 

--- a/docs/overview/integrate/registration.md
+++ b/docs/overview/integrate/registration.md
@@ -6,11 +6,13 @@ This guide intends to support teams looking to enlist their tokenized crypto ass
 
 ### Overview
 
-At a very high level, the process entails three main steps:
- - Registering to the Cosmos Chain Registry,
- - Registering to Osmosis Labs’ Assetlist Registry, and
- - Establishing markets for the asset on Osmosis.
-Note that the overall process could require collaboration from knowledgeable technical teams to provide information or services, as well as market-making entities to provide funding for initial liquidity or incentive programs.
+At a very high level, the process is:
+
+1. **Register chain and asset metadata to the Cosmos Chain Registry** (required), and ensure an IBC connection to Osmosis is registered there as well.
+2. **Wait for auto-listing** on Osmosis. The [osmosis-labs/assetlists](https://github.com/osmosis-labs/assetlists) pipeline runs twice weekly (Tuesdays and Fridays at 15:00 UTC) and automatically detects new IBC-connected assets in the Cosmos Chain Registry, adds them to `osmosis.zone_assets.json`, and ships them to Osmosis Zone as **unverified** assets.
+3. *(Optional)* **Submit a PR to `osmosis-labs/assetlists`** to configure advanced properties (categories, transfer methods, override metadata, etc.) and/or to request an upgrade to **verified status** once onchain liquidity criteria are met.
+
+Note that the overall process may require collaboration from technical teams (to provide chain services and IBC relaying) and market-making entities (to provide initial liquidity needed for verified status).
 
 To ensure a complete integration with Osmosis Zone and related apps, see the [Osmosis Labs' Assetlist Repository's LISTING.md Document](https://github.com/osmosis-labs/assetlists/blob/main/LISTING.md).
 
@@ -50,7 +52,7 @@ The Cosmos Chain Registry is meant to be a public good, used as a single source 
 		  - e.g., `"slip44": 118,`
 	  - Be sure to include at least one RPC and one REST under `apis`.
     - Be sure to include at least one working Block Explorer.
-  - Note that to enlisted on Osmosis, an IBC connection will need to be set up and registered (in `/_IBC/`) at the Chgain Registry.
+  - Note that to be enlisted on Osmosis, an IBC connection will need to be set up and registered (in `/_IBC/`) at the Chain Registry.
 3. If registering a new Asset, submit a pull request with necessary changes to the `assetlists.json` file.
 	- Follow the [assetlist.schema.json](https://github.com/cosmos/chain-registry/blob/master/assetlist.schema.json) format.
 	  - `name` refers to how the asset should be called when spoken in conversation.
@@ -65,114 +67,83 @@ The Cosmos Chain Registry is meant to be a public good, used as a single source 
   - Be sure to include a high quality logo image.
 
 
-## Step 2: Register an Asset to the Osmosis Labs' Assetlist Registry
+## Step 2: Wait for Auto-Listing on Osmosis (or Configure Advanced Properties)
 
 ### Purpose
 
-The Osmosis Labs' Assetlist Registry is used to serve asset metadata displayed on the Osmosis Zone app.
+The Osmosis Labs' Assetlist Registry ([osmosis-labs/assetlists](https://github.com/osmosis-labs/assetlists)) serves the asset metadata displayed on the Osmosis Zone app. For the vast majority of new tokens, **no manual PR to this repo is required**, the assetlist pipeline picks up new assets from the Cosmos Chain Registry automatically.
 
-### Prerequisites
+### How auto-detection works
 
-- Registered onto the Cosmos Chain Registry
-    - See: [How to register onto the Cosmos Chain Registry](https://docs.osmosis.zone/overview/integrate/registration#step-1-register-onto-the-cosmos-chain-registry)
-- IBC Connection
-  - Established an IBC connection between the source chain and Osmosis
-    - All native assets from a chain should go through a single connection, although some token types (e.g., CW20 tokens) may require another connection
-	  - See: [Enabling IBC transfers](https://docs.osmosis.zone/overview/integrate/transfer#enabling-ibc-transfers) and [Setting up and operating relayer to Osmosis](https://docs.osmosis.zone/overview/integrate/transfer#setting-up-and-operating-a-relayer-to-osmosis)
-  - Registered IBC Connection at the Cosmos Chain Registry.
-- There exists liquidity of the asset on Osmosis.
-	- See: [Pool Setup Guide](https://docs.osmosis.zone/overview/integrate/pool-setup) for the CLI command to create a pool.
-- Assets listed on CoinGecko (optional, but highly recommended)
-    - See: [How to enlist assets onto CoinGecko](../integrate/registration.md#how-to-enlist-an-asset-onto-coingecko)
+- A scheduled GitHub Actions workflow in `osmosis-labs/assetlists` runs regularly, currently twice weekly.
+- It scans the Cosmos Chain Registry for assets whose source chain has an IBC connection to Osmosis.
+- For each newly detected asset, the workflow generates an entry in `osmosis-1/osmosis.zone_assets.json` (and stubs the source chain into `osmosis.zone_chains.json` if it is not already present), opens a PR to the `update/assetlist_all` branch, runs validation, and auto-merges on success.
+- The asset is then shipped to Osmosis Zone as **unverified**. Unverified assets are visible only to users who have toggled "Show Unverified Assets" on in the Osmosis Zone app.
 
-### Requirements
+For the full workflow detail (validation steps, IBC client health checks, endpoint validation, etc.), see the [assetlists README](https://github.com/osmosis-labs/assetlists/blob/main/README.md).
 
-- Chain data and services:
-  - [Chain Registry] `chain_name`.
-    - E.G., `cosmoshub` is the registered chain_name for Cosmos Hub.
-  - Block Explorer Transaction URL
-    - Mintscan is a preferred default
-  - Working RPC and REST endpoints
-    - Must not block the Osmosis Domain.
-      - Note that many Cosmos SDK RPC Nodes have CORS blocking by default
-    - RPC node must have Secure Web Sockets (wss://) protocol enabled.
-- Asset data:
-  - Base denomination on source chain
-    - e.g., 'uatom' is the `base_denom` (i.e., the unique and immutable indivisible denomination unit) of ATOM
-  - IBC Path
-    - Generally describes to the 'path' (IBC hops) that the asset takes to get to Osmosis
-      - Every IBC hop is described in the path, including destination chain port and destination chain channel-id
-    - Used as input for the IBC Hash function to determine the asset denomination on the destination chain.
-      - IBC denoms always appear as: 'ibc/{SHA256 HASH of IBC Path}'
-    - In some rare cases, some characters in the source chain's base_denom or replaced with other characters.
-  - Whether the Asset is bridged (not referring to IBC transfers)
+### Prerequisites for auto-listing
 
-### Steps
+- Registered onto the Cosmos Chain Registry (see [Step 1](#step-1-register-to-the-cosmos-chain-registry)).
+- An IBC connection exists between the source chain and Osmosis, and is **registered at the Cosmos Chain Registry** under `_IBC/`.
+  - All native assets from a chain should normally go through a single connection, although some token types (e.g., CW20 tokens) may require another connection.
+  - See: [Enabling IBC transfers](https://docs.osmosis.zone/overview/integrate/transfer#enabling-ibc-transfers) and [Setting up and operating a relayer to Osmosis](https://docs.osmosis.zone/overview/integrate/transfer#setting-up-and-operating-a-relayer-to-osmosis).
 
-1. Review the [Osmosis Assetlists Registry](https://github.com/osmosis-labs/assetlists) docs and schema:
-    1. [README.md](https://github.com/osmosis-labs/assetlists/blob/main/README.md)
-    2. [LISTING.md](https://github.com/osmosis-labs/assetlists/blob/main/LISTING.md)
-    3. [zone_assets.schema.json](https://github.com/osmosis-labs/assetlists/blob/main/zone_assets.schema.json)
-2. Submit a pull request with necessary changes to enlist the asset:
-  - Ensure the source chain in included in `osmosis-1/osmosis.zone_chains.json`.
-    - If not yet registered, add the chain object to the end of the `chains` array.
-    - Include `chain_name`, `rpc`, `rest`, `explorer_tx_url`, and `keplr_features`.
-      - E.G.,
-        
-      ```
-        {
-          "chain_name": "osmosis",
-          "rpc": "https://rpc-osmosis.keplr.app",
-          "rest": "https://lcd-osmosis.keplr.app",
-          "explorer_tx_url": "https://www.mintscan.io/osmosis/txs/${txHash}",
-          "keplr_features": [
-            "ibc-go",
-            "ibc-transfer",
-            "cosmwasm",
-            "wasmd_0.24+",
-            "osmosis-txfees"
-          ]
-        }
-      ```
-  - Add the asset to the `osmosis-1/osmosis.zone_assets.json` file.
-    - Add the new asset object to the end of the `assets` array.
-    - Include `base_denom`, `chain_name`, and `path`.
-    - New additions always default with having `"osmosis_verified": false
-      - Once assets are fully integrated, the asset can then be upgraded to "Verified" status.
-      - See [LISTING.md](https://github.com/osmosis-labs/assetlists/blob/main/LISTING.md) for details on upgrading an asset to Verified status.
-    - If adding a stablecoin, please include the `peg_mechanism`
-      - E.G., `"peg_mechanism": "collateralized"`
-    - If transferring the asset is not a simple IBC transfer, but requires another bridging/transfer interface, provide the URL(s) for the Deposit and Withdraw functions in the `transfer_methods` array within the asset's object.
-    - E.G.,
-      
-    ```
-    {
-      "chain_name": "terra",
-      "base_denom": "uluna",
-      "path": "transfer/channel-72/uluna",
-      "osmosis_verified": true,
-      "override_properties": {
-        "name": "Luna Classic"
-      },
-      "transfer_methods": [
-        {
-          "name": "Terra Bridge",
-          "type": "external_interface",
-          "deposit_url": "https://bridge.terra.money",
-          "withdraw_url": "https://bridge.terra.money"
-        }
-      ]
-    },
-    ```
-  - In the Pull Request, briefly describe the change, and complete the checklist as thoroughly as possible.
-    - New Pull Requests will automatically initialize with a description template that includes the checklist.
-    - Be sure to describe the plan for onchain liquidity, and provide a Pool ID once one exists.
-    - The PR reviewers will assist with any questions.
-    - If requested, a preview link to Osmosis Zone that shows the new asset can be provided.
-      - From the preview, a Weighted liquidity pool can be created. However, note that a Supercharged (or newer) pool type is recommended.
-    - Be sure to check back to the PR regularly to check for any questions, comments, and additional action items required to complete the listing process.
+### Optional: Submit a manual PR for advanced configuration
 
+You only need to open a PR against `osmosis-labs/assetlists` if you want to configure properties that the auto-detection pipeline cannot infer. Common reasons include:
 
-## Step 3 (optional): Complete the Asset Integration
+- Assigning **categories** (e.g., stablecoin, defi, meme).
+- Adding custom **transfer methods** (external bridges, integrated bridges, fiat onramps) for assets that require more than a plain IBC transfer.
+- Providing custom RPC / REST endpoints for the source chain in `osmosis.zone_chains.json` (otherwise the chain entry is auto-stubbed from Chain Registry data).
+- Marking the asset as `osmosis_unlisted` while you finalize configuration.
+- Requesting an upgrade to verified status (covered in Step 3).
 
-To create an ideal user experience when interacting with an Asset on Osmosios Zone, it is best to ensure that all metadata is registered, dependent data sources have all data about the asset, and that there is sufficient and efficient liquidity of the asset on Osmosis. See [LISTING.md](https://github.com/osmosis-labs/assetlists/blob/main/LISTING.md) for details.
+#### Where the changes go
+
+- `osmosis-1/osmosis.zone_assets.json` — the asset entry.
+- `osmosis-1/osmosis.zone_chains.json` — only when you need to provide custom chain services (RPC/REST/explorer); otherwise leave it alone.
+
+#### Field reference
+
+See [assetlists README — Asset Object Structure](https://github.com/osmosis-labs/assetlists/blob/main/README.md) for a full field-by-field reference, defaults, and decision guidance.
+
+The minimum required shape for an asset object is:
+
+```json
+{
+  "chain_name": "terra",
+  "base_denom": "uluna",
+  "path": "transfer/channel-72/uluna"
+}
+```
+
+All other fields are optional and default to safe values (e.g., `osmosis_verified` defaults to `false`). Consult the assetlists README before adding any optional field.
+
+#### Submitting the PR
+
+- New Pull Requests will automatically initialize with a description template that includes a checklist — complete it as thoroughly as possible.
+- Validation checks run automatically on the PR; address any failures before requesting review.
+- Maintainers will review and merge once validation passes and the configuration is sound.
+
+## Step 3 (optional): Request Verified Status
+
+**Verified status** is what makes an asset visible to Osmosis Zone users by default (without requiring the "Show Unverified Assets" toggle). It is the recommended end state for any asset that has established meaningful onchain liquidity on Osmosis.
+
+### Verification criteria
+
+Verification is gated on objective criteria, most notably a minimum amount and depth of onchain liquidity in an Osmosis pool, plus metadata completeness on the Cosmos Chain Registry.
+
+The authoritative criteria live in [LISTING.md](https://github.com/osmosis-labs/assetlists/blob/main/LISTING.md). Read it before opening the upgrade PR, the thresholds and requirements there are the source of truth and may change over time.
+
+### How to request the upgrade
+
+1. Ensure your asset meets every criterion listed in LISTING.md (liquidity, metadata completeness, etc.).
+2. Create at least one liquidity pool on Osmosis that satisfies the liquidity requirements. A Supercharged pool type is recommended over a Weighted pool. See the [Pool Setup Guide](https://docs.osmosis.zone/overview/integrate/pool-setup).
+3. Open a PR against [osmosis-labs/assetlists](https://github.com/osmosis-labs/assetlists) that sets `"osmosis_verified": true` on the asset entry in `osmosis-1/osmosis.zone_assets.json`.
+4. In the PR description, include the **Pool ID(s)** that satisfy the liquidity requirements, and any other evidence requested by the PR template.
+
+### What happens next
+
+- Maintainers review the PR against the criteria in LISTING.md before merging.
+- Once merged, the asset is shipped to Osmosis Zone as verified on the next assetlist publish.


### PR DESCRIPTION
Rework registration.md to clarify the three-step process: register chain/asset in the Cosmos Chain Registry, wait for osmosis-labs/assetlists auto-listing (workflow runs twice weekly and ships unverified assets), and optionally submit a PR for advanced configuration or to request verified status. Adds detailed prerequisites and step-by-step guidance for auto-detection, where changes appear in the assetlists repo, a minimal asset JSON example, and explicit instructions for submitting PRs and meeting verification criteria. Also fixes typos (Chain Registry) and streamlines/remove outdated verbose procedural lists.

This change has been tested locally by rebuilding the doc website and verified content and links are expected