### PR TITLE
feat(docs): add Sidecar Query Server (SQS) integration page

### DIFF
--- a/docs/overview/integrate/frontend.md
+++ b/docs/overview/integrate/frontend.md
@@ -8,6 +8,10 @@ sidebar_position: 8
 
 As long as the asset has been properly registered according to the [registration documentation](https://docs.osmosis.zone/overview/integrate/registration) and there is a pool with USD $1,000 of [initial liquidity](https://docs.osmosis.zone/overview/integrate/liquidity) then the pool will be visible on this frontend.
 
+:::info Frontend data dependencies
+The production frontend at [app.osmosis.zone](https://app.osmosis.zone) reads pool state, routing quotes, and token prices from the [Sidecar Query Server (SQS)](./sqs) (`sqs.osmosis.zone`), not directly from chain RPC. If you are running a fork of the frontend or building anything that needs to mirror its data, point at SQS first.
+:::
+
 ## Verify Assets
 
 An asset will initially show as an Unverified asset. This will require users to toggle on the Unverified Assets setting in the Cog Menu in the top right of their screen to see the asset.

--- a/docs/overview/integrate/rest.md
+++ b/docs/overview/integrate/rest.md
@@ -4,6 +4,10 @@ sidebar_position: 11
 
 # Interact with REST
 
+:::tip Looking for swap routing or aggregated pool data?
+REST (gRPC-gateway) is suitable for individual module queries, but routing, batched pool state, and spot prices are served much faster by the [Sidecar Query Server (SQS)](./sqs).
+:::
+
 All gRPC services on the Cosmos SDK  and Osmosis are made available for more convenient REST-based queries through gRPC-gateway. The format of the URL path is based on the Protobuf service method's full-qualified name, but may contain small customizations so that final URLs look more idiomatic. For example, the REST endpoint for the `cosmos.bank.v1beta1.Query/AllBalances` method is `GET /cosmos/bank/v1beta1/balances/{address}`. Request arguments are passed as query parameters.
 
 As a concrete example, the `curl` command to make balances request is:

--- a/docs/overview/integrate/rpc.md
+++ b/docs/overview/integrate/rpc.md
@@ -6,6 +6,10 @@ sidebar_position: 12
 
 As shown on the RPC specifications, there are different endpoints to communicate with the Osmosis chain. Unlike the LCD rest api, the RPC endpoints provide generic endpoints to communicate with the various modules available. For example the [ABCI Query](/api?v=RPC#/operations/abci_query) allows you the query different data from Osmosis.
 
+:::tip Looking for swap routing or aggregated pool data?
+RPC is the right path for signing, broadcasting, and per-block subscriptions, but for routing quotes and batched pool state you almost certainly want the [Sidecar Query Server (SQS)](./sqs) — it is the query path used by the production frontend.
+:::
+
 For more information please read generating, [signing and boradcasting transactions.] https://docs.cosmos.network/v0.46/run-node/txs.html on the cosmos-sdk docs. 
 
 ## Querying the ABCI Query with Javascript via Telescope

--- a/docs/overview/integrate/rpc.md
+++ b/docs/overview/integrate/rpc.md
@@ -7,7 +7,7 @@ sidebar_position: 12
 As shown on the RPC specifications, there are different endpoints to communicate with the Osmosis chain. Unlike the LCD rest api, the RPC endpoints provide generic endpoints to communicate with the various modules available. For example the [ABCI Query](/api?v=RPC#/operations/abci_query) allows you the query different data from Osmosis.
 
 :::tip Looking for swap routing or aggregated pool data?
-RPC is the right path for signing, broadcasting, and per-block subscriptions, but for routing quotes and batched pool state you almost certainly want the [Sidecar Query Server (SQS)](./sqs) — it is the query path used by the production frontend.
+RPC is the right path for signing, broadcasting, and per-block subscriptions, but for routing quotes and batched pool state you almost certainly want the [Sidecar Query Server (SQS)](./sqs), the query path used by the production frontend.
 :::
 
 For more information please read generating, [signing and boradcasting transactions.] https://docs.cosmos.network/v0.46/run-node/txs.html on the cosmos-sdk docs. 

--- a/docs/overview/integrate/sqs.md
+++ b/docs/overview/integrate/sqs.md
@@ -1,0 +1,179 @@
+---
+sidebar_position: 13
+---
+
+# Sidecar Query Server (SQS)
+
+The Sidecar Query Server is a Go service that runs alongside an Osmosis full node and exposes high-performance HTTP endpoints for the queries that are too expensive or too slow to run directly against the chain — most importantly **swap routing**, **batched pool data**, and **token price lookups**.
+
+It is the query path used by [app.osmosis.zone](https://app.osmosis.zone) in production. If you are building a swap interface, a price oracle, an arbitrage bot, or any UI that needs current pool state without per-block chain queries, you should be reading SQS first and falling back to RPC/REST only when SQS does not expose the data you need.
+
+## Why SQS exists
+
+Routing a multi-hop swap on Osmosis requires knowing the balances, fees, and pool type of every relevant pool. Doing that on-chain or through stateless RPC is too slow to drive a frontend. SQS subscribes to a full node, ingests pool state at the end of every block, holds it in memory, and serves routing answers in single-digit milliseconds.
+
+The trade-off is that SQS is **eventually consistent** with the chain — by one block, in practice — and it does not cover every Cosmos SDK query. Use SQS for the operations it owns (routing, pool batch, prices) and use RPC/REST/gRPC for everything else.
+
+## Production endpoints
+
+| Environment | Host | Chain |
+| --- | --- | --- |
+| Mainnet | `https://sqs.osmosis.zone` | `osmosis-1` |
+| Staging | `https://sqs.stage.osmosis.zone` | `osmosis-1` |
+| Testnet | `https://sqs.testnet.osmosis.zone` | `osmo-test-5` |
+
+The mainnet host is geo-distributed across three regions and front-ended by nginx, which rate-limits and restricts which endpoints are publicly reachable. In production, only the following endpoints are exposed:
+
+- `/router/quote`
+- `/router/custom-direct-quote`
+- `/tokens/prices`
+- `/pools`
+- Health / metrics / version / config
+
+The testnet deployment exposes every endpoint and is the right environment to develop against if you need access to less-common routes such as `/router/routes` or `/tokens/metadata`.
+
+Swagger reference for the production surface: <https://sqs.osmosis.zone/swagger/index.html>.
+
+## Get a swap quote
+
+`GET /router/quote` returns the best route SQS can find for a token-in / token-out pair, including any split routes that improve execution.
+
+```bash
+curl "https://sqs.osmosis.zone/router/quote?tokenIn=1000000uosmo&tokenOutDenom=uion" | jq .
+```
+
+```json
+{
+  "amount_in": { "denom": "uosmo", "amount": "1000000" },
+  "amount_out": "1803",
+  "route": [
+    {
+      "pools": [
+        {
+          "id": 2,
+          "type": 0,
+          "spread_factor": "0.005000000000000000",
+          "token_out_denom": "uion",
+          "taker_fee": "0.001000000000000000"
+        }
+      ],
+      "out_amount": "1803",
+      "in_amount": "1000000"
+    }
+  ],
+  "effective_fee": "0.006000000000000000"
+}
+```
+
+Parameters:
+
+- `tokenIn` — the input amount as an `sdk.Coin` string (e.g. `1000000uosmo`).
+- `tokenOutDenom` — the chain denom of the desired output token.
+- `singleRoute` (optional) — set to `true` to disable split-route quoting and return only the best single-path execution. Defaults to `false`.
+- `humanReadable` (optional) — set to `true` if you are passing human-readable denoms (`OSMO`, `USDC`) instead of chain denoms (`uosmo`, `ibc/...`).
+
+`effective_fee` is the combined spread factor plus taker fee that the quote would pay if executed in the next block.
+
+## Quote a specific route
+
+If you already know which pool(s) you want to route through — for example, you are quoting against a contract-specific pool that the general router has filtered out — use `GET /router/custom-direct-quote`:
+
+```bash
+curl "https://sqs.osmosis.zone/router/custom-direct-quote?tokenIn=1000000uosmo&tokenOutDenom=uion&poolID=2" | jq .
+```
+
+This endpoint bypasses the router's minimum-liquidity filter, so it returns a quote as long as the pool exists on chain.
+
+## Discover available routes
+
+`GET /router/routes` enumerates every route between two tokens. The mainnet deployment does not expose this endpoint; use the testnet host or a self-hosted SQS for exploration.
+
+```bash
+curl "https://sqs.testnet.osmosis.zone/router/routes?tokenIn=uosmo&tokenOutDenom=uion" | jq .
+```
+
+## Fetch pool state
+
+`GET /pools` returns hydrated pool data — chain model, balances, spread factor, pool type — for either a batch of pool IDs or all pools.
+
+```bash
+# Specific pools
+curl "https://sqs.osmosis.zone/pools?IDs=1,2,1066" | jq .
+
+# All pools (large response; cache responsibly)
+curl "https://sqs.osmosis.zone/pools" | jq '.[0]'
+```
+
+This is the preferred way to populate a frontend's pool list. It is much faster than iterating `osmosis.gamm.v1beta1.Query.Pools` or its `osmosis.poolmanager.v1beta1` equivalent and it returns balances in the same payload, saving a separate `cosmos.bank.v1beta1.Query.AllBalances` per pool.
+
+## Read token prices
+
+`GET /tokens/prices` returns spot prices for a list of base denoms.
+
+```bash
+curl "https://sqs.osmosis.zone/tokens/prices?base=wbtc,dydx&humanDenoms=true" | jq .
+```
+
+Each base maps to a quote-denom map whose value is the spot price. Set `humanDenoms=true` to pass `wbtc` instead of the IBC hash. If a price cannot be determined on chain, SQS falls back to CoinGecko.
+
+## Token metadata
+
+`GET /tokens/metadata` returns chain denom, human denom, and precision for a list of denoms. The mainnet host does not expose this endpoint; use the testnet host or a self-hosted SQS.
+
+```bash
+curl "https://sqs.testnet.osmosis.zone/tokens/metadata/statom" | jq .
+```
+
+```json
+{
+  "chain_denom": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
+  "human_denom": "statom",
+  "precision": 6
+}
+```
+
+For mainnet integrators, the canonical source for this metadata is the [Osmosis assetlist](https://github.com/osmosis-labs/assetlists/blob/main/osmosis-1/osmosis.zone_assets.json) — SQS reads from the same file.
+
+## Health, metrics, and version
+
+| Endpoint | Use |
+| --- | --- |
+| `GET /healthcheck` | Returns 200 if the upstream node is reachable, not syncing, and the in-memory cache is within threshold of the chain tip. Wire this into your uptime monitoring. |
+| `GET /metrics` | Prometheus-format metrics. |
+| `GET /version` | Server version. |
+| `GET /config` | Effective configuration, including router parameters. |
+
+## When to use SQS vs RPC, REST, or gRPC
+
+| Need | Use |
+| --- | --- |
+| Quote a swap (best route, with splits) | SQS `/router/quote` |
+| Quote a swap through a specific pool | SQS `/router/custom-direct-quote` |
+| List pools and their current state | SQS `/pools` |
+| Spot prices for an arbitrary basket | SQS `/tokens/prices` |
+| Read a single account balance | REST `/cosmos/bank/v1beta1/balances/{address}` |
+| Subscribe to new blocks or txs | RPC websocket |
+| Sign and broadcast a transaction | RPC `/broadcast_tx_sync` |
+| Query historical state by block height | Archive RPC / REST |
+| Module queries not in the SQS surface | gRPC reflection (`grpc.osmosis.zone:9090`) |
+
+In short: SQS for cross-pool aggregation and routing, RPC/REST/gRPC for everything else. See [RPC](./rpc), [REST](./rest), and [gRPC](./grpc) for those paths.
+
+## Adding a custom CosmWasm pool to SQS
+
+If you operate a custom CosmWasm pool that you want SQS routing to use, there are two integration paths:
+
+1. **Implement a dedicated pool type in SQS.** Best when the pool's quote and spot-price logic is simple enough to mirror in Go. See the [transmuter routable pool](https://github.com/osmosis-labs/sqs/blob/main/router/usecase/pools/routable_transmuter_pool.go) as a reference implementation. Requires a PR against `osmosis-labs/sqs`.
+2. **Register your code ID as a generalized CosmWasm pool.** Best when the pool logic is complex enough that SQS would need to delegate quotes back to the chain. Add your code ID to `general-cosmwasm-code-ids` in [`config.json`](https://github.com/osmosis-labs/sqs/blob/main/config.json). Routes containing such pools are restricted to direct quotes (no splits) for performance reasons.
+
+After the PR merges, the SQS team will deploy the updated config to production.
+
+## Self-hosting
+
+SQS is open-source at [osmosis-labs/sqs](https://github.com/osmosis-labs/sqs). To run your own deployment you need an Osmosis full node with `is-enabled = "true"` under the `[osmosis-sqs]` section of `app.toml`. See the repo's `README.md` for the development setup, ingest configuration, and Docker images.
+
+## Reference
+
+- Repository: <https://github.com/osmosis-labs/sqs>
+- Production swagger: <https://sqs.osmosis.zone/swagger/index.html>
+- Go client: [`osmosis-labs/sqs-go-client`](https://github.com/osmosis-labs/sqs-go-client) — first-party Go SDK wrapping the routing and price endpoints.

--- a/docs/overview/integrate/sqs.md
+++ b/docs/overview/integrate/sqs.md
@@ -4,7 +4,7 @@ sidebar_position: 13
 
 # Sidecar Query Server (SQS)
 
-The Sidecar Query Server is a Go service that runs alongside an Osmosis full node and exposes high-performance HTTP endpoints for the queries that are too expensive or too slow to run directly against the chain — most importantly **swap routing**, **batched pool data**, and **token price lookups**.
+The Sidecar Query Server is a Go service that runs alongside an Osmosis full node and exposes high-performance HTTP endpoints for the queries that are too expensive or too slow to run directly against the chain: most importantly **swap routing**, **batched pool data**, and **token price lookups**.
 
 It is the query path used by [app.osmosis.zone](https://app.osmosis.zone) in production. If you are building a swap interface, a price oracle, an arbitrage bot, or any UI that needs current pool state without per-block chain queries, you should be reading SQS first and falling back to RPC/REST only when SQS does not expose the data you need.
 
@@ -12,7 +12,7 @@ It is the query path used by [app.osmosis.zone](https://app.osmosis.zone) in pro
 
 Routing a multi-hop swap on Osmosis requires knowing the balances, fees, and pool type of every relevant pool. Doing that on-chain or through stateless RPC is too slow to drive a frontend. SQS subscribes to a full node, ingests pool state at the end of every block, holds it in memory, and serves routing answers in single-digit milliseconds.
 
-The trade-off is that SQS is **eventually consistent** with the chain — by one block, in practice — and it does not cover every Cosmos SDK query. Use SQS for the operations it owns (routing, pool batch, prices) and use RPC/REST/gRPC for everything else.
+The trade-off is that SQS is **eventually consistent** with the chain (by one block, in practice) and it does not cover every Cosmos SDK query. Use SQS for the operations it owns (routing, pool batch, prices) and use RPC/REST/gRPC for everything else.
 
 ## Production endpoints
 
@@ -67,16 +67,16 @@ curl "https://sqs.osmosis.zone/router/quote?tokenIn=1000000uosmo&tokenOutDenom=u
 
 Parameters:
 
-- `tokenIn` — the input amount as an `sdk.Coin` string (e.g. `1000000uosmo`).
-- `tokenOutDenom` — the chain denom of the desired output token.
-- `singleRoute` (optional) — set to `true` to disable split-route quoting and return only the best single-path execution. Defaults to `false`.
-- `humanReadable` (optional) — set to `true` if you are passing human-readable denoms (`OSMO`, `USDC`) instead of chain denoms (`uosmo`, `ibc/...`).
+- `tokenIn`: the input amount as an `sdk.Coin` string (e.g. `1000000uosmo`).
+- `tokenOutDenom`: the chain denom of the desired output token.
+- `singleRoute` (optional): set to `true` to disable split-route quoting and return only the best single-path execution. Defaults to `false`.
+- `humanReadable` (optional): set to `true` if you are passing human-readable denoms (`OSMO`, `USDC`) instead of chain denoms (`uosmo`, `ibc/...`).
 
 `effective_fee` is the combined spread factor plus taker fee that the quote would pay if executed in the next block.
 
 ## Quote a specific route
 
-If you already know which pool(s) you want to route through — for example, you are quoting against a contract-specific pool that the general router has filtered out — use `GET /router/custom-direct-quote`:
+If you already know which pool(s) you want to route through (for example, when quoting against a contract-specific pool that the general router has filtered out), use `GET /router/custom-direct-quote`:
 
 ```bash
 curl "https://sqs.osmosis.zone/router/custom-direct-quote?tokenIn=1000000uosmo&tokenOutDenom=uion&poolID=2" | jq .
@@ -94,7 +94,7 @@ curl "https://sqs.testnet.osmosis.zone/router/routes?tokenIn=uosmo&tokenOutDenom
 
 ## Fetch pool state
 
-`GET /pools` returns hydrated pool data — chain model, balances, spread factor, pool type — for either a batch of pool IDs or all pools.
+`GET /pools` returns hydrated pool data (chain model, balances, spread factor, pool type) for either a batch of pool IDs or all pools.
 
 ```bash
 # Specific pools
@@ -132,7 +132,7 @@ curl "https://sqs.testnet.osmosis.zone/tokens/metadata/statom" | jq .
 }
 ```
 
-For mainnet integrators, the canonical source for this metadata is the [Osmosis assetlist](https://github.com/osmosis-labs/assetlists/blob/main/osmosis-1/osmosis.zone_assets.json) — SQS reads from the same file.
+For mainnet integrators, the canonical source for this metadata is the [generated frontend assetlist](https://github.com/osmosis-labs/assetlists/blob/main/osmosis-1/generated/frontend/assetlist.json). SQS reads from the same data.
 
 ## Health, metrics, and version
 
@@ -176,4 +176,4 @@ SQS is open-source at [osmosis-labs/sqs](https://github.com/osmosis-labs/sqs). T
 
 - Repository: <https://github.com/osmosis-labs/sqs>
 - Production swagger: <https://sqs.osmosis.zone/swagger/index.html>
-- Go client: [`osmosis-labs/sqs-go-client`](https://github.com/osmosis-labs/sqs-go-client) — first-party Go SDK wrapping the routing and price endpoints.
+- Go client: [`osmosis-labs/sqs-go-client`](https://github.com/osmosis-labs/sqs-go-client), a first-party Go SDK wrapping the routing and price endpoints.

--- a/docs/overview/integrate/sqs.md
+++ b/docs/overview/integrate/sqs.md
@@ -10,7 +10,7 @@ It is the query path used by [app.osmosis.zone](https://app.osmosis.zone) in pro
 
 ## Why SQS exists
 
-Routing a multi-hop swap on Osmosis requires knowing the balances, fees, and pool type of every relevant pool. Doing that on-chain or through stateless RPC is too slow to drive a frontend. SQS subscribes to a full node, ingests pool state at the end of every block, holds it in memory, and serves routing answers in single-digit milliseconds.
+Routing a multi-hop swap on Osmosis requires knowing the balances, fees, and pool type of every relevant pool. Doing that onchain or through stateless RPC is too slow to drive a frontend. SQS subscribes to a full node, ingests pool state at the end of every block, holds it in memory, and serves routing answers in single-digit milliseconds.
 
 The trade-off is that SQS is **eventually consistent** with the chain (by one block, in practice) and it does not cover every Cosmos SDK query. Use SQS for the operations it owns (routing, pool batch, prices) and use RPC/REST/gRPC for everything else.
 
@@ -28,6 +28,8 @@ The mainnet host is geo-distributed across three regions and front-ended by ngin
 - `/router/custom-direct-quote`
 - `/tokens/prices`
 - `/pools`
+- `/pools/canonical-orderbook`
+- `/pools/canonical-orderbooks`
 - Health / metrics / version / config
 
 The testnet deployment exposes every endpoint and is the right environment to develop against if you need access to less-common routes such as `/router/routes` or `/tokens/metadata`.
@@ -105,6 +107,29 @@ curl "https://sqs.osmosis.zone/pools" | jq '.[0]'
 ```
 
 This is the preferred way to populate a frontend's pool list. It is much faster than iterating `osmosis.gamm.v1beta1.Query.Pools` or its `osmosis.poolmanager.v1beta1` equivalent and it returns balances in the same payload, saving a separate `cosmos.bank.v1beta1.Query.AllBalances` per pool.
+
+## Canonical orderbook lookup
+
+When multiple orderbook contracts exist for the same base/quote pair, SQS tracks which one has the highest liquidity cap and promotes it to "canonical" for that pair. Two endpoints expose this view:
+
+`GET /pools/canonical-orderbook?base=<denom>&quote=<denom>` returns the canonical orderbook pool id and contract address for a single pair:
+
+```bash
+curl "https://sqs.osmosis.zone/pools/canonical-orderbook?base=factory/osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3/alloyed/allBTC&quote=ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4" | jq .
+```
+
+```json
+{
+  "base": "factory/osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3/alloyed/allBTC",
+  "quote": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+  "pool_id": 1930,
+  "contract_address": "osmo13zuafleemprax0csfddn8z8p8nt9a80tefg6cw0jlkqhzvt4h49sjxy0wm"
+}
+```
+
+`GET /pools/canonical-orderbooks` returns the canonical orderbook for every supported pair as an array of the same shape.
+
+These endpoints are the right entry point for any orderbook UI or bot that needs to know which contract address to talk to for a given trading pair. Non-canonical orderbooks for the same pair still appear in `/pools` and can be queried directly by pool id; they just are not the default routing target.
 
 ## Read token prices
 

--- a/docs/overview/integrate/sqs.md
+++ b/docs/overview/integrate/sqs.md
@@ -110,12 +110,20 @@ curl "https://sqs.osmosis.zone/router/routes?tokenIn=uosmo&tokenOutDenom=uion" |
         { "ID": 1100, "TokenInDenom": "uosmo", "TokenOutDenom": "uion" }
       ],
       "IsCanonicalOrderboolRoute": false
+    },
+    {
+      "Pools": [
+        { "ID": 2, "TokenInDenom": "uosmo", "TokenOutDenom": "uion" }
+      ],
+      "IsCanonicalOrderboolRoute": false
     }
   ],
-  "UniquePoolIDs": [1100, 2, 1013, 1933, 2109],
+  "UniquePoolIDs": { "1100": {}, "2": {} },
   "ContainsCanonicalOrderbook": false
 }
 ```
+
+`UniquePoolIDs` is a set serialized as a JSON object: the keys are the pool ids referenced across all routes and the values are empty objects. Read the keys, not the values.
 
 Useful for previewing what the router will consider before committing to a quote, or for surfacing every pool that connects two tokens.
 

--- a/docs/overview/integrate/sqs.md
+++ b/docs/overview/integrate/sqs.md
@@ -22,23 +22,17 @@ The trade-off is that SQS is **eventually consistent** with the chain (by one bl
 | Staging | `https://sqs.stage.osmosis.zone` | `osmosis-1` |
 | Testnet | `https://sqs.testnet.osmosis.zone` | `osmo-test-5` |
 
-The mainnet host is geo-distributed across three regions and front-ended by nginx, which rate-limits and restricts which endpoints are publicly reachable. In production, only the following endpoints are exposed:
+The mainnet host is geo-distributed across three regions and front-ended by nginx, which rate-limits requests. Every endpoint documented on this page is reachable on the mainnet host; the testnet deployment is functionally equivalent and is the right environment for high-volume exploration without consuming the mainnet rate-limit budget.
 
-- `/router/quote`
-- `/router/custom-direct-quote`
-- `/tokens/prices`
-- `/pools`
-- `/pools/canonical-orderbook`
-- `/pools/canonical-orderbooks`
-- Health / metrics / version / config
-
-The testnet deployment exposes every endpoint and is the right environment to develop against if you need access to less-common routes such as `/router/routes` or `/tokens/metadata`.
-
-Swagger reference for the production surface: <https://sqs.osmosis.zone/swagger/index.html>.
+Swagger reference: <https://sqs.osmosis.zone/swagger/index.html>.
 
 ## Get a swap quote
 
-`GET /router/quote` returns the best route SQS can find for a token-in / token-out pair, including any split routes that improve execution.
+`GET /router/quote` returns the best route SQS can find for a swap, including any split routes that improve execution. The same endpoint serves both quote directions; the canonical direction is **exact-in** (out-given-in), and **exact-out** (in-given-out) is a separate request shape.
+
+### Exact-in (canonical)
+
+Specify the input amount; SQS returns the maximum output it can produce.
 
 ```bash
 curl "https://sqs.osmosis.zone/router/quote?tokenIn=1000000uosmo&tokenOutDenom=uion" | jq .
@@ -47,34 +41,48 @@ curl "https://sqs.osmosis.zone/router/quote?tokenIn=1000000uosmo&tokenOutDenom=u
 ```json
 {
   "amount_in": { "denom": "uosmo", "amount": "1000000" },
-  "amount_out": "1803",
+  "amount_out": "2366",
   "route": [
     {
       "pools": [
         {
-          "id": 2,
+          "id": 1013,
           "type": 0,
           "spread_factor": "0.005000000000000000",
           "token_out_denom": "uion",
-          "taker_fee": "0.001000000000000000"
+          "taker_fee": "0.008000000000000000",
+          "liquidity_cap": "791"
         }
       ],
-      "out_amount": "1803",
+      "out_amount": "2366",
       "in_amount": "1000000"
     }
-  ],
-  "effective_fee": "0.006000000000000000"
+  ]
 }
 ```
 
-Parameters:
+### Exact-out
 
-- `tokenIn`: the input amount as an `sdk.Coin` string (e.g. `1000000uosmo`).
-- `tokenOutDenom`: the chain denom of the desired output token.
-- `singleRoute` (optional): set to `true` to disable split-route quoting and return only the best single-path execution. Defaults to `false`.
-- `humanReadable` (optional): set to `true` if you are passing human-readable denoms (`OSMO`, `USDC`) instead of chain denoms (`uosmo`, `ibc/...`).
+Specify the output amount; SQS returns the minimum input required.
 
-`effective_fee` is the combined spread factor plus taker fee that the quote would pay if executed in the next block.
+```bash
+curl "https://sqs.osmosis.zone/router/quote?tokenOut=1000000uion&tokenInDenom=uosmo" | jq .
+```
+
+The response has `amount_in` as a string (the required input) and `amount_out` as an `sdk.Coin` (the target output). Do not invert an exact-in quote to estimate exact-out: call `/router/quote` with the exact-out parameter pair instead. Exact-out is a separate routing search internally and the optimal route may differ.
+
+### Parameters
+
+- `tokenIn` (exact-in): input amount as an `sdk.Coin` string, e.g. `1000000uosmo`.
+- `tokenOutDenom` (exact-in): chain denom of the desired output token.
+- `tokenOut` (exact-out): output amount as an `sdk.Coin` string, e.g. `1000000uion`.
+- `tokenInDenom` (exact-out): chain denom of the input token.
+- `singleRoute` (optional): set to `true` to disable split-route quoting. Defaults to `false`.
+- `humanDenoms` (optional): set to `true` to pass human-readable denoms (`OSMO`, `USDC`) instead of chain denoms (`uosmo`, `ibc/...`).
+
+### Fees
+
+`amount_out` is the post-fee amount you would receive (for exact-in) or `amount_in` is the post-fee amount you must pay (for exact-out). Per-pool `spread_factor` and `taker_fee` are returned for transparency; do not subtract them again client-side.
 
 ## Quote a specific route
 
@@ -84,27 +92,46 @@ If you already know which pool(s) you want to route through (for example, when q
 curl "https://sqs.osmosis.zone/router/custom-direct-quote?tokenIn=1000000uosmo&tokenOutDenom=uion&poolID=2" | jq .
 ```
 
-This endpoint bypasses the router's minimum-liquidity filter, so it returns a quote as long as the pool exists on chain.
+This endpoint bypasses the router's minimum-liquidity filter, so it returns a quote as long as the pool exists onchain.
 
 ## Discover available routes
 
-`GET /router/routes` enumerates every route between two tokens. The mainnet deployment does not expose this endpoint; use the testnet host or a self-hosted SQS for exploration.
+`GET /router/routes` enumerates every route SQS has cached between two tokens, without actually pricing a quote.
 
 ```bash
-curl "https://sqs.testnet.osmosis.zone/router/routes?tokenIn=uosmo&tokenOutDenom=uion" | jq .
+curl "https://sqs.osmosis.zone/router/routes?tokenIn=uosmo&tokenOutDenom=uion" | jq .
 ```
+
+```json
+{
+  "Routes": [
+    {
+      "Pools": [
+        { "ID": 1100, "TokenInDenom": "uosmo", "TokenOutDenom": "uion" }
+      ],
+      "IsCanonicalOrderboolRoute": false
+    }
+  ],
+  "UniquePoolIDs": [1100, 2, 1013, 1933, 2109],
+  "ContainsCanonicalOrderbook": false
+}
+```
+
+Useful for previewing what the router will consider before committing to a quote, or for surfacing every pool that connects two tokens.
 
 ## Fetch pool state
 
 `GET /pools` returns hydrated pool data (chain model, balances, spread factor, pool type) for either a batch of pool IDs or all pools.
 
 ```bash
-# Specific pools
-curl "https://sqs.osmosis.zone/pools?IDs=1,2,1066" | jq .
+# Specific pools (returns a bare array)
+curl "https://sqs.osmosis.zone/pools?IDs=1,2,1066" | jq '.[0]'
 
-# All pools (large response; cache responsibly)
-curl "https://sqs.osmosis.zone/pools" | jq '.[0]'
+# All pools (returns a paginated { data, meta } wrapper)
+curl "https://sqs.osmosis.zone/pools" | jq '.data[0]'
 ```
+
+Two response shapes: `?IDs=…` returns a bare array of pool objects; the no-IDs path returns `{ "data": [...], "meta": {...} }` with pagination metadata. The all-pools response is large; cache it client-side rather than fetching it per request.
 
 This is the preferred way to populate a frontend's pool list. It is much faster than iterating `osmosis.gamm.v1beta1.Query.Pools` or its `osmosis.poolmanager.v1beta1` equivalent and it returns balances in the same payload, saving a separate `cosmos.bank.v1beta1.Query.AllBalances` per pool.
 
@@ -139,25 +166,38 @@ These endpoints are the right entry point for any orderbook UI or bot that needs
 curl "https://sqs.osmosis.zone/tokens/prices?base=wbtc,dydx&humanDenoms=true" | jq .
 ```
 
-Each base maps to a quote-denom map whose value is the spot price. Set `humanDenoms=true` to pass `wbtc` instead of the IBC hash. If a price cannot be determined on chain, SQS falls back to CoinGecko.
+Each base maps to a quote-denom map whose value is the spot price. Set `humanDenoms=true` to pass `wbtc` instead of the IBC hash. If a price cannot be determined onchain, SQS falls back to CoinGecko.
 
 ## Token metadata
 
-`GET /tokens/metadata` returns chain denom, human denom, and precision for a list of denoms. The mainnet host does not expose this endpoint; use the testnet host or a self-hosted SQS.
+`GET /tokens/metadata?denoms=<chainDenom>[,<chainDenom>...]` returns SQS's view of asset metadata for one or more chain denoms.
 
 ```bash
-curl "https://sqs.testnet.osmosis.zone/tokens/metadata/statom" | jq .
+curl "https://sqs.osmosis.zone/tokens/metadata?denoms=uosmo,uion" | jq .
 ```
 
 ```json
 {
-  "chain_denom": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
-  "human_denom": "statom",
-  "precision": 6
+  "uosmo": {
+    "name": "Osmosis",
+    "symbol": "OSMO",
+    "coinMinimalDenom": "uosmo",
+    "decimals": 6,
+    "preview": false,
+    "coingeckoId": "osmosis"
+  },
+  "uion": {
+    "name": "Ion DAO",
+    "symbol": "ION",
+    "coinMinimalDenom": "uion",
+    "decimals": 6,
+    "preview": false,
+    "coingeckoId": "ion"
+  }
 }
 ```
 
-For mainnet integrators, the canonical source for this metadata is the [generated frontend assetlist](https://github.com/osmosis-labs/assetlists/blob/main/osmosis-1/generated/frontend/assetlist.json). SQS reads from the same data.
+The response is keyed by the chain denom passed in. SQS reads this metadata from the [generated frontend assetlist](https://github.com/osmosis-labs/assetlists/blob/main/osmosis-1/generated/frontend/assetlist.json); the assetlist remains the canonical source if you are not running SQS yourself.
 
 ## Health, metrics, and version
 
@@ -186,10 +226,10 @@ In short: SQS for cross-pool aggregation and routing, RPC/REST/gRPC for everythi
 
 ## Adding a custom CosmWasm pool to SQS
 
-If you operate a custom CosmWasm pool that you want SQS routing to use, there are two integration paths:
+If you operate a custom CosmWasm pool that you want SQS to handle, there are two integration paths. Background: SQS ingests `CosmWasmPoolModel` per block and routes against in-memory pool state, so any pool type that participates in route search must be cheap to quote in Go. See the SQS architecture note on [CosmWasm pools](https://github.com/osmosis-labs/sqs/blob/main/docs/architecture/COSMWASM_POOLS.MD) for the model.
 
-1. **Implement a dedicated pool type in SQS.** Best when the pool's quote and spot-price logic is simple enough to mirror in Go. See the [transmuter routable pool](https://github.com/osmosis-labs/sqs/blob/main/router/usecase/pools/routable_transmuter_pool.go) as a reference implementation. Requires a PR against `osmosis-labs/sqs`.
-2. **Register your code ID as a generalized CosmWasm pool.** Best when the pool logic is complex enough that SQS would need to delegate quotes back to the chain. Add your code ID to `general-cosmwasm-code-ids` in [`config.json`](https://github.com/osmosis-labs/sqs/blob/main/config.json). Routes containing such pools are restricted to direct quotes (no splits) for performance reasons.
+1. **Implement a dedicated pool type in SQS.** Best when the pool's quote and spot-price logic is simple enough to mirror in Go. SQS gets enough state from the ingester each block to compute quotes in-process. See [`routable_cw_alloy_transmuter_pool.go`](https://github.com/osmosis-labs/sqs/blob/main/router/usecase/pools/routable_cw_alloy_transmuter_pool.go) (alloyed transmuter) or [`routable_cw_orderbook_pool.go`](https://github.com/osmosis-labs/sqs/blob/main/router/usecase/pools/routable_cw_orderbook_pool.go) (orderbook) as reference implementations. Requires a PR against `osmosis-labs/sqs` adding the new pool type alongside an entry in the relevant code-id list (`transmuter-code-ids`, `alloyed-transmuter-code-ids`, `orderbook-code-ids`).
+2. **Register your code ID as a generalised CosmWasm pool.** Best when the pool logic is too complex to mirror in Go. Add your code ID to `pools.general-cosmwasm-code-ids` in the SQS deployment config (mainnet's runtime config is maintained by the SQS team; see [`config-testnet.json`](https://github.com/osmosis-labs/sqs/blob/main/config-testnet.json) for the schema). **Pools registered under `general-cosmwasm-code-ids` are opted out of SQS route search entirely.** SQS will not surface them in `/router/quote` results; they remain reachable only via `/router/custom-direct-quote` against a known pool id, where SQS queries the contract directly at quote time.
 
 After the PR merges, the SQS team will deploy the updated config to production.
 


### PR DESCRIPTION
The Sidecar Query Server at sqs.osmosis.zone is the production query path used by app.osmosis.zone for swap routing, batched pool state, and token prices. It is the highest-impact coverage gap in the docs site — every modern integrator hits it and falls back to the HackMD link in the SQS repo README.

This commit adds a self-contained guide covering:

- Why SQS exists (in-memory pool state ingested per block, ~ms quote latency vs chain-direct queries).
- Production / staging / testnet endpoints and which routes the mainnet nginx exposes.
- /router/quote, /router/custom-direct-quote, /router/routes, /pools, /tokens/prices, /tokens/metadata with curl examples and current response shapes (verified against osmosis-labs/sqs README).
- A "when to use SQS vs RPC vs REST vs gRPC" decision table.
- Adding a custom CosmWasm pool to SQS routing.
- Pointer to sqs-go-client for Go integrators and the upstream repo for self-hosting.

Cross-references added in rpc.md, rest.md, and frontend.md so integrators landing on the legacy query pages get pointed at SQS when their use case is routing / pool / price oriented.

sidebar_position: 13 (next to rpc/rest/grpc, the API cluster).

## Verifying this change

This change has been tested locally by rebuilding the doc website and verified content and links are expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-path impact.
> 
> **Overview**
> Adds a new **Sidecar Query Server (SQS)** integration guide (`docs/overview/integrate/sqs.md`, `sidebar_position: 13`) so integrators have first-class docs for the same HTTP API `app.osmosis.zone` uses for routing, pools, and prices.
> 
> The new page explains why SQS exists (in-memory per-block pool state, low-latency quotes), documents mainnet/staging/testnet hosts, and walks through key endpoints—`/router/quote` (exact-in/out), `/router/custom-direct-quote`, `/router/routes`, `/pools`, canonical orderbook lookups, `/tokens/prices`, `/tokens/metadata`, plus health/metrics—with **curl** examples and response-shape notes. It also includes a **when to use SQS vs RPC/REST/gRPC** table, guidance on adding custom CosmWasm pools to routing, self-hosting pointers, and links to Swagger and `sqs-go-client`.
> 
> **Cross-references** were added on `frontend.md` (production UI reads SQS, not chain RPC), and tip callouts on `rest.md` and `rpc.md` directing routing/pool/price workloads to SQS instead of LCD/RPC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1e044c8a6a36da829b6268bca5ba947de649cde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->