### PR TITLE
[ISSUE-230] fix(docs): rewrite Long-Term Liquidity section in terminology.md

### DIFF
--- a/docs/overview/educate/terminology.md
+++ b/docs/overview/educate/terminology.md
@@ -138,7 +138,7 @@ Since buying and selling from the pool changes the quantities of assets within a
 ## Long-Term Liquidity
 Liquidity mining rewards tend to attract short-term “mercenary farmers” who quickly deposit and withdraw their liquidity after harvesting the yield. These farmers are only interested in the speculative value of the governance tokens that they are earning. They usually bounce between protocols in search of the best yield.
 Mercenary farmers often create the mirage of protocol adoption, but when these farmers leave, it results in significant liquidity volatility. Users of the AMM have difficulty executing trades without encountering slippage. Therefore, long-term liquidity is crucial to the success of an AMM.
-Osmosis’ design includes two mechanisms to incentivize long-term liquidity: [exit fees](../../overview/educate/getting-started.md#swap-fees) and [bonded liquidity gauges](../../overview/educate/getting-started.md#bonded-liquidity-gauges).
+To support long-term liquidity, Osmosis lets anyone permissionlessly create [external liquidity incentive gauges](../integrate/incentives.md) that distribute rewards to liquidity providers in a given pool, on top of the swap fees they already earn.
 
 
 ## Market swap


### PR DESCRIPTION
Closes #230. The previous text claimed Osmosis incentivizes long-term liquidity via 'exit fees' and 'bonded liquidity gauges' and linked to non-existent anchors in getting-started.md. Exit fees no longer exist on Osmosis, and liquidity gauges are no longer exclusively bonded.

## Verifying this change

This change has been tested locally by rebuilding the doc website and verified content and links are expected