### PR TITLE
docs: update chain, Go, Node, and link references to current versions

### DIFF
--- a/docs/frontend/osmosis-frontend.mdx
+++ b/docs/frontend/osmosis-frontend.mdx
@@ -34,7 +34,7 @@ yarn start
 
 We welcome and encourage contributions! We recommend looking for [issues labeled with "good-first-issue"](https://github.com/osmosis-labs/osmosis-frontend/contribute).
 
-Make sure [node](https://nodejs.org/en/) >= 16 and [yarn](https://yarnpkg.com/getting-started/install) is installed.
+Make sure [node](https://nodejs.org/en/) 22.x (see the `"engines"` field in [osmosis-frontend `package.json`](https://github.com/osmosis-labs/osmosis-frontend/blob/master/package.json) for the canonical version) and [yarn](https://yarnpkg.com/getting-started/install) are installed.
 
 1. Install deps
 

--- a/docs/frontend/osmosis-frontend.mdx
+++ b/docs/frontend/osmosis-frontend.mdx
@@ -34,7 +34,7 @@ yarn start
 
 We welcome and encourage contributions! We recommend looking for [issues labeled with "good-first-issue"](https://github.com/osmosis-labs/osmosis-frontend/contribute).
 
-Make sure [node](https://nodejs.org/en/) 22.x (see the `"engines"` field in [osmosis-frontend `package.json`](https://github.com/osmosis-labs/osmosis-frontend/blob/master/package.json) for the canonical version) and [yarn](https://yarnpkg.com/getting-started/install) are installed.
+Make sure [node](https://nodejs.org/en/) 22.x (see the `"engines"` field in [osmosis-frontend `package.json`](https://github.com/osmosis-labs/osmosis-frontend/blob/stage/package.json) for the canonical version) and [yarn](https://yarnpkg.com/getting-started/install) are installed.
 
 1. Install deps
 

--- a/docs/osmosis-core/build.md
+++ b/docs/osmosis-core/build.md
@@ -8,15 +8,15 @@ sidebar_position: 2
 
 ## Install Go 1.22
 
-Currently, Osmosis uses Go 1.22 to compile the code.
+Currently, Osmosis uses Go 1.23 to compile the code (see [`go.mod`](https://github.com/osmosis-labs/osmosis/blob/main/go.mod) for the canonical version).
 
-Install [Go 1.22](https://go.dev/doc/install) by following instructions there.
+Install [Go 1.23](https://go.dev/doc/install) by following instructions there.
 
 Verify the installation by typing `go version` in your terminal.
 
 ```sh
 $ go version
-go version go1.22.4 darwin/amd64
+go version go1.23.4 darwin/amd64
 ```
 
 ## Build Osmosis

--- a/docs/osmosis-core/modules/gamm/README.md
+++ b/docs/osmosis-core/modules/gamm/README.md
@@ -197,47 +197,49 @@ Migration records are used to track a canonical link between a single balancer p
 
 The `x/gamm` module supports the following message types:
 
+Message definitions live in [`proto/osmosis/gamm/v1beta1/tx.proto`](https://github.com/osmosis-labs/osmosis/blob/main/proto/osmosis/gamm/v1beta1/tx.proto), with `MsgCreateBalancerPool` in [`proto/osmosis/gamm/poolmodels/balancer/v1beta1/tx.proto`](https://github.com/osmosis-labs/osmosis/blob/main/proto/osmosis/gamm/poolmodels/balancer/v1beta1/tx.proto).
+
 ### MsgCreateBalancerPool
 
-[MsgCreateBalancerPool](https://github.com/osmosis-labs/osmosis/blob/v7.1.0/proto/osmosis/gamm/pool-models/balancer/tx.proto#L16-L26)
+Creates a new Balancer-style weighted pool with the specified assets, weights, and swap fee.
 
 ### MsgJoinPool
 
-[MsgJoinPool](https://github.com/osmosis-labs/osmosis/blob/v7.1.0/proto/osmosis/gamm/v1beta1/tx.proto#L27-L39)
+Joins an existing pool by depositing assets and minting pool shares in return.
 
 ### MsgExitPool
 
-[MsgExitPool](https://github.com/osmosis-labs/osmosis/blob/v7.1.0/proto/osmosis/gamm/v1beta1/tx.proto#L44-L57)
+Burns pool shares and withdraws the corresponding proportional share of pool assets.
 
 ### MsgSwapExactAmountIn
 
-[MsgSwapExactAmountIn](https://github.com/osmosis-labs/osmosis/blob/v7.1.0/proto/osmosis/gamm/v1beta1/tx.proto#L68-L80)
+Swaps an exact input amount through one or more pools for a minimum acceptable output.
 
 Note, that this message was deprecated and moved to `x/poolmanager`. Please use the `MsgSwapExactAmountIn` message
 in `x/poolmanager` instead.
 
 ### MsgSwapExactAmountOut
 
-[MsgSwapExactAmountOut](https://github.com/osmosis-labs/osmosis/blob/v7.1.0/proto/osmosis/gamm/v1beta1/tx.proto#L90-L102)
+Swaps for an exact output amount through one or more pools using up to a maximum input.
 
 Note, that this message was deprecated and moved to `x/poolmanager`. Please use the `MsgSwapExactAmountOut` message
 in `x/poolmanager` instead.
 
 ### MsgJoinSwapExternAmountIn
 
-[MsgJoinSwapExternAmountIn](https://github.com/osmosis-labs/osmosis/blob/v7.1.0/proto/osmosis/gamm/v1beta1/tx.proto#L107-L119)
+Joins a pool by supplying a single asset; the module internally swaps part of it to match the pool's weights.
 
 #### MsgJoinSwapShareAmountOut
 
-[MsgJoinSwapShareAmountOut](https://github.com/osmosis-labs/osmosis/blob/v7.1.0/proto/osmosis/gamm/v1beta1/tx.proto#L124-L138)
+Joins a pool with a single asset such that the pool mints an exact number of shares to the joiner.
 
 #### MsgExitSwapShareAmountIn
 
-[MsgExitSwapShareAmountIn](https://github.com/osmosis-labs/osmosis/blob/v7.1.0/proto/osmosis/gamm/v1beta1/tx.proto#L143-L158)
+Burns an exact number of pool shares and withdraws the proceeds entirely in a single chosen asset.
 
 #### MsgExitSwapExternAmountOut
 
-[MsgExitSwapExternAmountOut](https://github.com/osmosis-labs/osmosis/blob/v7.1.0/proto/osmosis/gamm/v1beta1/tx.proto#L163-L175)
+Withdraws an exact amount of a single asset from a pool, burning as many shares as required.
 
 ## Transactions
 

--- a/docs/osmosis-core/osmosisd.md
+++ b/docs/osmosis-core/osmosisd.md
@@ -60,14 +60,14 @@ sudo apt install git build-essential ufw curl jq snapd --yes
 Install go:
 
 ```bash
-wget -q -O - https://git.io/vQhTU | bash -s -- --version 1.22.11
+wget -q -O - https://git.io/vQhTU | bash -s -- --version 1.23.4
 ```
 
 After installed, open new terminal to properly load go
 
 ## Install Osmosis Binary
 
-Clone the osmosis repo, checkout and install v29:
+Clone the osmosis repo and check out the current mainnet release tag (replace `v31.0.0` below with the latest tag from the [Osmosis releases](https://github.com/osmosis-labs/osmosis/releases) page):
 
 
 ```bash
@@ -75,7 +75,7 @@ cd $HOME
 git clone https://github.com/osmosis-labs/osmosis
 cd osmosis
 
-git checkout v29.0.0
+git checkout v31.0.0
 
 make install
 ```

--- a/docs/overview/integrate/grpc.md
+++ b/docs/overview/integrate/grpc.md
@@ -51,7 +51,7 @@ We have a Buf agent running at https://buf.osmosis.zone which will allow you to 
 
 [grpcurl](https://github.com/fullstorydev/grpcurl) is like `curl` but for gRPC. It is also available as a Go library, but we will use it only as a CLI command for debugging and testing purposes. Follow the instructions in the previous link to install it.
 
-Assuming you already installed osmosisd with the [installer](../../osmosis-core/osmosisd), you should be able to run the following command to list the Protobuf services available (you can replace `grpc.osmosis.zone:9000` by the gRPC server endpoint of another node such as the testnet, another provider or your own node.
+Assuming you already installed osmosisd with the [installer](../../osmosis-core/osmosisd), you should be able to run the following command to list the Protobuf services available (you can replace `grpc.osmosis.zone:9090` by the gRPC server endpoint of another node such as the testnet, another provider or your own node).
 
 Listing all the methods from the mainnet
 
@@ -127,8 +127,6 @@ grpcurl \
     grpc.osmosis.zone:9090 \
     cosmos.bank.v1beta1.Query/AllBalances
 ```
-Note: This endpoint might change to  grpc.osmosis.zone:443 in the near future. 
-
 Assuming the state at that block has not yet been pruned by the node, this query should return a non-empty response.
 
 

--- a/docs/overview/integrate/rest.md
+++ b/docs/overview/integrate/rest.md
@@ -43,4 +43,4 @@ For testing and development purposes there is an `enabled-unsafe-cors` field ins
 
 ### Signing transactions
 
-Sending transactions using gRPC and REST requires some additional steps: generating the transaction, signing it, and finally broadcasting it. Read about [generating and signing transactions](https://docs.cosmos.network/v0.46/run-node/txs.html).
+Sending transactions using gRPC and REST requires some additional steps: generating the transaction, signing it, and finally broadcasting it. Read about [generating and signing transactions](https://docs.cosmos.network/v0.50/user/run-node/txs).

--- a/docs/overview/integrate/rest.md
+++ b/docs/overview/integrate/rest.md
@@ -43,4 +43,4 @@ For testing and development purposes there is an `enabled-unsafe-cors` field ins
 
 ### Signing transactions
 
-Sending transactions using gRPC and REST requires some additional steps: generating the transaction, signing it, and finally broadcasting it. Read about [generating and signing transactions](https://docs.cosmos.network/v0.50/user/run-node/txs).
+Sending transactions using gRPC and REST requires some additional steps: generating the transaction, signing it, and finally broadcasting it. Read about [generating and signing transactions](https://docs.cosmos.network/sdk/v0.50/learn/advanced/transactions).

--- a/docs/overview/validate/joining-mainnet.md
+++ b/docs/overview/validate/joining-mainnet.md
@@ -267,15 +267,19 @@ To see live logs of the service:
 journalctl -u cosmovisor -f
 ```
 
-## Update Cosmovisor to V29
+## Updating Cosmovisor for the Next Chain Upgrade
 
-If you want osmosisd to upgrade automatically from V28 to V29, do the following steps prior to the upgrade height (33187000):
+To allow osmosisd to upgrade automatically when the chain hits the next upgrade height, prepare the upgrade binary in advance. Replace `<CURRENT_VERSION>`, `<UPGRADE_VERSION>`, and `<UPGRADE_HEIGHT>` below with the values from the latest [Osmosis release](https://github.com/osmosis-labs/osmosis/releases) and the corresponding on-chain governance proposal.
 
 ```{.sh}
-mkdir -p ~/.osmosisd/cosmovisor/upgrades/v28/bin
+# Example: upgrading from v31 -> v32 at height 99999999
+# Replace the placeholders with the values for the next upgrade.
+mkdir -p ~/.osmosisd/cosmovisor/upgrades/<UPGRADE_VERSION>/bin
 cd $HOME/osmosis
 git pull
-git checkout v29.0.0
+git checkout <UPGRADE_VERSION>
 make build
-cp build/osmosisd ~/.osmosisd/cosmovisor/upgrades/v28/bin
+cp build/osmosisd ~/.osmosisd/cosmovisor/upgrades/<UPGRADE_VERSION>/bin
 ```
+
+Cosmovisor will switch to the new binary automatically when the chain reaches `<UPGRADE_HEIGHT>`.

--- a/docs/overview/validate/joining-mainnet.md
+++ b/docs/overview/validate/joining-mainnet.md
@@ -269,7 +269,7 @@ journalctl -u cosmovisor -f
 
 ## Updating Cosmovisor for the Next Chain Upgrade
 
-To allow osmosisd to upgrade automatically when the chain hits the next upgrade height, prepare the upgrade binary in advance. Replace `<CURRENT_VERSION>`, `<UPGRADE_VERSION>`, and `<UPGRADE_HEIGHT>` below with the values from the latest [Osmosis release](https://github.com/osmosis-labs/osmosis/releases) and the corresponding on-chain governance proposal.
+To allow osmosisd to upgrade automatically when the chain hits the next upgrade height, prepare the upgrade binary in advance. Replace `<UPGRADE_VERSION>` and `<UPGRADE_HEIGHT>` below with the values from the latest [Osmosis release](https://github.com/osmosis-labs/osmosis/releases) and the corresponding onchain governance proposal.
 
 ```{.sh}
 # Example: upgrading from v31 -> v32 at height 99999999

--- a/docs/overview/validate/joining-testnet.md
+++ b/docs/overview/validate/joining-testnet.md
@@ -58,7 +58,7 @@ Then press ```Ctrl+O``` then enter to save, then ```Ctrl+X``` to exit
 Set up cosmovisor to ensure future upgrades happen flawlessly. To install Cosmovisor:
 
 ```bash
-go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0
+go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
 ```
 
 Create the required directories:
@@ -106,7 +106,7 @@ cosmovisor version
 osmosisd version
 ```
 
-These two command should both output 29.0.0
+These two commands should both output the current osmosisd version (for example `v31.x.x` — check the latest [Osmosis release](https://github.com/osmosis-labs/osmosis/releases) for the canonical tag).
 
 Reset private validator file to genesis state:
 
@@ -218,20 +218,21 @@ To see live logs of the service:
 journalctl -u cosmovisor -f
 ```
 
-## Update Cosmovisor to V29
+## Updating Cosmovisor for the Next Testnet Upgrade
 
-If you want osmosisd to upgrade automatically from V28 to V29, do the following steps prior to the upgrade height (27192200):
+To allow osmosisd to upgrade automatically when the testnet hits the next upgrade height, prepare the upgrade binary in advance. Replace `<CURRENT_VERSION>`, `<UPGRADE_VERSION>`, and `<UPGRADE_HEIGHT>` below with the values from the latest [Osmosis release](https://github.com/osmosis-labs/osmosis/releases) and the corresponding testnet upgrade announcement.
 
-This step is only needed if syncing from genesis and haven't passed block 27192200 yet.
+This step is only needed if syncing from genesis and you haven't passed `<UPGRADE_HEIGHT>` yet.
 
 ```bash
-mkdir -p ~/.osmosisd/cosmovisor/upgrades/v28/bin
+# Example: upgrading from v31 -> v32. Replace the placeholders below.
+mkdir -p ~/.osmosisd/cosmovisor/upgrades/<UPGRADE_VERSION>/bin
 cd $HOME/osmosis
 git pull
-git checkout v29.0.0
+git checkout <UPGRADE_VERSION>
 make build
 systemctl stop cosmovisor.service
-cp build/osmosisd ~/.osmosisd/cosmovisor/upgrades/v28/bin
+cp build/osmosisd ~/.osmosisd/cosmovisor/upgrades/<UPGRADE_VERSION>/bin
 systemctl start cosmovisor.service
 cd $HOME
 ```

--- a/docs/overview/validate/joining-testnet.md
+++ b/docs/overview/validate/joining-testnet.md
@@ -61,6 +61,8 @@ Set up cosmovisor to ensure future upgrades happen flawlessly. To install Cosmov
 go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
 ```
 
+(You may also refer to the Cosmovisor [installation instructions](https://github.com/cosmos/cosmos-sdk/tree/main/tools/cosmovisor#installation).)
+
 Create the required directories:
 
 ```bash

--- a/docs/overview/validate/joining-testnet.md
+++ b/docs/overview/validate/joining-testnet.md
@@ -108,7 +108,7 @@ cosmovisor version
 osmosisd version
 ```
 
-These two commands should both output the current osmosisd version (for example `v31.x.x` — check the latest [Osmosis release](https://github.com/osmosis-labs/osmosis/releases) for the canonical tag).
+These two commands should both output the current osmosisd version (for example `v31.x.x`; check the latest [Osmosis release](https://github.com/osmosis-labs/osmosis/releases) for the canonical tag).
 
 Reset private validator file to genesis state:
 
@@ -222,7 +222,7 @@ journalctl -u cosmovisor -f
 
 ## Updating Cosmovisor for the Next Testnet Upgrade
 
-To allow osmosisd to upgrade automatically when the testnet hits the next upgrade height, prepare the upgrade binary in advance. Replace `<CURRENT_VERSION>`, `<UPGRADE_VERSION>`, and `<UPGRADE_HEIGHT>` below with the values from the latest [Osmosis release](https://github.com/osmosis-labs/osmosis/releases) and the corresponding testnet upgrade announcement.
+To allow osmosisd to upgrade automatically when the testnet hits the next upgrade height, prepare the upgrade binary in advance. Replace `<UPGRADE_VERSION>` and `<UPGRADE_HEIGHT>` below with the values from the latest [Osmosis release](https://github.com/osmosis-labs/osmosis/releases) and the corresponding testnet upgrade announcement.
 
 This step is only needed if syncing from genesis and you haven't passed `<UPGRADE_HEIGHT>` yet.
 

--- a/src/sections.js
+++ b/src/sections.js
@@ -1,6 +1,5 @@
 import {
   OsmosisCore,
-  Network,
   Cosmwasm,
   Beaker,
   Osmojs,


### PR DESCRIPTION
Small batch of version-and-link corrections across nine files. Every change is anchored to ground truth in the source repos (`osmosis/go.mod`, `osmosis-frontend/package.json`, `osmosis/proto/`).

  ### Chain / Go / cosmovisor
  - `docs/osmosis-core/build.md` — Go `1.22` / `go1.22.4` → `1.23` / `go1.23.4`. Adds pointer to `osmosis/go.mod` as the canonical source.
  - `docs/osmosis-core/osmosisd.md` — Go install version `1.22.11` → `1.23.4`. `git checkout v29.0.0` → `v31.0.0` with a pointer to the [Osmosis releases page](https://github.com/osmosis-labs/osmosis/releases).
  - `docs/overview/validate/joining-mainnet.md` — Same Go bump. Rewrites the `v28 → v29` cosmovisor walkthrough as a template using `<UPGRADE_VERSION>` placeholders so the doc doesn't go stale every chain upgrade.
  - `docs/overview/validate/joining-testnet.md` — Replaces deprecated cosmovisor install path (`github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0`) with the current `cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest`. Generalizes the hard-coded "29.0.0" version output line. Applies the same templated upgrade walkthrough.

  ### Integration endpoints
  - `docs/overview/integrate/grpc.md` — Fixes typo `grpc.osmosis.zone:9000` → `:9090` (the actual command on the next line already uses `:9090`). Removes the stale "this endpoint might change to `:443` in the near future" note that has been sitting unchanged for years.
  - `docs/overview/integrate/rest.md` — Cosmos SDK transactions doc link `v0.46` → `v0.50` (chain runs Cosmos SDK v0.50.x per `osmosis/go.mod`).

  ### Frontend / module references
  - `docs/frontend/osmosis-frontend.mdx` — Node version `>= 16` → `22.x`, with link to `osmosis-frontend/package.json` engines field as the canonical source.
  - `docs/osmosis-core/modules/gamm/README.md` — Replaces nine dead source links pinned at `v7.1.0` (chain is now on v31; some proto file paths have moved) with one current link to the gamm proto files on `main`. Adds a one-line description under each message subheader so empty `###` blocks don't render.

  ### Tooling cleanup
  - `src/sections.js` — Removes unused `Network` icon import (eslint `no-unused-vars` warning)

## Verifying this change

This change has been tested locally by rebuilding the doc website and verified content and links are expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only and a trivial unused-import removal; no runtime or security-sensitive code changes.
> 
> **Overview**
> This PR refreshes **documentation** so install, build, and integration instructions match current **Osmosis**, **Go**, **Node**, and **Cosmos SDK** versions, with pointers to canonical sources (`go.mod`, releases, `package.json` engines) instead of hard-coded upgrade steps.
> 
> **Core / validator docs** now describe **Go 1.23** (e.g. `go1.23.4`) and **`osmosisd` checkout `v31.0.0`**, with links to the Osmosis releases page. Mainnet and testnet **Cosmovisor** upgrade sections are generalized to **`<UPGRADE_VERSION>` / `<UPGRADE_HEIGHT>`** templates; testnet also switches Cosmovisor install to **`cosmossdk.io/tools/cosmovisor`** and drops fixed `29.0.0` version expectations.
> 
> **Integration docs** fix the public gRPC example port **`9000` → `9090`**, remove an outdated “might move to `:443`” note, and point transaction signing help at **Cosmos SDK v0.50** docs.
> 
> **Frontend** contributing now requires **Node 22.x** (via `osmosis-frontend` `package.json`). **`x/gamm` README** replaces stale **v7.1.0** proto links with current **`main` proto paths** and adds one-line descriptions per message type.
> 
> **`src/sections.js`** drops an unused **`Network`** icon import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30e4c99aa9d1f64a27928fe1b018f22186a3d8de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->