### PR TITLE
[ISSUE-210] fix(docs): restore vertical gap between cards on category index pages

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -811,10 +811,24 @@ img[src$='#terminal'] {
 
 /* OSMOSIS */
 
+/* Issue #210: render DocCardList items full-width on desktop. Infima
+   drives both flex-basis and max-width from --ifm-col-width on any
+   element matching .col[class*=col--], so override the variable
+   (scoped to <article class="col">, the DocCardList markup) to keep
+   the footer unaffected.
 
-    @media (min-width: 997px) 
-{
-  .col {
-    max-width: 100% !important;
-}
+   Docusaurus's DocCategoryGeneratedIndexPage zeros margin-bottom on
+   the last two articles (`article:nth-last-child(-n + 2)`) on the
+   assumption of a 2-col grid where they share a row. Once we collapse
+   to a single column those two are stacked, so we need the gap back
+   between them — restore margin-bottom on every article except the
+   actual last one. */
+@media (min-width: 997px) {
+  article.col {
+    --ifm-col-width: 100%;
+  }
+
+  article.col.margin-bottom--lg:not(:last-child) {
+    margin-bottom: 2rem !important;
+  }
 }


### PR DESCRIPTION
Closes #210. The existing single-column override on .col only set max-width, leaving --ifm-col-width and therefore flex-basis at 50% for .col--6 items, which broke layout math. Worse, Docusaurus's DocCategoryGeneratedIndexPage zeros margin-bottom on the last two <article> children on the assumption that they share a row in a 2-col grid — when the override stacks them instead, the second-to-last card loses its bottom margin and the gap to the final card disappears.

Override --ifm-col-width on <article class="col"> (DocCardList markup, so footer .col items are unaffected) and explicitly restore the bottom margin on every card except the final one to undo the upstream 2-col assumption.

## Verifying this change

This change has been tested locally by rebuilding the doc website and verified content and links are expected


