### PR TITLE
fix(docs): correct spelling 'accross' -> 'across' on endpoints page

### DIFF
--- a/docs/overview/endpoints/index.mdx
+++ b/docs/overview/endpoints/index.mdx
@@ -101,7 +101,7 @@ The following is a list of explorers available.
   - Features
     - https and websocket
     - AI-powered load balancer
-    - 40+ distributed providers accross 8 geoclusters
+    - 40+ distributed providers across 8 geoclusters
     - 180+ network APIs
     - advance key and team features
     - PAYG flat-fee CU pricing


### PR DESCRIPTION
Only finding from running the repo's codespell workflow locally with the same flags it uses in CI:

  codespell --skip="yarn.lock,package-lock.json,node_modules,build" \
            --ignore-words=".codespellignore"

After this fix, codespell returns exit 0 (zero findings).
