### PR TITLE
chore(docs): remove Tally contact popup

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -271,9 +271,6 @@ const config = {
         apiKey: '00',
       },
     }),
-  scripts: [
-    "https://tally.so/widgets/embed.js",
-  ],
 };
 
 module.exports = config;

--- a/src/theme/Footer/Layout/index.jsx
+++ b/src/theme/Footer/Layout/index.jsx
@@ -1,28 +1,7 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import clsx from 'clsx';
 
 export default function FooterLayout({ style, links, logo, copyright }) {
-  useEffect(() => {
-    const script = document.createElement('script');
-    script.src = 'https://tally.so/widgets/embed.js';
-    script.async = true;
-    document.body.appendChild(script);
-
-    window.TallyConfig = {
-      formId: 'w8zL9k',
-      popup: {
-        width: 900,
-        emoji: {
-          text: '👋',
-          animation: 'wave'
-        },
-        layout: 'modal',
-        showOnce: true,
-        autoClose: 0
-      }
-    };
-  }, []);
-
   return (
     <footer
       className={clsx('footer', {


### PR DESCRIPTION
The docs site loaded a Tally form (w8zL9k) as a one-time modal popup on first visit, via a useEffect in the swizzled FooterLayout and a top-level <script> include. Remove both: drop the useEffect from the footer component and the tally embed script from docusaurus.config.js. Footer markup wrapping is preserved because custom.css depends on it.

## Verifying this change

This change has been tested locally by rebuilding the doc website and verified content and links are expected
