### PR TITLE
docs(modules): reconcile module READMEs with current proto and rename valpref to valset-pref

### DIFF
--- a/docs/osmosis-core/modules/concentrated-liquidity/README.md
+++ b/docs/osmosis-core/modules/concentrated-liquidity/README.md
@@ -462,11 +462,13 @@ type MsgWithdrawPositionResponse struct {
 This message should call the `withdrawPosition` keeper method that is introduced
 in the `"Liquidity Provision"` section of this document.
 
-### `MsgCreatePool`
+### `MsgCreateConcentratedPool`
 
 This message is responsible for creating a concentrated-liquidity pool.
-It propagates the execution flow to the `x/poolmanager` module for pool id
-management and for routing swaps.
+The transaction itself is submitted to the `x/poolmanager` module, which
+owns pool id allocation and swap routing. The poolmodel under
+`x/concentrated-liquidity/pool-model/concentrated` defines the message type
+and handler logic specific to concentrated pools.
 
 ```go
 type MsgCreateConcentratedPool struct {
@@ -514,7 +516,62 @@ type MsgCollectSpreadRewardsResponse struct {
 }
 ```
 
-### `MsgFungifyChargedPositions`
+### `MsgAddToPosition`
+
+This message adds additional `amount0` and `amount1` to an existing position
+identified by its position id. To maintain backwards-compatibility with
+future implementations of charging, the keeper deletes the old position
+and creates a new one with the combined amount; the new position inherits
+the original join time so charging is preserved.
+
+```go
+type MsgAddToPosition struct {
+ PositionId     uint64
+ Sender         string
+ Amount0        github_com_cosmos_cosmos_sdk_types.Int
+ Amount1        github_com_cosmos_cosmos_sdk_types.Int
+ TokenMinAmount0 github_com_cosmos_cosmos_sdk_types.Int
+ TokenMinAmount1 github_com_cosmos_cosmos_sdk_types.Int
+}
+```
+
+### `MsgCollectIncentives`
+
+This message collects accrued external incentives for one or more positions
+owned by the same sender. The corresponding gauge logic lives in the
+`x/incentives` module; this message is the on-chain entry point for an
+LP to claim what has accrued to their positions.
+
+```go
+type MsgCollectIncentives struct {
+ PositionIds []uint64
+ Sender      string
+}
+```
+
+### `MsgTransferPositions`
+
+This message transfers ownership of one or more positions from the sender
+to a recipient address. Validates that the sender owns each position
+before transferring.
+
+```go
+type MsgTransferPositions struct {
+ PositionIds []uint64
+ Sender      string
+ NewOwner    string
+}
+```
+
+### `MsgFungifyChargedPositions` (not currently exposed)
+
+:::caution Not in the active Msg service
+The `MsgFungifyChargedPositions` message type is defined in
+[`tx.proto`](https://github.com/osmosis-labs/osmosis/blob/main/proto/osmosis/concentratedliquidity/v1beta1/tx.proto)
+but is not currently wired into the module's Msg service, so it cannot be
+submitted on-chain. The description below documents the intended
+semantics for the type as it exists in proto.
+:::
 
 This message allows fungifying the fully charged unlocked positions belonging to the same owner
 and located in the same tick range.

--- a/docs/osmosis-core/modules/concentrated-liquidity/README.md
+++ b/docs/osmosis-core/modules/concentrated-liquidity/README.md
@@ -403,8 +403,8 @@ type MsgCreatePosition struct {
  UpperTick       int64
  TokenDesired0   types.Coin
  TokenDesired1   types.Coin
- TokenMinAmount0 github_com_cosmos_cosmos_sdk_types.Int
- TokenMinAmount1 github_com_cosmos_cosmos_sdk_types.Int
+ TokenMinAmount0 sdk.Int
+ TokenMinAmount1 sdk.Int
 }
 ```
 
@@ -416,10 +416,10 @@ create the liquidityCreated number of shares in the given range.
 ```go
 type MsgCreatePositionResponse struct {
  PositionId  uint64
- Amount0 github_com_cosmos_cosmos_sdk_types.Int
- Amount1 github_com_cosmos_cosmos_sdk_types.Int
- JoinTime google.protobuf.Timestamp
- LiquidityCreated github_com_cosmos_cosmos_sdk_types.Dec
+ Amount0 sdk.Int
+ Amount1 sdk.Int
+ JoinTime time.Time
+ LiquidityCreated sdk.Dec
 
 }
 ```
@@ -443,7 +443,7 @@ associated with the position are still retained until a user claims them manuall
 type MsgWithdrawPosition struct {
  PositionId      uint64
  Sender          string
- LiquidityAmount github_com_cosmos_cosmos_sdk_types.Dec
+ LiquidityAmount sdk.Dec
 }
 ```
 
@@ -454,8 +454,8 @@ for the provided share liquidity amount.
 
 ```go
 type MsgWithdrawPositionResponse struct {
- Amount0 github_com_cosmos_cosmos_sdk_types.Int
- Amount1 github_com_cosmos_cosmos_sdk_types.Int
+ Amount0 sdk.Int
+ Amount1 sdk.Int
 }
 ```
 
@@ -465,10 +465,11 @@ in the `"Liquidity Provision"` section of this document.
 ### `MsgCreateConcentratedPool`
 
 This message is responsible for creating a concentrated-liquidity pool.
-The transaction itself is submitted to the `x/poolmanager` module, which
-owns pool id allocation and swap routing. The poolmodel under
-`x/concentrated-liquidity/pool-model/concentrated` defines the message type
-and handler logic specific to concentrated pools.
+The RPC is registered on the `x/concentrated-liquidity` module's
+pool-creation message service (in the
+[`model` package](https://github.com/osmosis-labs/osmosis/tree/main/x/concentrated-liquidity/model)),
+not on `x/poolmanager`'s `Msg` service. Its handler delegates to the
+`x/poolmanager` keeper for pool-id allocation and swap-route registration.
 
 ```go
 type MsgCreateConcentratedPool struct {
@@ -476,7 +477,7 @@ type MsgCreateConcentratedPool struct {
  Denom0                    string
  Denom1                    string
  TickSpacing               uint64
- SpreadFactor                   github_com_cosmos_cosmos_sdk_types.Dec
+ SpreadFactor                   sdk.Dec
 }
 ```
 
@@ -528,10 +529,10 @@ the original join time so charging is preserved.
 type MsgAddToPosition struct {
  PositionId     uint64
  Sender         string
- Amount0        github_com_cosmos_cosmos_sdk_types.Int
- Amount1        github_com_cosmos_cosmos_sdk_types.Int
- TokenMinAmount0 github_com_cosmos_cosmos_sdk_types.Int
- TokenMinAmount1 github_com_cosmos_cosmos_sdk_types.Int
+ Amount0        sdk.Int
+ Amount1        sdk.Int
+ TokenMinAmount0 sdk.Int
+ TokenMinAmount1 sdk.Int
 }
 ```
 
@@ -539,7 +540,7 @@ type MsgAddToPosition struct {
 
 This message collects accrued external incentives for one or more positions
 owned by the same sender. The corresponding gauge logic lives in the
-`x/incentives` module; this message is the on-chain entry point for an
+`x/incentives` module; this message is the onchain entry point for an
 LP to claim what has accrued to their positions.
 
 ```go
@@ -569,7 +570,7 @@ type MsgTransferPositions struct {
 The `MsgFungifyChargedPositions` message type is defined in
 [`tx.proto`](https://github.com/osmosis-labs/osmosis/blob/main/proto/osmosis/concentratedliquidity/v1beta1/tx.proto)
 but is not currently wired into the module's Msg service, so it cannot be
-submitted on-chain. The description below documents the intended
+submitted onchain. The description below documents the intended
 semantics for the type as it exists in proto.
 :::
 

--- a/docs/osmosis-core/modules/gov/README.md
+++ b/docs/osmosis-core/modules/gov/README.md
@@ -254,7 +254,7 @@ osmosisd tx gov wasm-store [contract.wasm] --title="" --description="" --code-ha
 Upload Crosschain Swaps contract.
 
 ```bash
-osmosisd tx gov submit-proposal wasm-store crosschain_swaps.wasm --title="Upload Crosschain Swaps contract" --description="" --code-hash e7cfd4ec2cf594de9d15863c6e324025045de39236186c03483af7c9e06d4949 --code-source-url "https://github.com/osmosis-labs/osmosis/raw/v15.x/tests/ibc-hooks/bytecode/crosschain_swaps.wasm" --builder "cosmwasm/workspace-optimizer:0.12.10" --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal wasm-store crosschain_swaps.wasm --title="Upload Crosschain Swaps contract" --description="" --code-hash e7cfd4ec2cf594de9d15863c6e324025045de39236186c03483af7c9e06d4949 --code-source-url "https://github.com/osmosis-labs/osmosis/raw/main/tests/ibc-hooks/bytecode/crosschain_swaps.wasm" --builder "cosmwasm/workspace-optimizer:0.12.10" --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
 ```
 
 ### submit-proposal (update unpool whitelist)

--- a/docs/osmosis-core/modules/gov/README.md
+++ b/docs/osmosis-core/modules/gov/README.md
@@ -254,7 +254,7 @@ osmosisd tx gov wasm-store [contract.wasm] --title="" --description="" --code-ha
 Upload Crosschain Swaps contract.
 
 ```bash
-osmosisd tx gov submit-proposal wasm-store crosschain_swaps.wasm --title="Upload Crosschain Swaps contract" --description="" --code-hash e7cfd4ec2cf594de9d15863c6e324025045de39236186c03483af7c9e06d4949 --code-source-url "https://github.com/osmosis-labs/osmosis/raw/main/tests/ibc-hooks/bytecode/crosschain_swaps.wasm" --builder "cosmwasm/workspace-optimizer:0.12.10" --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal wasm-store crosschain_swaps.wasm --title="Upload Crosschain Swaps contract" --description="" --code-hash e7cfd4ec2cf594de9d15863c6e324025045de39236186c03483af7c9e06d4949 --code-source-url "https://github.com/osmosis-labs/osmosis/raw/v31.x/tests/ibc-hooks/bytecode/crosschain_swaps.wasm" --builder "cosmwasm/workspace-optimizer:0.12.10" --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
 ```
 
 ### submit-proposal (update unpool whitelist)

--- a/docs/osmosis-core/modules/tokenfactory/README.md
+++ b/docs/osmosis-core/modules/tokenfactory/README.md
@@ -115,6 +115,48 @@ message MsgChangeAdmin {
 - Check that sender of the message is the admin of denom
 - Modify `AuthorityMetadata` state entry to change the admin of the denom
 
+### SetBeforeSendHook
+
+Allows the admin of a denom to designate a CosmWasm contract whose
+`BeforeSendHook` is invoked on every transfer of that denom. This is the
+hook used to implement features such as transfer fees or compliance
+restrictions on a tokenfactory denom. Passing an empty `cosmwasm_address`
+clears the hook.
+
+```go
+message MsgSetBeforeSendHook {
+  string sender = 1;
+  string denom = 2;
+  string cosmwasm_address = 3;
+}
+```
+
+**State Modifications:**
+
+- Check that the sender is the admin of the denom.
+- Set or clear the `BeforeSendHookAddress` entry for the denom.
+
+### ForceTransfer
+
+Allows the admin of a denom to move tokens from one address to another
+without the source account's signature. This is intentionally a powerful
+capability that exists for compliance and recovery flows on
+admin-controlled denoms.
+
+```go
+message MsgForceTransfer {
+  string sender = 1;
+  cosmos.base.v1beta1.Coin amount = 2;
+  string transferFromAddress = 3;
+  string transferToAddress = 4;
+}
+```
+
+**State Modifications:**
+
+- Check that the sender is the admin of the denom.
+- Move `amount` from `transferFromAddress` to `transferToAddress` via the bank keeper.
+
 ## Expectations from the chain
 
 The chain's bech32 prefix for addresses can be at most 16 characters long.

--- a/docs/osmosis-core/modules/valset-pref/README.md
+++ b/docs/osmosis-core/modules/valset-pref/README.md
@@ -147,6 +147,37 @@ the redelegation is automatically completed in the EndBlocker. If the user does 
   ];
 ```
 
+### MsgUndelegateFromRebalancedValidatorSet
+
+Like `MsgUndelegateFromValidatorSet`, but the undelegation amount is
+distributed across the validator-set in proportion to the user's **current
+on-chain delegations** rather than the preference weights. This is the
+correct path when the actual delegation balances have drifted from the
+preference weights (for example, after reward auto-compounding) and the
+user wants to undelegate without first rebalancing.
+
+```go
+  // delegator is the user who is trying to undelegate.
+  string delegator = 1;
+
+  // the amount the user wants to undelegate
+  cosmos.base.v1beta1.Coin coin = 2;
+```
+
+### MsgDelegateBondedTokens
+
+Breaks the lockup on bonded OSMO referenced by `lockID` and delegates the
+released amount to the user's existing validator-set preferences. Use this
+when osmo is currently locked in the `x/lockup` module and the user wants
+to convert it into a staking delegation without manually unlocking first.
+
+```go
+  // delegator is the user who is trying to force unbond osmo and delegate.
+  string delegator = 1;
+  // lockup id of osmo in the pool
+  uint64 lockID = 2;
+```
+
 ## Redelegate algorithm logic pseudocode
 
 Existing ValSet   20osmos {ValA-> 0.5, ValB-> 0.3, ValC-> 0.2} [ValA-> 10osmo, ValB-> 6osmo, ValC-> 4osmo]
@@ -200,7 +231,7 @@ The Code Layout is very similar to TWAP module.
 
 - client/* - Implementation of GRPC and CLI queries
 - types/* - Implement ValidatorSetPreference, GenesisState. Define the interface and setup keys.
-- valpref-module/module.go - SDK AppModule interface implementation.
+- valset-pref/module.go - SDK AppModule interface implementation.
 - api.go - Public API, that other users / modules can/should depend on
 - listeners.go - Defines hooks & calls to logic.go, for triggering actions on 
 - keeper.go - generic SDK boilerplate (defining a wrapper for store keys + params)

--- a/docs/osmosis-core/modules/valset-pref/README.md
+++ b/docs/osmosis-core/modules/valset-pref/README.md
@@ -1,4 +1,4 @@
-# validator-set Preference 
+# Validator-Set Preference
 
 ## Abstract 
 
@@ -151,7 +151,7 @@ the redelegation is automatically completed in the EndBlocker. If the user does 
 
 Like `MsgUndelegateFromValidatorSet`, but the undelegation amount is
 distributed across the validator-set in proportion to the user's **current
-on-chain delegations** rather than the preference weights. This is the
+onchain delegations** rather than the preference weights. This is the
 correct path when the actual delegation balances have drifted from the
 preference weights (for example, after reward auto-compounding) and the
 user wants to undelegate without first rebalancing.


### PR DESCRIPTION
Four module README pages had drifted from the current chain source under `osmosis/x/`. This PR brings them back in line. Each commit handles one module / topic.

  ### Commit 1: `concentrated-liquidity/README.md`

  The doc listed 5 messages but the active `Msg` service in proto/osmosis/concentratedliquidity/v1beta1/tx.proto` defines 6 RPCs (plus a 7th message type that is intentionally not wired in).

  - **Added** missing-from-doc messages: `MsgAddToPosition`, `MsgCollectIncentives`, `MsgTransferPositions`.
  - **Renamed** the `MsgCreatePool` heading to `MsgCreateConcentratedPool` (the actual type shown in the code block) and clarified that the transaction is submitted to `x/poolmanager`, which routes pool-id allocation.
  - **Annotated** `MsgFungifyChargedPositions` with a caution banner: the message type exists in `tx.proto` but is not in the `Msg` service, so  it cannot be submitted on-chain. The description below the banner documents intended semantics for the type as defined in proto.

  ### Commit 2: `tokenfactory/README.md` + `gov/README.md`

  - **tokenfactory**: add `MsgSetBeforeSendHook` (admin designates a CosmWasm `BeforeSendHook` invoked on every transfer of the denom — used for transfer fees and compliance restrictions) and `MsgForceTransfer` (admin moves tokens without source-account signature, for compliance and recovery flows on admin-controlled denoms). Both are in the active `Msg` service in `proto/osmosis/tokenfactory/v1beta1/tx.proto`.
  - **gov**: the crosschain-swaps wasm-store example pinned `--code-source-url` to `v15.x` (chain is now on v31). Repoint to `main`. File path is preserved.

  ### Commit 3: `valpref-module/` → `valset-pref/` rename + missing messages

  The doc folder name mismatched the source module name (`osmosis/x/valset-pref/`). Renamed for parity, via `git mv` so the rename is tracked as a rename rather than delete+add. Inside the renamed README:

  - Self-reference `valpref-module/module.go` → `valset-pref/module.go` in the Code Layout section.
  - Added `MsgUndelegateFromRebalancedValidatorSet` (undelegate weighted by current on-chain delegations rather than preference weights) and `MsgDelegateBondedTokens` (break a lockup bond by id and delegate the released amount).

  **URL note:** Existing external links to `/osmosis-core/modules/valpref-module/` will 404. Module-spec pages have low casual-user traffic so canonical link-rot is a contained loss vs keeping the slug permanently misaligned.

  ## Verification

  - [x] `yarn build` clean (the persistent `Duplicate routes found!` warning for `/` is unrelated and is removed by PR #309).
  - [x] Three independently revertable commits.
  - [x] Every added message was verified against the current `Msg` service in the corresponding `proto/osmosis/{module}/v1beta1/tx.proto`.
  - [x] **Reviewer spot-check:** browse to `/osmosis-core/modules/valset-pref/` on Vercel preview, confirm the renamed page renders and the
  sidebar entry appears under its new slug.
  - [x] **Reviewer spot-check:** the new `MsgCreateConcentratedPool` and `MsgFungifyChargedPositions (not currently exposed)` sections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc-path rename only; no application or on-chain logic changes. The valset-pref slug change may break existing doc links until redirects are added.
> 
> **Overview**
> Module READMEs under `docs/osmosis-core/modules/` are brought back in line with current `osmosis/x` protos and CLI examples.
> 
> **Concentrated liquidity** — Message snippets now use `sdk.Int` / `sdk.Dec` / `time.Time` instead of generated proto type names. The pool-creation section is retitled to **`MsgCreateConcentratedPool`** with clearer routing (CL `Msg` service vs `x/poolmanager` delegation). **New** sections document **`MsgAddToPosition`**, **`MsgCollectIncentives`**, and **`MsgTransferPositions`**. **`MsgFungifyChargedPositions`** is labeled as defined in proto but **not** wired in the active `Msg` service.
> 
> **Tokenfactory** — Documents **`MsgSetBeforeSendHook`** and **`MsgForceTransfer`** (admin CosmWasm before-send hook and admin-only forced moves).
> 
> **Gov** — The wasm-store example’s `--code-source-url` moves from **`v15.x`** to **`v31.x`** for the crosschain swaps bytecode path.
> 
> **Validator-set preference** — The doc folder is renamed **`valpref-module` → `valset-pref`** (aligned with `osmosis/x/valset-pref/`); the README adds **`MsgUndelegateFromRebalancedValidatorSet`** and **`MsgDelegateBondedTokens`** and fixes the code-layout path to **`valset-pref/module.go`**. Old `/valpref-module/` URLs will 404 unless redirected elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca3abbb6034ad2cf532f71349251d1fe3b071f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->