### PR TITLE
  Unify docs site styling and section landings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,41 @@ The code should satisfy the following:
 - Have meaningful file names, directory names and directory structure.
 - Have a scope for easy fixing, refactoring and scaling.
 
+### Docs page conventions
+
+A few conventions keep the docs readable and consistent. These are
+strongly preferred — push back in review if a PR ignores them.
+
+- **Open every page with a lede.** One or two sentences directly under
+  the page title that explain what the page covers and who it's for.
+  The first paragraph gets a slightly larger size automatically, so use
+  the space — don't waste it on filler ("This guide will...").
+
+- **Break up walls of text.** If a paragraph is more than ~6 lines,
+  split it, pull part into a bullet list, or move an aside into a
+  Docusaurus admonition (`:::tip`, `:::note`, `:::warning`,
+  `:::info`, `:::danger`). Admonitions are the cheapest way to break
+  up dense prose and they render with strong visual contrast.
+
+- **Use headings as scannable structure, not decoration.** Aim for an
+  `<h2>` every ~150–200 words on dense pages. A reader should be able
+  to skim heading-to-heading and understand the page's shape.
+
+- **Index pages need an intro paragraph above the card grid.** When a
+  page is mostly a `<HomepageSection>` table of contents (like the
+  `osmosis-core/README.mdx`), add one or two sentences above the grid
+  that frame what's in the section and which card to read first. A bare
+  grid of identical cards reads as a placeholder.
+
+- **Featured card per section.** `<HomepageCard>` accepts a `featured`
+  prop that doubles the card width and brightens the border. Use it for
+  the "if you read nothing else, read this" entry — **at most one per
+  section**. Don't featuring everything; that's just colour noise.
+
+- **Code blocks deserve a language tag.** ` ```sh ` / ` ```ts ` /
+  ` ```rust ` so syntax highlighting picks them up. Plain ` ``` ` is
+  rarely the right choice.
+
 ## What should I know before I get started
 
 You can contribute to any of the features you want, here's what you need to know:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,12 +47,12 @@ The code should satisfy the following:
 ### Docs page conventions
 
 A few conventions keep the docs readable and consistent. These are
-strongly preferred — push back in review if a PR ignores them.
+strongly preferred; push back in review if a PR ignores them.
 
 - **Open every page with a lede.** One or two sentences directly under
   the page title that explain what the page covers and who it's for.
   The first paragraph gets a slightly larger size automatically, so use
-  the space — don't waste it on filler ("This guide will...").
+  the space, don't waste it on filler ("This guide will...").
 
 - **Break up walls of text.** If a paragraph is more than ~6 lines,
   split it, pull part into a bullet list, or move an aside into a
@@ -72,7 +72,7 @@ strongly preferred — push back in review if a PR ignores them.
 
 - **Featured card per section.** `<HomepageCard>` accepts a `featured`
   prop that doubles the card width and brightens the border. Use it for
-  the "if you read nothing else, read this" entry — **at most one per
+  the "if you read nothing else, read this" entry, **at most one per
   section**. Don't featuring everything; that's just colour noise.
 
 - **Code blocks deserve a language tag.** ` ```sh ` / ` ```ts ` /

--- a/docs/beaker/README.md
+++ b/docs/beaker/README.md
@@ -1,21 +1,10 @@
 # Beaker
 
-<p align="center">
-<a href="https://docs.osmosis.zone/cosmwasm/">
-    <img src="/icons/beaker.svg" alt="Beaker logo" title="Beaker" width="150" align="center" height="150" />
-</a>
-</p>
+[Beaker](https://github.com/osmosis-labs/beaker) is a scaffolding tool for CosmWasm apps on Osmosis. It wires up the contract dependencies, an interactive console, and a sample frontend so you can go from `beaker new` to a working dapp in a few commands.
 
-<p align="center" width="100%">
-    <img  height="20" src="https://github.com/osmosis-labs/beaker/actions/workflows/doctest.yml/badge.svg"/>
-    <img height="20" src="https://github.com/osmosis-labs/beaker/actions/workflows/lint.yml/badge.svg"/>
-    <a href="https://github.com/osmosis-labs/beaker/blob/main/LICENSE-APACHE"><img height="20" src="https://img.shields.io/badge/license-APACHE-blue.svg"/></a>
-    <a href="https://github.com/osmosis-labs/beaker/blob/main/LICENSE-MIT"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
-    <a href="https://deps.rs/repo/github/osmosis-labs/beaker"><img height="20" src="https://deps.rs/repo/github/osmosis-labs/beaker/status.svg"/></a>
-    <a href="https://crates.io/crates/beaker"><img height="20" src="https://img.shields.io/crates/v/beaker.svg"/></a>
-</p>
-
-[Beaker](https://github.com/osmosis-labs/beaker) makes it easy to scaffold a new cosmwasm app, with all of the dependencies for osmosis hooked up, interactive console, and a sample front-end at the ready.
+:::info Source on GitHub
+Beaker is maintained at [osmosis-labs/beaker](https://github.com/osmosis-labs/beaker) — see the repo for the latest releases, CI status, and license info.
+:::
 
 ---
 

--- a/docs/beaker/README.md
+++ b/docs/beaker/README.md
@@ -3,7 +3,7 @@
 [Beaker](https://github.com/osmosis-labs/beaker) is a scaffolding tool for CosmWasm apps on Osmosis. It wires up the contract dependencies, an interactive console, and a sample frontend so you can go from `beaker new` to a working dapp in a few commands.
 
 :::info Source on GitHub
-Beaker is maintained at [osmosis-labs/beaker](https://github.com/osmosis-labs/beaker) — see the repo for the latest releases, CI status, and license info.
+Beaker is maintained at [osmosis-labs/beaker](https://github.com/osmosis-labs/beaker), see the repo for the latest releases, CI status, and license info.
 :::
 
 ---

--- a/docs/cosmwasm/README.mdx
+++ b/docs/cosmwasm/README.mdx
@@ -2,148 +2,119 @@
 title: Cosmwasm
 sidebar_position: 1
 ---
----
+
 import {
   HomepageCard as Card,
   HomepageSection as Section,
 } from '../../src/components/HomepageComponents';
 
 import {
-  ChainIcon,
-  IDEIcon,
   TerminalIcon,
-  ModulesIcon,
-  RelayerIcon,
-  AssetIcon,
   KeysIcon,
   Cosmwasm,
   Beaker,
   Osmojs,
+  LocalOsmosis,
+  Network,
+  Contribute,
+  Guide,
 } from '../../src/icons';
 
-# Smart Contracts Development
+# Smart Contract Development
 
-The following are a collection of guides on how to build and deploy CoswmWasm smart contracts on the Osmosis blockchain. Please note that a user can deploy contracts with tools such as Beaker or directly with the Osmosisd binary via CLI. 
+Build and deploy CosmWasm smart contracts on Osmosis. The guides below cover the full path — from running contracts against a local node, to deploying on testnet, to submitting a governance proposal for inclusion on mainnet. If you've never deployed a CosmWasm contract before, start with **CosmWasm on LocalOsmosis**.
 
-<Section title="Guides" id="web-sdks" hasSubSections >
-
-   <Section>
-    <Card
+<Section title="Guides">
+  <Card
+    featured
     title="CosmWasm on LocalOsmosis"
-    description=" Compile, upload and interact with a contract with LocalOsmosis."
+    description="Compile, upload and interact with a contract against a local Osmosis node — the fastest feedback loop for getting started."
     to="/cosmwasm/local/localosmosis"
-    icon={<Cosmwasm />}
+    icon={<LocalOsmosis />}
   />
-    <Card
-    title=" Deploy Cosmwasm Contracts to Testnet"
-    description=" Deploying contracts to testnet via osmosisd binary"
+  <Card
+    title="Deploy to Testnet"
+    description="Push a contract to the public Osmosis testnet via the osmosisd binary."
     to="/cosmwasm/testnet/cosmwasm-deployment"
-    icon={<Cosmwasm />}
+    icon={<Network />}
   />
-    <Card
-    title=" Submit a CosmWasm Governance Proposal"
-    description="  Example on how submit a CosmWasm binary proposal."
-    to="/cosmwasm/local/submit-wasm-proposal"
-    icon={<Cosmwasm />}
-  />
-    <Card
-    title=" Deploy Cosmwasm Contracts to Testnet with Beaker"
-    description=" Deploying contracts to testnet with Beaker"
+  <Card
+    title="Deploy to Testnet with Beaker"
+    description="The same testnet workflow, scripted end-to-end with Beaker."
     to="/cosmwasm/testnet/cosmwasm-beaker"
-    icon={<Cosmwasm />}
+    icon={<Beaker />}
   />
- 
+  <Card
+    title="Submit a Governance Proposal"
+    description="Walk through proposing a CosmWasm binary for inclusion on mainnet."
+    to="/cosmwasm/local/submit-wasm-proposal"
+    icon={<Contribute />}
+  />
   <Card
     title="Verifying Smart Contracts"
-    description=" Download contract and verify the hash."
+    description="Download a deployed contract and verify its hash against source."
     to="/cosmwasm/cosmwasm-verify-contract"
-    icon={<Cosmwasm />}
+    icon={<KeysIcon />}
   />
-
-
   <Card
-    title="Testing and Interacting with Smart Contracts"
-    description="Cw-Orchestrator, an all-in-one Rust-based CosmWasm contracts testing, scripting, and deployment tool"
+    title="Testing & Interacting with Contracts"
+    description="Cw-Orchestrator: a Rust-based contract testing, scripting, and deployment tool."
     to="/cosmwasm/cw-orch"
-    icon={<Cosmwasm />}
     svgFile="/icons/cw-orch.svg"
   />
- 
-  </Section>
-
-  </Section>
-
-
-<Section title="Resources" id="web-sdks" hasSubSections >
-   <Section>
-    <Card
-    title="Osmosis Contract List"
-    description="Repository contains a list of all approved code IDs to Osmosis"
-    to="https://github.com/osmosis-labs/contract-list"
-    icon={<Cosmwasm />}
-  />
-    <Card
-    title="Your first contract"
-    description=" Official CosmWasm Documentation"
-    to="https://docs.cosmwasm.com/docs/1.0/getting-started/intro"
-    icon={<Cosmwasm />}
-  />
-    </Section>
-  </Section>
-
-
-<Section title="Front-end Development" id="web-sdks" hasSubSections >
-   <Section>
-    <Card
-    title=" Cosmwasm & Javascript"
-    description="Interacting via JavaScript runtimes such as Node.js and the browser."
+  <Card
+    title="CosmWasm & JavaScript"
+    description="Talk to deployed contracts from Node.js or the browser."
     to="/cosmwasm/javascript"
-    icon={<Cosmwasm />}
+    icon={<Osmojs />}
   />
-    </Section>
-  </Section>
+</Section>
 
-
-<Section title="Tools" id="web-sdks" hasSubSections >
-   <Section>
-    <Card
+<Section title="Tools">
+  <Card
     title="Beaker"
-    description="Easy to scaffold a new cosmwasm app."
+    description="Scaffold a new CosmWasm app — contracts, frontend, and configuration in one command."
     to="/beaker"
     icon={<Beaker />}
   />
-<Card
-    title="OsmoJs"
-    description="Osmosis JS Stargate Client"
+  <Card
+    title="OsmoJS"
+    description="JS/TS client for sending messages to Osmosis, with proto and amino encoding handled for you."
     to="/osmojs"
     icon={<Osmojs />}
   />
-<Card
+  <Card
     title="Osmosisd CLI"
-    description="Learn how to interact with Osmosis via the CLI"
+    description="Query the chain and broadcast transactions directly from your terminal."
     to="/osmosis-core/osmosisd"
     icon={<TerminalIcon />}
+    svgFile="/icons/cli.svg"
   />
-    </Section>
-  </Section>
- 
-
-
-<Section title="Networks" id="web-sdks" hasSubSections >
-   <Section>
-    <Card
-    title="Public endpoints"
-    description="Official and third party API endpoints."
-    to="/overview/endpoints"
-    icon={<KeysIcon />}
-  />
-
-<Card
-    title="Explorers"
-    description="Block and contract explorers"
-    to="/overview/endpoints#explorers"
-    icon={<KeysIcon />}
-  />
-
 </Section>
+
+<Section title="Resources">
+  <Card
+    title="Osmosis Contract List"
+    description="Every approved code ID currently deployed on Osmosis."
+    to="https://github.com/osmosis-labs/contract-list"
+    svgFile="/icons/registry.svg"
+  />
+  <Card
+    title="CosmWasm Documentation"
+    description="The official CosmWasm getting-started guide — language-agnostic primer."
+    to="https://docs.cosmwasm.com/docs/1.0/getting-started/intro"
+    icon={<Guide />}
+  />
+  <Card
+    title="Public Endpoints"
+    description="Official and third-party RPC, LCD, and gRPC endpoints for testnet and mainnet."
+    to="/overview/endpoints"
+    icon={<Network />}
+  />
+  <Card
+    title="Block Explorers"
+    description="Browse blocks, transactions, and deployed contracts."
+    to="/overview/endpoints#explorers"
+    icon={<Guide />}
+  />
 </Section>

--- a/docs/cosmwasm/README.mdx
+++ b/docs/cosmwasm/README.mdx
@@ -22,13 +22,13 @@ import {
 
 # Smart Contract Development
 
-Build and deploy CosmWasm smart contracts on Osmosis. The guides below cover the full path — from running contracts against a local node, to deploying on testnet, to submitting a governance proposal for inclusion on mainnet. If you've never deployed a CosmWasm contract before, start with **CosmWasm on LocalOsmosis**.
+Build and deploy CosmWasm smart contracts on Osmosis. The guides below cover the full path, from running contracts against a local node, to deploying on testnet, to submitting a governance proposal for inclusion on mainnet. If you've never deployed a CosmWasm contract before, start with **CosmWasm on LocalOsmosis**.
 
 <Section title="Guides">
   <Card
     featured
     title="CosmWasm on LocalOsmosis"
-    description="Compile, upload and interact with a contract against a local Osmosis node — the fastest feedback loop for getting started."
+    description="Compile, upload and interact with a contract against a local Osmosis node, the fastest feedback loop for getting started."
     to="/cosmwasm/local/localosmosis"
     icon={<LocalOsmosis />}
   />
@@ -73,7 +73,7 @@ Build and deploy CosmWasm smart contracts on Osmosis. The guides below cover the
 <Section title="Tools">
   <Card
     title="Beaker"
-    description="Scaffold a new CosmWasm app — contracts, frontend, and configuration in one command."
+    description="Scaffold a new CosmWasm app, contracts, frontend, and configuration in one command."
     to="/beaker"
     icon={<Beaker />}
   />
@@ -101,7 +101,7 @@ Build and deploy CosmWasm smart contracts on Osmosis. The guides below cover the
   />
   <Card
     title="CosmWasm Documentation"
-    description="The official CosmWasm getting-started guide — language-agnostic primer."
+    description="The official CosmWasm getting-started guide, language-agnostic primer."
     to="https://docs.cosmwasm.com/docs/1.0/getting-started/intro"
     icon={<Guide />}
   />

--- a/docs/frontend/README.mdx
+++ b/docs/frontend/README.mdx
@@ -2,117 +2,90 @@
 title: Frontend & SDKs
 sidebar_position: 1
 ---
----
+
 import {
   HomepageCard as Card,
   HomepageSection as Section,
 } from '../../src/components/HomepageComponents';
-import Link from '@docusaurus/Link';
+
 import {
-  ChainIcon,
-  IDEIcon,
-  TerminalIcon,
-  ModulesIcon,
-  RelayerIcon,
-  AssetIcon,
   Telescope,
   Osmojs,
   Createapp,
   Cosmoskit,
+  Chainregistry,
   Tscodegen,
-  Chain
+  Frontend,
+  Network,
 } from '../../src/icons';
 
-# Osmosis Frontend, SDKs and Tools
+# Frontend, SDKs & Tooling
 
-The following are libraries and utilities to start developing with Osmosis.
+Libraries for building on top of Osmosis from JavaScript, TypeScript, and the web. The **Osmosis Frontend** section covers the official `app.osmosis.zone` codebase and the npm packages it's built from; **Cosmos Ecosystem** lists the wider tooling that most Cosmos frontends — Osmosis included — rely on.
 
-<Section title="Osmosis Frontend" id="web-sdks" hasSubSections >
-
-   <Section>
-   <Card
+<Section title="Osmosis Frontend">
+  <Card
+    featured
     title="Osmosis Frontend"
-    description="Web interface for Osmosis Zone"
+    description="The web interface for app.osmosis.zone. Start here for architecture, local setup, and contributing."
     to="/frontend/osmosis-frontend"
-    icon=""
-    svgFile="/icons/osmo.svg"/>
-
+    svgFile="/icons/osmo.svg"
+  />
   <Card
     title="OsmoJS"
-    description="Compose and broadcast Osmosis and Cosmos messages, with all of the proto and amino encoding handled for you."
+    description="Compose and broadcast Osmosis and Cosmos messages — proto and amino encoding handled for you."
     to="/osmojs"
     icon={<Osmojs />}
-    svgFile=""
   />
-
   <Card
-    title="Osmosis-Labs Math"
-    description="NPM package with math functions related to Osmosis AMM. Useful for estimating state changes to propose reasonable min/max amounts in transactions."
+    title="@osmosis-labs/math"
+    description="AMM math utilities. Estimate state changes to set reasonable min/max amounts on transactions."
     to="https://www.npmjs.com/package/@osmosis-labs/math"
-    icon={<Tscodegen />}
     svgFile="/icons/math.svg"
-  />   
+  />
   <Card
-    title="Osmosis-Labs Pools"
-    description="NPM package that defines pool interface and pool routing logic for the Osmosis Dex."
+    title="@osmosis-labs/pools"
+    description="The pool interface and routing logic that powers the Osmosis DEX."
     to="https://www.npmjs.com/package/@osmosis-labs/pools"
-    icon={<Tscodegen />}
     svgFile="/icons/pools.svg"
-  /> 
+  />
   <Card
-    title="Osmosis-Labs Stores"
-    description="NPM package which contains observable stores via mobx data storage framework for the Osmosis front-end"
+    title="@osmosis-labs/stores"
+    description="Observable MobX stores used by the Osmosis frontend — live balances, pools, and chain state."
     to="https://www.npmjs.com/package/@osmosis-labs/stores"
-    icon={<Tscodegen />}
     svgFile="/icons/store.svg"
-  /> 
-  </Section>
+  />
 </Section>
 
-<Section title="Frontend SDK Libraries & Utilities" id="web-sdks" hasSubSections >
-
-   <Section>
-
+<Section title="Cosmos Ecosystem">
   <Card
     title="Cosmos Kit"
-    description="A wallet adapter for react with mobile WalletConnect support for the Cosmos ecosystem."
+    description="React wallet adapter with mobile WalletConnect support for every major Cosmos wallet."
     to="/frontend/cosmos-kit"
-    icon=""
     svgFile="/icons/bag.svg"
   />
   <Card
     title="Telescope"
-    description="TypeScript Transpiler for Cosmos Protobufs. Telescope is used to generate libraries for Cosmos blockchains."
+    description="TypeScript transpiler for Cosmos protobufs — generate typed clients for any Cosmos chain."
     to="/telescope"
     icon={<Telescope />}
-    svgFile=""
   />
   <Card
     title="Create Cosmos App"
-    description="Set up a modern Cosmos app by running one command"
+    description="Bootstrap a modern Cosmos frontend with a single command."
     to="https://github.com/cosmology-tech/create-cosmos-app"
-    icon={<Createapp />}
     svgFile="/icons/create-cosmos-app.svg"
   />
   <Card
     title="Chain Registry"
-    description="The npm package for the Official Cosmos chain registry"
+    description="npm package wrapping the official Cosmos chain registry — chain IDs, RPC endpoints, asset lists."
     to="https://github.com/cosmology-tech/chain-registry"
-    icon={<Cosmoskit />}
-    svgFile="/icons/registry.svg"
+    icon={<Chainregistry />}
   />
   <Card
     title="TS Codegen"
-    description="The quickest and easiest way to interact with CosmWasm Contracts"
+    description="Generate TypeScript clients from CosmWasm contract schemas."
     to="https://github.com/CosmWasm/ts-codegen"
     icon={<Tscodegen />}
-    svgFile="/icons/tscodegen.svg"
-  />   
-  
-
-
- 
-  </Section>
-
-  </Section>
-
+  />
+</Section>

--- a/docs/frontend/README.mdx
+++ b/docs/frontend/README.mdx
@@ -21,7 +21,7 @@ import {
 
 # Frontend, SDKs & Tooling
 
-Libraries for building on top of Osmosis from JavaScript, TypeScript, and the web. The **Osmosis Frontend** section covers the official `app.osmosis.zone` codebase and the npm packages it's built from; **Cosmos Ecosystem** lists the wider tooling that most Cosmos frontends — Osmosis included — rely on.
+Libraries for building on top of Osmosis from JavaScript, TypeScript, and the web. The **Osmosis Frontend** section covers the official `app.osmosis.zone` codebase and the npm packages it's built from; **Cosmos Ecosystem** lists the wider tooling that most Cosmos frontends, Osmosis included, rely on.
 
 <Section title="Osmosis Frontend">
   <Card
@@ -33,7 +33,7 @@ Libraries for building on top of Osmosis from JavaScript, TypeScript, and the we
   />
   <Card
     title="OsmoJS"
-    description="Compose and broadcast Osmosis and Cosmos messages — proto and amino encoding handled for you."
+    description="Compose and broadcast Osmosis and Cosmos messages, proto and amino encoding handled for you."
     to="/osmojs"
     icon={<Osmojs />}
   />
@@ -51,7 +51,7 @@ Libraries for building on top of Osmosis from JavaScript, TypeScript, and the we
   />
   <Card
     title="@osmosis-labs/stores"
-    description="Observable MobX stores used by the Osmosis frontend — live balances, pools, and chain state."
+    description="Observable MobX stores used by the Osmosis frontend, live balances, pools, and chain state."
     to="https://www.npmjs.com/package/@osmosis-labs/stores"
     svgFile="/icons/store.svg"
   />
@@ -66,7 +66,7 @@ Libraries for building on top of Osmosis from JavaScript, TypeScript, and the we
   />
   <Card
     title="Telescope"
-    description="TypeScript transpiler for Cosmos protobufs — generate typed clients for any Cosmos chain."
+    description="TypeScript transpiler for Cosmos protobufs, generate typed clients for any Cosmos chain."
     to="/telescope"
     icon={<Telescope />}
   />
@@ -78,7 +78,7 @@ Libraries for building on top of Osmosis from JavaScript, TypeScript, and the we
   />
   <Card
     title="Chain Registry"
-    description="npm package wrapping the official Cosmos chain registry — chain IDs, RPC endpoints, asset lists."
+    description="npm package wrapping the official Cosmos chain registry, chain IDs, RPC endpoints, asset lists."
     to="https://github.com/cosmology-tech/chain-registry"
     icon={<Chainregistry />}
   />

--- a/docs/osmosis-core/README.mdx
+++ b/docs/osmosis-core/README.mdx
@@ -23,7 +23,7 @@ import {
 
 # Introduction
 
-The guides on this page will explain the process of developing on Osmosis.
+These guides cover everything you need to develop on the Osmosis chain itself — from compiling the source and setting up your IDE, through running a node, to writing modules and contributing back upstream. If you've never built the chain before, start with **Build and Test Osmosis Source Code**.
 
 
  ## Get Started

--- a/docs/osmosis-core/README.mdx
+++ b/docs/osmosis-core/README.mdx
@@ -23,7 +23,7 @@ import {
 
 # Introduction
 
-These guides cover everything you need to develop on the Osmosis chain itself — from compiling the source and setting up your IDE, through running a node, to writing modules and contributing back upstream. If you've never built the chain before, start with **Build and Test Osmosis Source Code**.
+These guides cover everything you need to develop on the Osmosis chain itself, from compiling the source and setting up your IDE, through running a node, to writing modules and contributing back upstream. If you've never built the chain before, start with **Build and Test Osmosis Source Code**.
 
 
  ## Get Started

--- a/docs/osmosis-outpost/README.md
+++ b/docs/osmosis-outpost/README.md
@@ -2,40 +2,25 @@
 sidebar_position: 1
 sidebar_label: What is an Osmosis outpost
 ---
+
 # What is an Osmosis Outpost
 
-An Osmosis outpost is a platform that makes it *much simpler* to perform swaps
-on different *Cosmos chains*, without having to manually send the tokens to 
-Osmosis to trade them, or worse, to build their own DEx.
+An Osmosis outpost is a platform that lets users on **other Cosmos chains** swap through the Osmosis DEX without first bridging their tokens over and back. The outpost handles the IBC routing, the smart-contract calls, and the return delivery — the user sees a single, native-feeling swap on their home chain.
 
-The outpost performs the swaps through the **Osmosis DEX** and can send the
-swapped token to the outpost chain. Such a platform uses **IBC protocol** and
-**smart contracts** to allow users on the outpost chain to *perform the swaps*.
+Each outpost UI is meant to be **simple, intuitive, and customizable** for its host chain. The [**nabla** framework](/osmosis-outpost/user-interface-setup/introduction) ships a set of components and templates so any enabled chain can spin up its own outpost frontend without rebuilding the plumbing.
 
-It is important for the UI of such a platform to be *simple, intuitive, and* 
-*highly customizable* for each outpost chain and, for this reason, **nabla** 
-provides a set of **components** and **templates** to allow any enabled chain 
-to realize its own *frontend outpost*.
+:::tip Building your own outpost?
+Start with the [Introduction page](/osmosis-outpost/user-interface-setup/introduction) — it walks through the templates, configuration, and deployment.
+:::
 
-If you want to create your own outpost platform, please follow the instruction
-available at the [Introduction page](/osmosis-outpost/user-interface-setup/introduction).
+## 📡 Stay tuned
 
-### 📡 Stay tuned 
+If you've integrated the platform, let us know so we can share the news with the wider community. To follow new features and changes, [find us on our channels](/osmosis-outpost/contact).
 
-If you have integrated the platform, please let us know so we can share the news
-with our community! Moreover, to stay updated with any changes or new features,
-please follow us. You can find how to reach us [here](/osmosis-outpost/contact).
+## 📖 User guide
 
-### 📖 User guide 
-We realized a set of **tutorial** to follow your users step by step on *how to*
-*perform a swap* and *how to troubleshoot some common issues*. You can find it 
-[here](/osmosis-outpost/user-guide/how-to-do-a-swap).
+A step-by-step walkthrough — including common troubleshooting — for users performing their first outpost swap is available in the [User Guide](/osmosis-outpost/user-guide/how-to-do-a-swap).
 
-### 📞 Support 
-Once you have integrated the widget, or created your new platform application, 
-we recommend you create a support channel in your own community for users to 
-troubleshoot issues that users may encounter while using the widget or the app.
+## 📞 Support
 
-If you, or your users, discover any **issues or errors** while using the 
-platform, please *reach us* through the channels available 
-[here](/osmosis-outpost/contact).
+Once you've shipped your outpost, we recommend opening a community support channel so users have somewhere to report issues. If you or your users hit problems with the widget or the underlying chain, [reach out through our channels](/osmosis-outpost/contact).

--- a/docs/overview/educate/getting-started.md
+++ b/docs/overview/educate/getting-started.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: Install a wallet, open the Osmosis app, and execute your first swap or liquidity position.
 ---
 # Getting Started
 ## Set up a Wallet

--- a/docs/overview/educate/osmo.mdx
+++ b/docs/overview/educate/osmo.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: How OSMO is used — governance voting, staking, and capturing protocol-level revenue.
 ---
 # The OSMO Token
 

--- a/docs/overview/educate/osmo.mdx
+++ b/docs/overview/educate/osmo.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-description: How OSMO is used — governance voting, staking, and capturing protocol-level revenue.
+description: How OSMO is used, governance voting, staking, and capturing protocol-level revenue.
 ---
 # The OSMO Token
 

--- a/docs/overview/educate/osmosis.md
+++ b/docs/overview/educate/osmosis.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: Osmosis is the premier cross-chain DEX and DeFi hub for the Cosmos ecosystem and beyond.
 ---
 # What is Osmosis?
 

--- a/docs/overview/educate/terminology.md
+++ b/docs/overview/educate/terminology.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+description: Definitions for the terms used across Osmosis and the wider Cosmos ecosystem.
 ---
 
 # Glossary 

--- a/docs/overview/endpoints/index.mdx
+++ b/docs/overview/endpoints/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: Overview
 sidebar_position: 1
+description: Public RPC, LCD, and gRPC endpoints for mainnet and testnet, plus block explorers and infrastructure providers.
 ---
-import DocCardList from '@theme/DocCardList';
 
 # Endpoints
 
-This section serves the purpose of different endpoints for different projects on top of Osmosis.
+Public endpoints for connecting to Osmosis — mainnet and testnet RPC/LCD/gRPC, indexed historical data, block explorers, and third-party infrastructure providers.
 
 ## Table of Contents
 [Endpoints](#endpoints)

--- a/docs/overview/endpoints/index.mdx
+++ b/docs/overview/endpoints/index.mdx
@@ -6,7 +6,7 @@ description: Public RPC, LCD, and gRPC endpoints for mainnet and testnet, plus b
 
 # Endpoints
 
-Public endpoints for connecting to Osmosis — mainnet and testnet RPC/LCD/gRPC, indexed historical data, block explorers, and third-party infrastructure providers.
+Public endpoints for connecting to Osmosis, mainnet and testnet RPC/LCD/gRPC, indexed historical data, block explorers, and third-party infrastructure providers.
 
 ## Table of Contents
 [Endpoints](#endpoints)

--- a/docs/overview/features/concentrated-liquidity.md
+++ b/docs/overview/features/concentrated-liquidity.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: Capital-efficient AMM design where LPs concentrate liquidity into specific price ranges.
 ---
 
 # Concentrated Liquidity

--- a/docs/overview/features/eip-1559.md
+++ b/docs/overview/features/eip-1559.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: Osmosis' dynamic base-fee mechanism — how transaction fees adjust to network congestion to deter spam.
 ---
 
 # EIP-1559

--- a/docs/overview/features/eip-1559.md
+++ b/docs/overview/features/eip-1559.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-description: Osmosis' dynamic base-fee mechanism — how transaction fees adjust to network congestion to deter spam.
+description: Osmosis' dynamic base-fee mechanism, how transaction fees adjust to network congestion to deter spam.
 ---
 
 # EIP-1559

--- a/docs/overview/features/fee-abstraction.md
+++ b/docs/overview/features/fee-abstraction.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+description: Pay transaction fees in any whitelisted IBC asset, not just OSMO.
 ---
 
 # Fee Abstraction

--- a/docs/overview/features/ibc-hooks.md
+++ b/docs/overview/features/ibc-hooks.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+description: Middleware that lets ICS-20 token transfers trigger CosmWasm contract calls — cross-chain calls with value attached.
 ---
 
 # IBC Hooks

--- a/docs/overview/features/ibc-hooks.md
+++ b/docs/overview/features/ibc-hooks.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-description: Middleware that lets ICS-20 token transfers trigger CosmWasm contract calls — cross-chain calls with value attached.
+description: Middleware that lets ICS-20 token transfers trigger CosmWasm contract calls, cross-chain calls with value attached.
 ---
 
 # IBC Hooks

--- a/docs/overview/features/ibc-rate-limit.md
+++ b/docs/overview/features/ibc-rate-limit.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+description: A governance-configurable safety control that caps IBC outflows in a rolling window to contain hacks and bugs.
 ---
 
 # IBC Rate Limit

--- a/docs/overview/features/index.mdx
+++ b/docs/overview/features/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: Overview
 sidebar_position: 1
+description: The distinctive on-chain features Osmosis ships — concentrated liquidity, fee abstraction, ProtoRev, and more.
 ---
 import DocCardList from '@theme/DocCardList';
 
 # Features
 
-
-This page serves as an informative gateway to explore the innovative and distinctive features that Osmosis brings to the decentralized finance (DeFi) landscape. Leveraging its pioneering App Chain architecture, Osmosis offers a unique DeFi experience that sets it apart from traditional platforms. 
+Osmosis is an appchain — every feature on this page is part of the protocol itself, not a contract layered on top. The pages below cover the mechanics of each: how it works, why it exists, and how to interact with it.
 
 ## Table of Contents
   - [Concentrated Liquidity](/overview/features/concentrated-liquidity)

--- a/docs/overview/features/index.mdx
+++ b/docs/overview/features/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: Overview
 sidebar_position: 1
-description: The distinctive on-chain features Osmosis ships — concentrated liquidity, fee abstraction, ProtoRev, and more.
+description: The distinctive onchain features Osmosis ships: concentrated liquidity, fee abstraction, ProtoRev, and more.
 ---
 import DocCardList from '@theme/DocCardList';
 
 # Features
 
-Osmosis is an appchain — every feature on this page is part of the protocol itself, not a contract layered on top. The pages below cover the mechanics of each: how it works, why it exists, and how to interact with it.
+Osmosis is an appchain, every feature on this page is part of the protocol itself, not a contract layered on top. The pages below cover the mechanics of each: how it works, why it exists, and how to interact with it.
 
 ## Table of Contents
   - [Concentrated Liquidity](/overview/features/concentrated-liquidity)

--- a/docs/overview/features/index.mdx
+++ b/docs/overview/features/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 sidebar_position: 1
-description: The distinctive onchain features Osmosis ships: concentrated liquidity, fee abstraction, ProtoRev, and more.
+description: "The distinctive onchain features Osmosis ships: concentrated liquidity, fee abstraction, ProtoRev, and more."
 ---
 import DocCardList from '@theme/DocCardList';
 

--- a/docs/overview/features/protorev.md
+++ b/docs/overview/features/protorev.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+description: Protocol-owned arbitrage that captures cyclic-trade MEV on Osmosis and returns it to OSMO stakers.
 ---
 
 # Protorev

--- a/docs/overview/features/protorev.md
+++ b/docs/overview/features/protorev.md
@@ -142,7 +142,7 @@ message Trade {
 
 ### DenomPairToPool
 
-DenomPairToPool takes in a base denomination (read below) – denom that is used to build routes (ex. osmo, atom, usdc) – and a denom to match (akash, juno) and returns the highest liquidity pool id between the pair of denominations. For example, an input might look like (osmo, juno) —> poolID: 5. This store is directly tied to the highest liquidity method (described in state transitions below). Each base denomination is going to have its own set of denominations it maps to.
+DenomPairToPool takes in a base denomination (read below) – denom that is used to build routes (ex. osmo, atom, usdc) – and a denom to match (akash, juno) and returns the highest liquidity pool id between the pair of denominations. For example, an input might look like (osmo, juno) , > poolID: 5. This store is directly tied to the highest liquidity method (described in state transitions below). Each base denomination is going to have its own set of denominations it maps to.
 
 ### BaseDenoms
 
@@ -220,7 +220,7 @@ type PoolWeights struct {
 
 ### GenesisState
 
-There is only one configurable parameter for the genesis state —> whether protorev is enabled or not.
+There is only one configurable parameter for the genesis state , > whether protorev is enabled or not.
 
 ```go
 // GenesisState defines the protorev module's genesis state.
@@ -251,13 +251,13 @@ BaseDenoms
 - Osmosis
 - Atom
 
-Lets say the `postHandler` receives a transaction that contains a swap of **Juno** —> **Akash** on pool **4**. In this case, the module will attempt to create three-pool route where a base denomination is on either side of the route. For example, a route that it might create is
+Lets say the `postHandler` receives a transaction that contains a swap of **Juno** , > **Akash** on pool **4**. In this case, the module will attempt to create three-pool route where a base denomination is on either side of the route. For example, a route that it might create is
 
-- Osmosis —> Akash (on pool 1), Akash —> Juno (on pool 4), Juno —> Osmosis (on pool 2)
+- Osmosis , > Akash (on pool 1), Akash , > Juno (on pool 4), Juno , > Osmosis (on pool 2)
 
-It does so by finding the highest liquidity pool between (Osmosis, Akash) —> pool 1 and the highest liquidity pool between (Osmosis, Juno) —> pool 2. If there is no highest liquidity pool pair between (Osmosis, Juno) or (Osmosis, Akash), no route will be generated.
+It does so by finding the highest liquidity pool between (Osmosis, Akash) , > pool 1 and the highest liquidity pool between (Osmosis, Juno) , > pool 2. If there is no highest liquidity pool pair between (Osmosis, Juno) or (Osmosis, Akash), no route will be generated.
 
-**NOTE: Cyclic arbitrage routes will always go in the opposite direction of the original swap i.e. in this case we see Juno —> Akash so we know that the route must include a swap of Akash —> Juno.**
+**NOTE: Cyclic arbitrage routes will always go in the opposite direction of the original swap i.e. in this case we see Juno , > Akash so we know that the route must include a swap of Akash , > Juno.**
 
 The same line of reasoning exists for Atom. `x/protorev` will attempt to find the highest liquidity pool between (Atom, Akash) and (Atom, Juno). If these pools exist, they will be added to the list of routes that can be simulated later in the pipeline. If not, the route is discarded.
 

--- a/docs/overview/features/tokenfactory.md
+++ b/docs/overview/features/tokenfactory.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+description: Permissionless token creation — any account can mint a token namespaced under its address.
 ---
 
 # Token Factory

--- a/docs/overview/features/tokenfactory.md
+++ b/docs/overview/features/tokenfactory.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 7
-description: Permissionless token creation — any account can mint a token namespaced under its address.
+description: Permissionless token creation, any account can mint a token namespaced under its address.
 ---
 
 # Token Factory

--- a/docs/overview/integrate/airdrops.md
+++ b/docs/overview/integrate/airdrops.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: Snapshot Osmosis accounts at a given height — optionally filtered by LP position — for airdrop distribution.
 ---
 
 # Airdrop Distribution

--- a/docs/overview/integrate/airdrops.md
+++ b/docs/overview/integrate/airdrops.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-description: Snapshot Osmosis accounts at a given height — optionally filtered by LP position — for airdrop distribution.
+description: Snapshot Osmosis accounts at a given height, optionally filtered by LP position, for airdrop distribution.
 ---
 
 # Airdrop Distribution

--- a/docs/overview/integrate/apr.md
+++ b/docs/overview/integrate/apr.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 11
+description: How LP APRs are computed — separately for concentrated-liquidity pools and classic AMM pools.
 ---
 
 # APR Calculation

--- a/docs/overview/integrate/apr.md
+++ b/docs/overview/integrate/apr.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 11
-description: How LP APRs are computed — separately for concentrated-liquidity pools and classic AMM pools.
+description: How LP APRs are computed, separately for concentrated-liquidity pools and classic AMM pools.
 ---
 
 # APR Calculation

--- a/docs/overview/integrate/cli.md
+++ b/docs/overview/integrate/cli.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+description: Query chain state and broadcast transactions from your terminal using osmosisd.
 ---
 
 # Interact with CLI

--- a/docs/overview/integrate/earn-risk.md
+++ b/docs/overview/integrate/earn-risk.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 16
+description: How the risk level shown for each Earn strategy on app.osmosis.zone is determined.
 ---
 
 # Determination of Risk Level for Earn Strategies

--- a/docs/overview/integrate/external_projects/README.md
+++ b/docs/overview/integrate/external_projects/README.md
@@ -1,3 +1,7 @@
+---
+description: Integrations between Osmosis and external services — oracles, indexers, and analytics platforms.
+---
+
 # External Projects
 
 Osmosis supports integration with a diverse range of external projects. 

--- a/docs/overview/integrate/external_projects/README.md
+++ b/docs/overview/integrate/external_projects/README.md
@@ -1,5 +1,5 @@
 ---
-description: Integrations between Osmosis and external services — oracles, indexers, and analytics platforms.
+description: Integrations between Osmosis and external services, oracles, indexers, and analytics platforms.
 ---
 
 # External Projects

--- a/docs/overview/integrate/external_projects/pyth.md
+++ b/docs/overview/integrate/external_projects/pyth.md
@@ -1,3 +1,7 @@
+---
+description: Use Pyth Network price feeds inside CosmWasm contracts on Osmosis.
+---
+
 # Pyth
 
 ## Introduction

--- a/docs/overview/integrate/external_projects/subquery.md
+++ b/docs/overview/integrate/external_projects/subquery.md
@@ -1,3 +1,7 @@
+---
+description: Index Osmosis chain data — including cross-chain IBC flows — using the SubQuery SDK.
+---
+
 # SubQuery
 
 ## Intro

--- a/docs/overview/integrate/external_projects/subquery.md
+++ b/docs/overview/integrate/external_projects/subquery.md
@@ -1,5 +1,5 @@
 ---
-description: Index Osmosis chain data — including cross-chain IBC flows — using the SubQuery SDK.
+description: Index Osmosis chain data, including cross-chain IBC flows, using the SubQuery SDK.
 ---
 
 # SubQuery

--- a/docs/overview/integrate/frontend.md
+++ b/docs/overview/integrate/frontend.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+description: Once an asset is registered and a pool has $1,000+ in liquidity it appears on app.osmosis.zone automatically.
 ---
 
 # Ensure Visibility

--- a/docs/overview/integrate/grpc.md
+++ b/docs/overview/integrate/grpc.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 10
+description: Connect to Osmosis nodes via gRPC for typed, efficient queries and message broadcasts.
 ---
 
 # Interact with gRPC Server

--- a/docs/overview/integrate/incentives.md
+++ b/docs/overview/integrate/incentives.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+description: Add external rewards to a pool by creating a permissionless liquidity-mining gauge.
 ---
 # Liquidity Incentives
 

--- a/docs/overview/integrate/index.mdx
+++ b/docs/overview/integrate/index.mdx
@@ -1,12 +1,13 @@
 ---
 title: Introduction
 sidebar_position: 1
+description: List a new asset, source liquidity, set up pools, and talk to Osmosis from your application.
 ---
 import DocCardList from '@theme/DocCardList';
 
 # Integrate
 
-The guides on this page will explain the process of integrating with Osmosis.
+Bring a new asset onto Osmosis or build an application against it. The pages below cover the full integration path — registering an asset, sourcing initial liquidity, configuring pools — and the developer-facing interfaces (CLI, gRPC, REST, RPC) you'll use to query state and broadcast transactions.
 
 <DocCardList />
 

--- a/docs/overview/integrate/index.mdx
+++ b/docs/overview/integrate/index.mdx
@@ -7,7 +7,7 @@ import DocCardList from '@theme/DocCardList';
 
 # Integrate
 
-Bring a new asset onto Osmosis or build an application against it. The pages below cover the full integration path — registering an asset, sourcing initial liquidity, configuring pools — and the developer-facing interfaces (CLI, gRPC, REST, RPC) you'll use to query state and broadcast transactions.
+Bring a new asset onto Osmosis or build an application against it. The pages below cover the full integration path, registering an asset, sourcing initial liquidity, configuring pools, and the developer-facing interfaces (CLI, gRPC, REST, RPC) you'll use to query state and broadcast transactions.
 
 <DocCardList />
 

--- a/docs/overview/integrate/liquidity.md
+++ b/docs/overview/integrate/liquidity.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+description: Several routes for sourcing the $1,000+ minimum liquidity Osmosis Zone requires to list a new asset.
 ---
 
 # Source Initial Liquidity

--- a/docs/overview/integrate/on-chain.md
+++ b/docs/overview/integrate/on-chain.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: Integrate against the concentrated-liquidity module — pool creation, position management, and queries.
 ---
 
 # Concentrated Liquidity Integration

--- a/docs/overview/integrate/on-chain.md
+++ b/docs/overview/integrate/on-chain.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-description: Integrate against the concentrated-liquidity module — pool creation, position management, and queries.
+description: Integrate against the concentrated-liquidity module, pool creation, position management, and queries.
 ---
 
 # Concentrated Liquidity Integration

--- a/docs/overview/integrate/pool-setup.mdx
+++ b/docs/overview/integrate/pool-setup.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+description: Step-by-step walkthrough for creating a new pool — picking type, setting weights, and seeding liquidity.
 ---
 
 # Pool Setup Guide

--- a/docs/overview/integrate/pool-setup.mdx
+++ b/docs/overview/integrate/pool-setup.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-description: Step-by-step walkthrough for creating a new pool — picking type, setting weights, and seeding liquidity.
+description: Step-by-step walkthrough for creating a new pool, picking type, setting weights, and seeding liquidity.
 ---
 
 # Pool Setup Guide

--- a/docs/overview/integrate/registration.md
+++ b/docs/overview/integrate/registration.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+description: Register a new asset in every required location so it displays correctly across Osmosis interfaces.
 ---
 # Register your Asset
 This guide intends to support teams looking to enlist their tokenized crypto asset onto the Osmosis Zone app. Assets need to be registered in several locations in order to be displayed correctly on all interfaces.

--- a/docs/overview/integrate/registration.md
+++ b/docs/overview/integrate/registration.md
@@ -102,12 +102,12 @@ You only need to open a PR against `osmosis-labs/assetlists` if you want to conf
 
 #### Where the changes go
 
-- `osmosis-1/osmosis.zone_assets.json` — the asset entry.
-- `osmosis-1/osmosis.zone_chains.json` — only when you need to provide custom chain services (RPC/REST/explorer); otherwise leave it alone.
+- `osmosis-1/osmosis.zone_assets.json`, the asset entry.
+- `osmosis-1/osmosis.zone_chains.json`, only when you need to provide custom chain services (RPC/REST/explorer); otherwise leave it alone.
 
 #### Field reference
 
-See [assetlists README — Asset Object Structure](https://github.com/osmosis-labs/assetlists/blob/main/README.md) for a full field-by-field reference, defaults, and decision guidance.
+See [assetlists README, Asset Object Structure](https://github.com/osmosis-labs/assetlists/blob/main/README.md) for a full field-by-field reference, defaults, and decision guidance.
 
 The minimum required shape for an asset object is:
 
@@ -123,7 +123,7 @@ All other fields are optional and default to safe values (e.g., `osmosis_verifie
 
 #### Submitting the PR
 
-- New Pull Requests will automatically initialize with a description template that includes a checklist — complete it as thoroughly as possible.
+- New Pull Requests will automatically initialize with a description template that includes a checklist, complete it as thoroughly as possible.
 - Validation checks run automatically on the PR; address any failures before requesting review.
 - Maintainers will review and merge once validation passes and the configuration is sound.
 

--- a/docs/overview/integrate/rest.md
+++ b/docs/overview/integrate/rest.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 11
+description: REST/LCD endpoints exposed via gRPC-gateway for simpler HTTP-based queries.
 ---
 
 # Interact with REST

--- a/docs/overview/integrate/rpc.md
+++ b/docs/overview/integrate/rpc.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 12
+description: Generic Tendermint RPC endpoints for low-level chain access — ABCI queries, mempool, and block data.
 ---
 
 # Interact with RPC endpoints

--- a/docs/overview/integrate/rpc.md
+++ b/docs/overview/integrate/rpc.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 12
-description: Generic Tendermint RPC endpoints for low-level chain access — ABCI queries, mempool, and block data.
+description: Generic Tendermint RPC endpoints for low-level chain access, ABCI queries, mempool, and block data.
 ---
 
 # Interact with RPC endpoints

--- a/docs/overview/integrate/transfer.md
+++ b/docs/overview/integrate/transfer.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: Bring your IBC-enabled chain's token to Osmosis — the prerequisites for permissionless trading.
 ---
 
 # Connect with Osmosis

--- a/docs/overview/integrate/transfer.md
+++ b/docs/overview/integrate/transfer.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-description: Bring your IBC-enabled chain's token to Osmosis — the prerequisites for permissionless trading.
+description: Bring your IBC-enabled chain's token to Osmosis, the prerequisites for permissionless trading.
 ---
 
 # Connect with Osmosis

--- a/docs/overview/validate/index.mdx
+++ b/docs/overview/validate/index.mdx
@@ -1,11 +1,12 @@
 ---
 title: Overview
 sidebar_position: 3.5
+description: Run an Osmosis full node or validator — mainnet and testnet setup, key management, and registration.
 ---
 import DocCardList from '@theme/DocCardList';
 
 # Validating the Osmosis Blockchain
 
-Welcome to the validator documentation for Osmosis. Validators are nodes that participate in the security of a network and are responsible for committing new blocks in the blockchain. To learn more, select one of the options below.
+Validators secure the Osmosis network — they sign blocks, vote on governance, and stand behind their stake. The guides below cover running a full node, becoming a validator, and the differences between the mainnet and testnet paths.
 
 <DocCardList />

--- a/docs/overview/validate/index.mdx
+++ b/docs/overview/validate/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: Overview
 sidebar_position: 3.5
-description: Run an Osmosis full node or validator — mainnet and testnet setup, key management, and registration.
+description: Run an Osmosis full node or validator, mainnet and testnet setup, key management, and registration.
 ---
 import DocCardList from '@theme/DocCardList';
 
 # Validating the Osmosis Blockchain
 
-Validators secure the Osmosis network — they sign blocks, vote on governance, and stand behind their stake. The guides below cover running a full node, becoming a validator, and the differences between the mainnet and testnet paths.
+Validators secure the Osmosis network, they sign blocks, vote on governance, and stand behind their stake. The guides below cover running a full node, becoming a validator, and the differences between the mainnet and testnet paths.
 
 <DocCardList />

--- a/docs/overview/validate/joining-mainnet.md
+++ b/docs/overview/validate/joining-mainnet.md
@@ -1,4 +1,6 @@
-
+---
+description: Set up an Osmosis mainnet full node using the official installer or from source.
+---
 
 # Running a Node on Mainnet
 

--- a/docs/overview/validate/joining-testnet.md
+++ b/docs/overview/validate/joining-testnet.md
@@ -1,3 +1,7 @@
+---
+description: Set up an Osmosis testnet full node to test changes against the public testnet.
+---
+
 # Running a Node on Testnet
 
 ## Osmosis Installer

--- a/docs/overview/validate/validating-mainnet.md
+++ b/docs/overview/validate/validating-mainnet.md
@@ -1,3 +1,7 @@
+---
+description: Turn a synced mainnet node into a validator — keyring setup, self-delegation, and registration.
+---
+
 # Validating On Mainnet
 
 ## Synced Node

--- a/docs/overview/validate/validating-mainnet.md
+++ b/docs/overview/validate/validating-mainnet.md
@@ -1,5 +1,5 @@
 ---
-description: Turn a synced mainnet node into a validator — keyring setup, self-delegation, and registration.
+description: Turn a synced mainnet node into a validator, keyring setup, self-delegation, and registration.
 ---
 
 # Validating On Mainnet

--- a/docs/overview/validate/validating-testnet.md
+++ b/docs/overview/validate/validating-testnet.md
@@ -1,3 +1,7 @@
+---
+description: Turn a synced testnet node into a validator — keyring setup, self-delegation, and registration.
+---
+
 # Validating On Testnet
 
 ## Synced Node

--- a/docs/overview/validate/validating-testnet.md
+++ b/docs/overview/validate/validating-testnet.md
@@ -1,5 +1,5 @@
 ---
-description: Turn a synced testnet node into a validator — keyring setup, self-delegation, and registration.
+description: Turn a synced testnet node into a validator, keyring setup, self-delegation, and registration.
 ---
 
 # Validating On Testnet

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -140,7 +140,7 @@ const config = {
           {
             label: 'Develop',
             to: 'osmosis-core',
-            position: 'right',
+            position: 'left',
             // className: 'new-badge',
             activeBaseRegex: '(.*ui-kit|.*web-core)',
           },
@@ -170,21 +170,9 @@ const config = {
             position: 'right',
           },
           {
-            href: 'https://discord.com/invite/osmosis',
-            className: 'pseudo-icon discord-icon',
-            position: 'right',
-          },
-          {
             type: 'search',
             position: 'right',
           },
-          {
-            label: 'Launch Dex',
-            href: 'https://app.osmosis.zone',
-            position: 'right',
-            className: 'dev-portal-signup dev-portal-link',
-          },
-
         ],
       },
       footer: {
@@ -271,8 +259,21 @@ const config = {
         apiKey: '00',
       },
     }),
-  scripts: [
-    "https://tally.so/widgets/embed.js",
+  scripts: ['https://tally.so/widgets/embed.js'],
+  stylesheets: [
+    {
+      href: 'https://fonts.googleapis.com',
+      rel: 'preconnect',
+    },
+    {
+      href: 'https://fonts.gstatic.com',
+      rel: 'preconnect',
+      crossorigin: 'anonymous',
+    },
+    {
+      href: 'https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&display=swap',
+      rel: 'stylesheet',
+    },
   ],
 };
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -140,7 +140,7 @@ const config = {
           {
             label: 'Develop',
             to: 'osmosis-core',
-            position: 'right',
+            position: 'left',
             // className: 'new-badge',
             activeBaseRegex: '(.*ui-kit|.*web-core)',
           },
@@ -170,21 +170,9 @@ const config = {
             position: 'right',
           },
           {
-            href: 'https://discord.com/invite/osmosis',
-            className: 'pseudo-icon discord-icon',
-            position: 'right',
-          },
-          {
             type: 'search',
             position: 'right',
           },
-          {
-            label: 'Launch Dex',
-            href: 'https://app.osmosis.zone',
-            position: 'right',
-            className: 'dev-portal-signup dev-portal-link',
-          },
-
         ],
       },
       footer: {
@@ -271,6 +259,21 @@ const config = {
         apiKey: '00',
       },
     }),
+  stylesheets: [
+    {
+      href: 'https://fonts.googleapis.com',
+      rel: 'preconnect',
+    },
+    {
+      href: 'https://fonts.gstatic.com',
+      rel: 'preconnect',
+      crossorigin: 'anonymous',
+    },
+    {
+      href: 'https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&display=swap',
+      rel: 'stylesheet',
+    },
+  ],
 };
 
 module.exports = config;

--- a/src/components/HomepageComponents.jsx
+++ b/src/components/HomepageComponents.jsx
@@ -27,13 +27,24 @@ export function HomepageSection({
   );
 }
 
-export function HomepageCard({ id, icon, svgFile, title, description, to }) {
+export function HomepageCard({
+  id,
+  icon,
+  svgFile,
+  title,
+  description,
+  to,
+  featured = false,
+}) {
+  const hasIcon = Boolean(svgFile) || Boolean(icon);
+
   return (
-    <Link to={to} className="homepage-card">
-      {svgFile
-        ?  <div className="icon"><img src={svgFile}/></div>
-        :  icon && <div className="icon">{icon}</div>
-      }
+    <Link to={to} className={clsx('homepage-card', featured && 'featured')}>
+      {hasIcon && (
+        <div className="icon-frame">
+          {svgFile ? <img src={svgFile} alt="" /> : icon}
+        </div>
+      )}
       <div className="card-content">
         <div className="title" id={id && paramCase(title)}>
           {title}

--- a/src/components/SidebarMenu/styles.module.css
+++ b/src/components/SidebarMenu/styles.module.css
@@ -1,11 +1,11 @@
 :root {
-  --docs-sections-menu-background-color: #efefef;
-  --docs-sections-menu-active-background-color: #2549aa;
+  --docs-sections-menu-background-color: var(--docs-color-background-200);
+  --docs-sections-menu-active-background-color: var(--docs-color-primary);
   --docs-sections-menu-active-color: #fff;
 }
 
 html[data-theme='dark'] {
-  --docs-sections-menu-background-color: #3f3f3f;
+  --docs-sections-menu-background-color: var(--docs-color-background-200);
 }
 
 .container {
@@ -40,11 +40,11 @@ html[data-theme='dark'] {
 }
 
 .section:first-child {
-  border-radius: 8px 8px 0 0;
+  border-radius: 12px 12px 0 0;
 }
 
 .section:last-child {
-  border-radius: 0 0 8px 8px;
+  border-radius: 0 0 12px 12px;
 }
 
 .label {

--- a/src/css/api-reference.css
+++ b/src/css/api-reference.css
@@ -14,7 +14,7 @@
 .elements-container {
   --ifm-link-color: currentColor;
   --ifm-link-decoration: none;
-  
+
   flex-grow: 1;
   height: 100%;
 }
@@ -25,16 +25,16 @@
 
 .ElementsTableOfContentsItem div {
   border-right: 2px solid transparent !important;
-  border-radius: 4px 0 0 4px;
+  border-radius: 6px 0 0 6px;
 }
 
 .ElementsTableOfContentsItem .sl-bg-primary-tint {
-  border-color: var(--docs-color-primary-100) !important;
+  border-color: var(--docs-color-primary) !important;
 }
 
 html[data-theme='dark'] .elements-container {
   --color-canvas-200: var(--docs-color-background-200) !important;
-  --ifm-pre-background: #1e1e1e;
+  --ifm-pre-background: var(--docs-color-code-background);
 }
 
 html[data-theme='dark'] .TryItPanel {
@@ -42,11 +42,15 @@ html[data-theme='dark'] .TryItPanel {
   --color-canvas-200: var(--docs-color-background-200) !important;
 }
 
-html[data-theme='dark'] .elements-container :is(.token.string, .token.function, .token.property) {
-  color: var(--docs-color-primary-100) !important;
+html[data-theme='dark']
+  .elements-container
+  :is(.token.string, .token.function, .token.property) {
+  color: var(--docs-color-primary) !important;
 }
 
-html[data-theme='dark'] .elements-container :is(.token.punctuation, .token.operator) {
+html[data-theme='dark']
+  .elements-container
+  :is(.token.punctuation, .token.operator) {
   color: #fff !important;
 }
 
@@ -57,7 +61,7 @@ html[data-theme='dark'] .elements-container :is(.token.boolean, .token.number) {
 .JsonSchemaViewer > div:first-child {
   --color-canvas-pure: var(--docs-color-background-200);
   z-index: 0;
-  border-radius: 4px;
+  border-radius: 8px;
   padding: 0 12px !important;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,50 +36,32 @@ body {
   --dyte-colors-video-bg: 50 50 50;
 }
 
-/* Dyte Docs Tokens */
+/* Design tokens — light mode
+   Names kept from the legacy Dyte template; values remapped to the
+   Osmosis frontend palette (osmosis-frontend/packages/web/tailwind.config.js). */
 :root {
-  --docs-color-primary: #322DC2;
-  --docs-color-secondary: #db5224;
-  --docs-color-primary-100: #4540D8;
-  --docs-color-primary-tint: rgba(33, 96, 253, 0.16);
-  --docs-color-primary-tint-light: rgba(33 96 253/0.24);
+  --docs-color-primary: #462adf; /* wosmongton-700 */
+  --docs-color-primary-100: #361fb2; /* wosmongton-800 */
+  --docs-color-secondary: #29d0b2; /* bullish-500 */
+  --docs-color-primary-tint: rgba(70, 42, 223, 0.12);
+  --docs-color-primary-tint-light: rgba(70, 42, 223, 0.2);
 
-  --docs-color-border: #dadde1;
+  --docs-color-border: #e4e1fb; /* osmoverse-100 */
 
-  --docs-color-text: #000000;
-  --docs-color-text-100: #646464;
+  --docs-color-text: #140f34; /* osmoverse-900 — purple-tinted near-black */
+  --docs-color-text-100: #565081; /* osmoverse-600 */
 
   --docs-color-background: #ffffff;
-  --docs-color-background-100: #f8f8f8;
-  --docs-color-background-200: #efefef;
-  --docs-color-background-300: #dcdcdc;
+  --docs-color-background-100: #f8f8fa;
+  --docs-color-background-200: #e4e1fb; /* osmoverse-100 */
+  --docs-color-background-300: #cec8f3; /* osmoverse-200 */
 
-  /* Color from prism themes */
-  --docs-color-code-background: #f6f8fa;
+  --docs-color-code-background: #f6f5ff;
 
   --docs-color-android: #44db85;
   --docs-color-apple: var(--docs-color-text) !important;
-}
 
-[data-theme='dark'] {
-  --docs-color-border: #2e2e2e;
-
-  --docs-color-text: #ffffff;
-  --docs-color-text-100: #b4b4b4;
-
-  --docs-color-background: #161616;
-  --docs-color-background-100: #1c1c1c;
-  --docs-color-background-200: #2a2a2a;
-  --docs-color-background-300: #2e2e2e;
-
-  --docs-color-code-background: #1e1e1e;
-}
-
-/* Docusaurus Theming */
-
-:root {
-  /* Default values */
-
+  /* Docusaurus IFM core */
   --ifm-spacing-horizontal: 1.5rem;
 
   --ifm-font-family-base: 'Inter var', system-ui, -apple-system, Segoe UI,
@@ -87,52 +69,131 @@ body {
     'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol';
 
+  --ifm-heading-font-family: 'Poppins', 'Inter var', system-ui, -apple-system,
+    Segoe UI, Roboto, sans-serif;
+  --ifm-heading-font-weight: 600;
+  --ifm-heading-line-height: 1.25;
+  --ifm-h1-font-size: 2.5rem;
+  --ifm-h2-font-size: 1.875rem;
+  --ifm-h3-font-size: 1.5rem;
+  --ifm-h4-font-size: 1.25rem;
+
   --ifm-font-family-monospace: 'Fira Code VF', SFMono-Regular, Menlo, Monaco,
     Consolas, 'Liberation Mono', 'Courier New', monospace;
 
-  /* Theme colors */
-  --ifm-color-primary: #110D8B;
-  --ifm-color-primary-dark: #0A0674;
-  --ifm-color-primary-darker: #080559;
-  --ifm-color-primary-darkest: #02003F;
-  --ifm-color-primary-light: #1D18A8;
-  --ifm-color-primary-lighter: #2722BB;
-  --ifm-color-primary-lightest: #322DC2;
+  /* Light-mode IFM accents */
+  --ifm-color-primary: #462adf;
+  --ifm-color-primary-dark: #361fb2;
+  --ifm-color-primary-darker: #2d1b8f;
+  --ifm-color-primary-darkest: #1f1366;
+  --ifm-color-primary-light: #5b57fa;
+  --ifm-color-primary-lighter: #6a67ea;
+  --ifm-color-primary-lightest: #8c8af9;
+
+  --ifm-link-color: var(--docs-color-primary);
 
   --ifm-navbar-shadow: none;
-  --ifm-toc-border-color: #dedede;
+  --ifm-toc-border-color: var(--docs-color-border);
 
   --ifm-table-border-color: var(--docs-color-border);
   --code-border-color: var(--docs-color-border);
 
   --ifm-code-font-size: 92%;
-  --docusaurus-highlighted-code-line-bg: rgba(147, 178, 244, 0.38);
+  --ifm-button-border-radius: 0.75rem;
+  --ifm-card-border-radius: 1rem;
+  --ifm-global-shadow-lw: 0 6px 8px rgba(9, 5, 36, 0.12);
+
+  --docusaurus-highlighted-code-line-bg: rgba(140, 138, 249, 0.18);
 }
 
-/* For readability concerns, you should choose a lighter palette in dark mode. */
-html[data-theme='dark'] {
-  --ifm-link-color: #1a90ff;
-  --ifm-tabs-color-active-border: #1a90ff;
-  --ifm-tabs-color-active: #1a90ff;
+/* Headings — tighter tracking for Poppins */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  letter-spacing: -0.01em;
+}
 
-  --ifm-color-primary: #1a90ff;
+/* Dark mode
+   Page background stays #161616 (per user). Purple accents/surfaces
+   are pulled from the frontend osmoverse palette. */
+[data-theme='dark'] {
+  --docs-color-border: #282750; /* osmoverse-800 — purple-tinted */
+
+  --docs-color-text: #ffffff;
+  --docs-color-text-100: #b0aadc; /* osmoverse-300 */
+
+  --docs-color-background: #161616;
+  --docs-color-background-100: #1c1c1c;
+  --docs-color-background-200: #232047; /* osmoverse-825 */
+  --docs-color-background-300: #282750; /* osmoverse-800 */
+
+  --docs-color-code-background: #140f34; /* osmoverse-900 */
+  --docs-color-primary: #8c8af9; /* wosmongton-300 — accent/link */
+  --docs-color-primary-100: #6a67ea; /* wosmongton-400 */
+  --docs-color-primary-tint: rgba(140, 138, 249, 0.16);
+  --docs-color-primary-tint-light: rgba(140, 138, 249, 0.24);
+
+  --ifm-link-color: #8c8af9;
+  --ifm-tabs-color-active-border: #8c8af9;
+  --ifm-tabs-color-active: #8c8af9;
+
+  --ifm-color-primary: #8c8af9;
+  --ifm-color-primary-dark: #6a67ea;
+  --ifm-color-primary-darker: #5b57fa;
+  --ifm-color-primary-darkest: #462adf;
+  --ifm-color-primary-light: #b3b1fd;
+  --ifm-color-primary-lighter: #d3d1ff;
+  --ifm-color-primary-lightest: #e4e1fb;
 
   --ifm-footer-background-color: #1c1c1c;
   --ifm-background-surface-color: #161616;
   --ifm-background-color: #161616;
-  --ifm-toc-border-color: #2e2e2e;
+  --ifm-toc-border-color: var(--docs-color-border);
 
   --ifm-color-content: #e7e7e7;
 
-  --docusaurus-highlighted-code-line-bg: rgba(105, 105, 105, 0.3);
+  --ifm-global-shadow-lw: 0 6px 8px rgba(9, 5, 36, 0.4);
+
+  --docusaurus-highlighted-code-line-bg: rgba(140, 138, 249, 0.16);
 }
 
 nav.navbar {
-  border-bottom: 1px solid var(--ifm-toc-border-color);
+  border-bottom: 1px solid var(--docs-color-border);
+}
+
+.navbar__inner {
+  align-items: center;
+}
+
+.navbar__items {
+  align-items: center;
+}
+
+.navbar__item,
+.navbar__link {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+}
+
+/* Wider search bar to fit longer queries comfortably. */
+.navbar .DocSearch-Button {
+  min-width: 260px;
+}
+
+@media (max-width: 996px) {
+  .navbar .DocSearch-Button {
+    min-width: 0;
+  }
 }
 
 pre.prism-code {
   border: 1px solid var(--code-border-color);
+  border-radius: 0.5rem;
+  background-color: var(--docs-color-code-background);
 }
 
 .navbar__logo {
@@ -145,7 +206,7 @@ pre.prism-code {
 }
 
 .menu__link {
-  border-radius: 4px 0 0 4px;
+  border-radius: 6px 0 0 6px;
 }
 
 .menu__list-item-collapsible:hover {
@@ -153,7 +214,7 @@ pre.prism-code {
 }
 
 ul.menu__list > li > a.menu__link--active {
-  border-right: 1px solid var(--ifm-color-primary);
+  border-right: 2px solid var(--docs-color-primary);
 }
 
 nav.menu {
@@ -165,10 +226,11 @@ nav.menu {
   align-items: baseline;
   margin-left: 6px;
   content: 'NEW';
-  padding: 2px 4px;
+  padding: 2px 6px;
   font-size: 11px;
-  color: var(--docs-color-primary-100);
-  border: 1px solid var(--docs-color-primary-100);
+  letter-spacing: 0.05em;
+  color: var(--docs-color-primary);
+  border: 1px solid var(--docs-color-primary);
   border-radius: 6px;
 }
 
@@ -199,16 +261,21 @@ nav.menu {
 .footer__cta a {
   --ifm-link-hover-color: #fff;
   margin-top: 0.25rem;
-  display: inline-block;
-  padding: 0.25rem 1.5rem;
-  border-radius: 4px;
-  background-color: var(--docs-color-primary);
+  display: inline-flex;
+  align-items: center;
+  padding: 0.625rem 1.5rem;
+  border: 2px solid #462adf; /* wosmongton-700 */
+  border-radius: 0.75rem;
+  background-color: #462adf;
   color: #ffffff;
   text-decoration: none;
+  font-weight: 600;
+  transition: background-color 150ms ease, border-color 150ms ease;
 }
 
 .footer__cta a:hover {
-  background-color: var(--ifm-color-primary-darker);
+  background-color: #6a67ea; /* wosmongton-400 */
+  border-color: #6a67ea;
 }
 
 .footer__data {
@@ -220,10 +287,12 @@ nav.menu {
 }
 
 .footer__title {
-  font-size: 14px;
-  font-weight: normal;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
   color: var(--docs-color-text-100);
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
 }
 
 .footer__item {
@@ -234,6 +303,7 @@ nav.menu {
 
 .footer__link-item:hover {
   text-decoration: none;
+  color: var(--docs-color-primary);
 }
 
 .navbar-sidebar__item {
@@ -268,28 +338,24 @@ nav.menu {
 .pseudo-icon::before {
   content: '';
   display: block;
-  width: 32px;
-  height: 32px;
+  width: 22px;
+  height: 22px;
   opacity: 0.8;
   background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center;
 }
 
 .github-icon::before {
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' aria-hidden='true' focusable='false' fill='%23000000' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' d='M12.026 2c-5.509 0-9.974 4.465-9.974 9.974 0 4.406 2.857 8.145 6.821 9.465.499.09.679-.217.679-.481 0-.237-.008-.865-.011-1.696-2.775.602-3.361-1.338-3.361-1.338-.452-1.152-1.107-1.459-1.107-1.459-.905-.619.069-.605.069-.605 1.002.07 1.527 1.028 1.527 1.028.89 1.524 2.336 1.084 2.902.829.091-.645.351-1.085.635-1.334-2.214-.251-4.542-1.107-4.542-4.93 0-1.087.389-1.979 1.024-2.675-.101-.253-.446-1.268.099-2.64 0 0 .837-.269 2.742 1.021a9.582 9.582 0 0 1 2.496-.336 9.554 9.554 0 0 1 2.496.336c1.906-1.291 2.742-1.021 2.742-1.021.545 1.372.203 2.387.099 2.64.64.696 1.024 1.587 1.024 2.675 0 3.833-2.33 4.675-4.552 4.922.355.308.675.916.675 1.846 0 1.334-.012 2.41-.012 2.737 0 .267.178.577.687.479C19.146 20.115 22 16.379 22 11.974 22 6.465 17.535 2 12.026 2z' clip-rule='evenodd'%3E%3C/path%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' aria-hidden='true' focusable='false' fill='%23140F34' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' d='M12.026 2c-5.509 0-9.974 4.465-9.974 9.974 0 4.406 2.857 8.145 6.821 9.465.499.09.679-.217.679-.481 0-.237-.008-.865-.011-1.696-2.775.602-3.361-1.338-3.361-1.338-.452-1.152-1.107-1.459-1.107-1.459-.905-.619.069-.605.069-.605 1.002.07 1.527 1.028 1.527 1.028.89 1.524 2.336 1.084 2.902.829.091-.645.351-1.085.635-1.334-2.214-.251-4.542-1.107-4.542-4.93 0-1.087.389-1.979 1.024-2.675-.101-.253-.446-1.268.099-2.64 0 0 .837-.269 2.742 1.021a9.582 9.582 0 0 1 2.496-.336 9.554 9.554 0 0 1 2.496.336c1.906-1.291 2.742-1.021 2.742-1.021.545 1.372.203 2.387.099 2.64.64.696 1.024 1.587 1.024 2.675 0 3.833-2.33 4.675-4.552 4.922.355.308.675.916.675 1.846 0 1.334-.012 2.41-.012 2.737 0 .267.178.577.687.479C19.146 20.115 22 16.379 22 11.974 22 6.465 17.535 2 12.026 2z' clip-rule='evenodd'%3E%3C/path%3E%3C/svg%3E");
 }
 
 html[data-theme='dark'] .github-icon::before {
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' aria-hidden='true' focusable='false' fill='%23b4b4b4' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' d='M12.026 2c-5.509 0-9.974 4.465-9.974 9.974 0 4.406 2.857 8.145 6.821 9.465.499.09.679-.217.679-.481 0-.237-.008-.865-.011-1.696-2.775.602-3.361-1.338-3.361-1.338-.452-1.152-1.107-1.459-1.107-1.459-.905-.619.069-.605.069-.605 1.002.07 1.527 1.028 1.527 1.028.89 1.524 2.336 1.084 2.902.829.091-.645.351-1.085.635-1.334-2.214-.251-4.542-1.107-4.542-4.93 0-1.087.389-1.979 1.024-2.675-.101-.253-.446-1.268.099-2.64 0 0 .837-.269 2.742 1.021a9.582 9.582 0 0 1 2.496-.336 9.554 9.554 0 0 1 2.496.336c1.906-1.291 2.742-1.021 2.742-1.021.545 1.372.203 2.387.099 2.64.64.696 1.024 1.587 1.024 2.675 0 3.833-2.33 4.675-4.552 4.922.355.308.675.916.675 1.846 0 1.334-.012 2.41-.012 2.737 0 .267.178.577.687.479C19.146 20.115 22 16.379 22 11.974 22 6.465 17.535 2 12.026 2z' clip-rule='evenodd'%3E%3C/path%3E%3C/svg%3E");
-}
-
-.discord-icon::before {
-  width: 32px;
-  height: 25px;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 28 22' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17.967 0c-.278.497-.525 1.01-.741 1.537a20.488 20.488 0 0 0-6.401 0A14.164 14.164 0 0 0 10.085 0c-1.998.341-3.94.953-5.773 1.817A24.22 24.22 0 0 0 .12 18.015a23.2 23.2 0 0 0 7.085 3.62 18.01 18.01 0 0 0 1.552-2.432 13.48 13.48 0 0 1-2.39-1.16c.207-.138.404-.293.587-.462a16.296 16.296 0 0 0 14.143 0c.196.168.392.322.587.462-.76.46-1.56.853-2.39 1.174.433.87.938 1.702 1.51 2.487a22.977 22.977 0 0 0 7.072-3.62 24.066 24.066 0 0 0-4.193-16.197A22.487 22.487 0 0 0 17.967 0ZM9.386 14.745a2.712 2.712 0 0 1-2.516-2.796 2.697 2.697 0 0 1 2.516-2.795A2.697 2.697 0 0 1 11.9 11.95a2.697 2.697 0 0 1-2.515 2.796Zm9.28 0a2.712 2.712 0 0 1-2.516-2.796 2.698 2.698 0 0 1 2.515-2.795 2.684 2.684 0 0 1 2.516 2.795 2.684 2.684 0 0 1-2.516 2.796Z' fill='%23000000'%3E%3C/path%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' aria-hidden='true' focusable='false' fill='%23B0AADC' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' d='M12.026 2c-5.509 0-9.974 4.465-9.974 9.974 0 4.406 2.857 8.145 6.821 9.465.499.09.679-.217.679-.481 0-.237-.008-.865-.011-1.696-2.775.602-3.361-1.338-3.361-1.338-.452-1.152-1.107-1.459-1.107-1.459-.905-.619.069-.605.069-.605 1.002.07 1.527 1.028 1.527 1.028.89 1.524 2.336 1.084 2.902.829.091-.645.351-1.085.635-1.334-2.214-.251-4.542-1.107-4.542-4.93 0-1.087.389-1.979 1.024-2.675-.101-.253-.446-1.268.099-2.64 0 0 .837-.269 2.742 1.021a9.582 9.582 0 0 1 2.496-.336 9.554 9.554 0 0 1 2.496.336c1.906-1.291 2.742-1.021 2.742-1.021.545 1.372.203 2.387.099 2.64.64.696 1.024 1.587 1.024 2.675 0 3.833-2.33 4.675-4.552 4.922.355.308.675.916.675 1.846 0 1.334-.012 2.41-.012 2.737 0 .267.178.577.687.479C19.146 20.115 22 16.379 22 11.974 22 6.465 17.535 2 12.026 2z' clip-rule='evenodd'%3E%3C/path%3E%3C/svg%3E");
 }
 
 html[data-theme='dark'] .discord-icon::before {
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 28 22' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17.967 0c-.278.497-.525 1.01-.741 1.537a20.488 20.488 0 0 0-6.401 0A14.164 14.164 0 0 0 10.085 0c-1.998.341-3.94.953-5.773 1.817A24.22 24.22 0 0 0 .12 18.015a23.2 23.2 0 0 0 7.085 3.62 18.01 18.01 0 0 0 1.552-2.432 13.48 13.48 0 0 1-2.39-1.16c.207-.138.404-.293.587-.462a16.296 16.296 0 0 0 14.143 0c.196.168.392.322.587.462-.76.46-1.56.853-2.39 1.174.433.87.938 1.702 1.51 2.487a22.977 22.977 0 0 0 7.072-3.62 24.066 24.066 0 0 0-4.193-16.197A22.487 22.487 0 0 0 17.967 0ZM9.386 14.745a2.712 2.712 0 0 1-2.516-2.796 2.697 2.697 0 0 1 2.516-2.795A2.697 2.697 0 0 1 11.9 11.95a2.697 2.697 0 0 1-2.515 2.796Zm9.28 0a2.712 2.712 0 0 1-2.516-2.796 2.698 2.698 0 0 1 2.515-2.795 2.684 2.684 0 0 1 2.516 2.795 2.684 2.684 0 0 1-2.516 2.796Z' fill='%23b4b4b4'%3E%3C/path%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 28 22' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17.967 0c-.278.497-.525 1.01-.741 1.537a20.488 20.488 0 0 0-6.401 0A14.164 14.164 0 0 0 10.085 0c-1.998.341-3.94.953-5.773 1.817A24.22 24.22 0 0 0 .12 18.015a23.2 23.2 0 0 0 7.085 3.62 18.01 18.01 0 0 0 1.552-2.432 13.48 13.48 0 0 1-2.39-1.16c.207-.138.404-.293.587-.462a16.296 16.296 0 0 0 14.143 0c.196.168.392.322.587.462-.76.46-1.56.853-2.39 1.174.433.87.938 1.702 1.51 2.487a22.977 22.977 0 0 0 7.072-3.62 24.066 24.066 0 0 0-4.193-16.197A22.487 22.487 0 0 0 17.967 0ZM9.386 14.745a2.712 2.712 0 0 1-2.516-2.796 2.697 2.697 0 0 1 2.516-2.795A2.697 2.697 0 0 1 11.9 11.95a2.697 2.697 0 0 1-2.515 2.796Zm9.28 0a2.712 2.712 0 0 1-2.516-2.796 2.698 2.698 0 0 1 2.515-2.795 2.684 2.684 0 0 1 2.516 2.795 2.684 2.684 0 0 1-2.516 2.796Z' fill='%23B0AADC'%3E%3C/path%3E%3C/svg%3E");
 }
 
 .navbar-sidebar .pseudo-icon {
@@ -310,22 +376,36 @@ html[data-theme='dark'] .discord-icon::before {
   content: 'GitHub';
 }
 
-.navbar-sidebar .discord-icon::after {
-  content: 'Discord';
-}
-
+/* Navbar primary CTA — mirrors the frontend's <Button mode="primary">:
+   wosmongton-700 bg, 2px wosmongton-700 border, rounded-xl, hover to
+   wosmongton-400. Inline-flex with align-items:center fixes the
+   slight vertical offset against neighbour links. */
 .dev-portal-link {
-  background-color: var(--docs-color-primary);
-  border-radius: 4px;
-  margin-right: 12px;
-  transition-property: all;
+  display: inline-flex;
+  align-items: center;
+  height: 36px;
+  padding: 0 1rem;
+  margin: 0 0.5rem;
+  border: 2px solid #462adf; /* wosmongton-700 */
+  border-radius: 0.75rem;
+  background-color: #462adf;
+  font-weight: 600;
+  line-height: 1;
+  transition: background-color 150ms ease, border-color 150ms ease;
 }
 
 .dev-postman-link {
+  display: inline-flex;
+  align-items: center;
+  height: 36px;
+  padding: 0 1rem;
+  margin: 0 0.5rem;
+  border: 2px solid var(--docs-color-secondary);
+  border-radius: 0.75rem;
   background-color: var(--docs-color-secondary);
-  border-radius: 4px;
-  margin-right: 12px;
-  transition-property: all;
+  font-weight: 600;
+  line-height: 1;
+  transition: background-color 150ms ease, border-color 150ms ease;
 }
 
 .dev-portal-link svg {
@@ -341,7 +421,8 @@ html[data-theme='dark'] .discord-icon::before {
 }
 
 .dev-portal-signup:hover {
-  background-color: var(--ifm-color-primary-darker);
+  background-color: #6a67ea; /* wosmongton-400 */
+  border-color: #6a67ea;
 }
 
 .dev-portal-login {
@@ -350,11 +431,12 @@ html[data-theme='dark'] .discord-icon::before {
 }
 
 .navbar-sidebar .dev-portal-link {
-  padding: 0.75rem;
+  height: auto;
+  padding: 0.75rem 1rem;
   margin-top: 1rem;
 }
 
-/* Custom design for sidebar hide and expand buttons */
+/* Sidebar collapse / expand buttons */
 
 aside.theme-doc-sidebar-container {
   position: relative;
@@ -369,20 +451,21 @@ aside.theme-doc-sidebar-container {
   width: 28px;
   height: 28px;
   padding: 0;
-  border-radius: 4px;
+  border-radius: 8px;
   z-index: 10;
   background-size: 16px;
   background-position: center;
   background-repeat: no-repeat;
-  background-color: var(--docs-color-border);
+  background-color: var(--docs-color-background-200);
+  border: 1px solid var(--docs-color-border);
 
-  background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M15.707 4.293a1 1 0 0 1 0 1.414L9.414 12l6.293 6.293a1 1 0 0 1-1.414 1.414l-7-7a1 1 0 0 1 0-1.414l7-7a1 1 0 0 1 1.414 0Z' fill='%23181818'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M15.707 4.293a1 1 0 0 1 0 1.414L9.414 12l6.293 6.293a1 1 0 0 1-1.414 1.414l-7-7a1 1 0 0 1 0-1.414l7-7a1 1 0 0 1 1.414 0Z' fill='%23140F34'/%3E%3C/svg%3E");
 }
 
 .theme-doc-sidebar-container div[title='Expand sidebar'] {
   position: sticky;
   margin-left: 16px;
-  background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.293 4.293a1 1 0 0 0 0 1.414L14.586 12l-6.293 6.293a1 1 0 1 0 1.414 1.414l7-7a1 1 0 0 0 0-1.414l-7-7a1 1 0 0 0-1.414 0Z' fill='%23181818'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.293 4.293a1 1 0 0 0 0 1.414L14.586 12l-6.293 6.293a1 1 0 1 0 1.414 1.414l7-7a1 1 0 0 0 0-1.414l-7-7a1 1 0 0 0-1.414 0Z' fill='%23140F34'/%3E%3C/svg%3E");
 }
 
 html[data-theme='dark']
@@ -404,13 +487,12 @@ html[data-theme='dark']
 }
 
 .sections-menu-trigger {
-  /* all: unset; */
   flex: 1;
   display: inline-flex;
   background-color: var(--docs-color-background-100);
   color: var(--docs-color-text);
   height: 48px;
-  border-radius: 6px;
+  border-radius: 0.75rem;
   align-items: center;
   justify-content: space-between;
   text-align: left;
@@ -419,13 +501,12 @@ html[data-theme='dark']
   outline: none;
 
   cursor: pointer;
-
-  box-sizing: border-box;
-  border: 1px solid var(--docs-color-background-200);
+  border: 1px solid var(--docs-color-border);
 }
 
 .sections-menu-trigger:hover {
-  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.2);
+  border-color: var(--docs-color-primary);
+  box-shadow: 0 6px 16px rgba(9, 5, 36, 0.16);
 }
 
 .sections-menu-trigger,
@@ -470,7 +551,7 @@ html[data-theme='dark']
 .sections-menu-item .item-indicator {
   height: 20px;
   width: 20px;
-  color: var(--docs-color-primary-100);
+  color: var(--docs-color-primary);
 }
 
 .sections-menu-trigger .item-text,
@@ -491,10 +572,11 @@ html[data-theme='dark']
 .sections-menu-content {
   box-sizing: border-box;
   background-color: var(--docs-color-background-100);
-  border-radius: 6px;
+  border-radius: 0.75rem;
   padding: 6px 0;
+  border: 1px solid var(--docs-color-border);
 
-  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 6px 16px rgba(9, 5, 36, 0.16);
 }
 
 .sections-menu-trigger.compact {
@@ -524,7 +606,7 @@ html[data-theme='dark']
 .loading-container dyte-spinner {
   width: 48px;
   height: 48px;
-  color: var(--docs-color-primary-100);
+  color: var(--docs-color-primary);
 }
 
 .dyte-video-showcase {
@@ -532,7 +614,7 @@ html[data-theme='dark']
   display: block;
   width: 100%;
   max-width: 80%;
-  border-radius: 8px;
+  border-radius: 12px;
 }
 
 .dyte-video-showcase.mobile {
@@ -545,7 +627,7 @@ img.cover-image {
   width: 100%;
   max-width: 840px;
   border-radius: 16px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 6px 24px rgba(9, 5, 36, 0.2);
   margin: 0 auto;
 }
 
@@ -576,7 +658,6 @@ ul.emoji-list span {
 }
 
 .menu__link {
-  /* Background tint only for menu links in sidebar */
   --ifm-menu-color-background-active: var(--docs-color-primary-tint);
 }
 
@@ -602,8 +683,10 @@ table thead tr {
 }
 
 table th {
-  font-weight: 500;
-  font-size: 14px;
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--docs-color-text-100);
 }
 
@@ -613,13 +696,13 @@ table th {
 
 .tabs__item {
   --ifm-tabs-padding-vertical: 0.75rem;
-  --ifm-tabs-color-active: var(--docs-color-primary-100);
+  --ifm-tabs-color-active: var(--docs-color-primary);
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
 
 .tabs__item--active {
-  border-bottom: 2px solid var(--docs-color-primary-100);
+  border-bottom: 2px solid var(--docs-color-primary);
 }
 
 /* Mobile breakpoint */
@@ -657,6 +740,7 @@ img + em {
   text-align: center;
   display: block;
   margin-top: 1rem;
+  color: var(--docs-color-text-100);
 }
 
 /**
@@ -668,6 +752,7 @@ img[src$='#terminal'] {
   max-width: 720px;
   margin-left: auto;
   margin-right: auto;
+  border-radius: 8px;
 }
 
 .pad {
@@ -686,23 +771,67 @@ img[src$='#terminal'] {
 }
 
 #hero {
-  padding: 2rem 0 1.5rem 0;
-  margin-bottom: 4rem;
+  padding: 3rem 0 2.5rem 0;
+  margin-bottom: 3rem;
   border-bottom: 1px solid var(--docs-color-border);
 }
 
+.hero-eyebrow {
+  display: inline-block;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--docs-color-text-100);
+  margin-bottom: 0.75rem;
+}
+
 #hero h2 {
-  font-size: 36px;
+  font-family: var(--ifm-heading-font-family);
+  font-size: 48px;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin-bottom: 1rem;
 }
 
 #hero p {
   color: var(--docs-color-text-100);
+  font-size: 1rem;
+  line-height: 1.6;
+  max-width: 60ch;
+}
+
+/* Hero CTA — mirrors the frontend's <Button mode="primary" size="normal">:
+   wosmongton-700 bg, 2px border same colour, rounded-xl, h-[56px], px-6,
+   hover to wosmongton-400. */
+.hero-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+  height: 56px;
+  padding: 0 1.5rem;
+  border: 2px solid #462adf; /* wosmongton-700 */
+  border-radius: 0.75rem;
+  background-color: #462adf;
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 150ms ease, border-color 150ms ease;
+}
+
+.hero-cta:hover {
+  background-color: #6a67ea; /* wosmongton-400 */
+  border-color: #6a67ea;
+  color: #fff;
+  text-decoration: none;
 }
 
 .section-content {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+  gap: 14px;
 }
 
 .two-cols .section-content {
@@ -726,13 +855,27 @@ img[src$='#terminal'] {
 }
 
 .homepage-section h3 {
+  font-family: var(--ifm-heading-font-family);
   font-weight: 600;
+  font-size: 1.375rem;
+  letter-spacing: -0.01em;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1.25rem;
+  border-bottom: 1px solid var(--docs-color-border);
+}
+
+.homepage-section h4 {
+  font-family: var(--ifm-heading-font-family);
+  font-weight: 600;
+  font-size: 1rem;
+  margin-bottom: 1rem;
 }
 
 .section-description {
   color: var(--docs-color-text-100);
-  margin: 0rem 0 1.25rem 0;
-  margin-top: -0.5rem;
+  margin: -0.25rem 0 1.25rem 0;
+  font-size: 14px;
+  line-height: 1.5;
 }
 
 .has-sub-sections > .section-content .section-description {
@@ -743,8 +886,8 @@ img[src$='#terminal'] {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 10px;
-  padding: 0.75rem;
+  gap: 12px;
+  padding: 1rem;
   text-decoration: none;
   color: var(--docs-color-text);
 
@@ -752,14 +895,22 @@ img[src$='#terminal'] {
   --ifm-link-hover-color: inherit;
   cursor: pointer;
 
-  transition-property: background-color, color;
+  transition: border-color 150ms ease, transform 150ms ease,
+    box-shadow 150ms ease;
 
   border: 1px solid var(--docs-color-border);
-  border-radius: 8px;
+  border-radius: 14px;
+  background-color: var(--docs-color-background);
 }
 
 .homepage-card:hover {
-  background-color: var(--docs-color-background-100);
+  border-color: var(--docs-color-primary);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(9, 5, 36, 0.08);
+}
+
+[data-theme='dark'] .homepage-card:hover {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 }
 
 .icon svg {
@@ -767,11 +918,27 @@ img[src$='#terminal'] {
   height: 100%;
 }
 
+.homepage-card .icon-frame {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--docs-color-background-200);
+  border-radius: 10px;
+  padding: 6px;
+}
+
+.homepage-card .icon-frame img,
+.homepage-card .icon-frame svg {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
 .homepage-card .icon {
-  width: 48px;
-  height: 48px;
-  /* background-color: #262626;
-  border-radius: 8px; */
+  width: 40px;
+  height: 40px;
 }
 
 .card-content {
@@ -781,21 +948,71 @@ img[src$='#terminal'] {
 }
 
 .card-content .title {
-  font-size: 16px;
-  letter-spacing: -0.5px;
+  font-family: var(--ifm-heading-font-family);
+  font-size: 15px;
+  letter-spacing: -0.01em;
   font-weight: 600;
 }
 
 .card-content .description {
-  font-size: 14px;
+  font-size: 13px;
   color: var(--docs-color-text-100);
   line-height: 1.5;
+}
+
+/* Featured card variant — for "if you read nothing else, read this".
+   Spans two grid columns, larger title, brighter border, subtle gradient
+   wash. Use sparingly: 1 per section, never more. */
+.homepage-card.featured {
+  grid-column: span 2;
+  border-color: var(--docs-color-primary);
+  background: linear-gradient(
+    135deg,
+    var(--docs-color-background) 0%,
+    var(--docs-color-background-200) 100%
+  );
+}
+
+.homepage-card.featured .card-content .title {
+  font-size: 1.125rem;
+  margin-bottom: 0.125rem;
+}
+
+.homepage-card.featured .card-content .description {
+  font-size: 14px;
+}
+
+.homepage-card.featured .icon-frame {
+  width: 48px;
+  height: 48px;
+  background-color: var(--docs-color-primary-tint);
+}
+
+/* Single-column / sub-section grids — don't span 2 cols there. */
+.has-sub-sections .homepage-card.featured,
+.two-cols .homepage-card.featured {
+  grid-column: span 1;
+}
+
+@media screen and (max-width: 768px) {
+  .homepage-card.featured {
+    grid-column: span 1;
+  }
 }
 
 @media screen and (max-width: 1160px) {
   /* Hide icons when header UI breaks */
   .pseudo-icon {
     display: none;
+  }
+}
+
+@media screen and (max-width: 996px) {
+  #hero {
+    padding: 2rem 0 1.5rem 0;
+  }
+  #hero h2 {
+    font-size: 32px;
   }
 }
 
@@ -808,8 +1025,69 @@ img[src$='#terminal'] {
   }
 }
 
+/* ─────────────────────────────────────────────────────────────────────
+   Built-in DocCardList (auto-generated category index pages)
+   ─────────────────────────────────────────────────────────────────────
+   Docusaurus renders <DocCardList /> as a grid of `.card` links, each
+   prefixed with a generic emoji (📄 / 🔗 / 🗃️). We can't drop the emoji
+   without swizzling the DocCard component, so we tone it down — small,
+   muted, and treat it like the icon-frame on our HomepageCard.
 
-/* OSMOSIS */
+   The card itself is restyled to match `.homepage-card` so the visual
+   language is consistent across the docs. */
+
+article .card {
+  border: 1px solid var(--docs-color-border);
+  border-radius: 14px;
+  background-color: var(--docs-color-background);
+  box-shadow: none;
+  transition: border-color 150ms ease, transform 150ms ease,
+    box-shadow 150ms ease;
+}
+
+article .card:hover {
+  border-color: var(--docs-color-primary);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(9, 5, 36, 0.08);
+}
+
+[data-theme='dark'] article .card:hover {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+article .card h2 {
+  font-family: var(--ifm-heading-font-family);
+  font-size: 1rem !important;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin-top: 0;
+  margin-bottom: 0.375rem;
+  color: var(--docs-color-text);
+  /* The generic page emoji (📄 / 🔗 / 🗃️) is text inside the h2 — we
+     can't strip it without swizzling, so soften it via the first letter
+     until each page has a real icon mapping. */
+  font-variant-emoji: text;
+}
+
+/* Tone down the leading emoji — first-letter targets the emoji glyph
+   since it's the first character in the title node. */
+article .card h2::first-letter {
+  font-size: 1.1em;
+  opacity: 0.55;
+  margin-right: 0.25rem;
+}
+
+article .card p {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--docs-color-text-100);
+  margin: 0;
+}
+
+/* DocCardList grid spacing — slightly looser than Docusaurus default. */
+article .row > .col {
+  margin-bottom: 1rem;
+}
 
 /* Issue #210: render DocCardList items full-width on desktop. Infima
    drives both flex-basis and max-width from --ifm-col-width on any
@@ -831,4 +1109,81 @@ img[src$='#terminal'] {
   article.col.margin-bottom--lg:not(:last-child) {
     margin-bottom: 2rem !important;
   }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   Prose readability
+   ─────────────────────────────────────────────────────────────────────
+   These rules target Docusaurus's MDX content container (.theme-doc-markdown
+   wraps the rendered prose). The goal is to make wall-of-text pages feel
+   less blocky without forcing every author to restructure their markdown:
+
+   - Cap the reading measure (~72ch) — long lines hurt readability more than
+     people expect. The doc body retains the full container width for code
+     blocks, tables, and embedded images; only flowing prose is capped.
+   - Loosen paragraph leading by one notch.
+   - Tighten heading→paragraph spacing, loosen paragraph→heading.
+   - Bump the lede (first paragraph) one size for visual entry.
+   - Make <hr> a real section break, not a hairline. */
+
+.theme-doc-markdown {
+  max-width: 72ch;
+}
+
+/* Wide elements (code blocks, tables, embedded media, cards) escape the
+   measure cap and continue using the full column width. */
+.theme-doc-markdown
+  > :is(pre, .theme-code-block, table, .table-wrapper, .tabs-container, .admonition, .alert, details, blockquote, figure, .homepage-section, .section-content) {
+  max-width: none;
+}
+
+.theme-doc-markdown p {
+  line-height: 1.7;
+  margin-bottom: 1rem;
+}
+
+.theme-doc-markdown :is(h2, h3, h4) {
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+}
+
+/* First content element gets no extra top margin. */
+.theme-doc-markdown > :is(h1, h2, h3, h4):first-child {
+  margin-top: 0;
+}
+
+/* Lede paragraph — the first <p> directly under the page heading. */
+.theme-doc-markdown > p:first-of-type,
+.theme-doc-markdown header + p {
+  font-size: 1.125rem;
+  line-height: 1.6;
+  color: var(--docs-color-text);
+}
+
+.theme-doc-markdown hr {
+  border: none;
+  border-top: 1px solid var(--docs-color-border);
+  margin: 3rem 0;
+}
+
+.theme-doc-markdown :is(ul, ol) {
+  line-height: 1.7;
+}
+
+.theme-doc-markdown :is(ul, ol) li + li {
+  margin-top: 0.375rem;
+}
+
+/* Blockquotes — used occasionally for asides. Make them feel intentional. */
+.theme-doc-markdown blockquote {
+  border-left: 3px solid var(--docs-color-primary);
+  background-color: var(--docs-color-background-100);
+  padding: 0.75rem 1.25rem;
+  margin: 1.5rem 0;
+  border-radius: 0 8px 8px 0;
+  color: var(--docs-color-text-100);
+}
+
+.theme-doc-markdown blockquote p {
+  margin: 0;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,7 +36,7 @@ body {
   --dyte-colors-video-bg: 50 50 50;
 }
 
-/* Design tokens — light mode
+/* Design tokens, light mode
    Names kept from the legacy Dyte template; values remapped to the
    Osmosis frontend palette (osmosis-frontend/packages/web/tailwind.config.js). */
 :root {
@@ -48,7 +48,7 @@ body {
 
   --docs-color-border: #e4e1fb; /* osmoverse-100 */
 
-  --docs-color-text: #140f34; /* osmoverse-900 — purple-tinted near-black */
+  --docs-color-text: #140f34; /* osmoverse-900, purple-tinted near-black */
   --docs-color-text-100: #565081; /* osmoverse-600 */
 
   --docs-color-background: #ffffff;
@@ -106,7 +106,7 @@ body {
   --docusaurus-highlighted-code-line-bg: rgba(140, 138, 249, 0.18);
 }
 
-/* Headings — tighter tracking for Poppins */
+/* Headings, tighter tracking for Poppins */
 h1,
 h2,
 h3,
@@ -120,7 +120,7 @@ h6 {
    Page background stays #161616 (per user). Purple accents/surfaces
    are pulled from the frontend osmoverse palette. */
 [data-theme='dark'] {
-  --docs-color-border: #282750; /* osmoverse-800 — purple-tinted */
+  --docs-color-border: #282750; /* osmoverse-800, purple-tinted */
 
   --docs-color-text: #ffffff;
   --docs-color-text-100: #b0aadc; /* osmoverse-300 */
@@ -131,7 +131,7 @@ h6 {
   --docs-color-background-300: #282750; /* osmoverse-800 */
 
   --docs-color-code-background: #140f34; /* osmoverse-900 */
-  --docs-color-primary: #8c8af9; /* wosmongton-300 — accent/link */
+  --docs-color-primary: #8c8af9; /* wosmongton-300, accent/link */
   --docs-color-primary-100: #6a67ea; /* wosmongton-400 */
   --docs-color-primary-tint: rgba(140, 138, 249, 0.16);
   --docs-color-primary-tint-light: rgba(140, 138, 249, 0.24);
@@ -376,7 +376,7 @@ html[data-theme='dark'] .discord-icon::before {
   content: 'GitHub';
 }
 
-/* Navbar primary CTA — mirrors the frontend's <Button mode="primary">:
+/* Navbar primary CTA, mirrors the frontend's <Button mode="primary">:
    wosmongton-700 bg, 2px wosmongton-700 border, rounded-xl, hover to
    wosmongton-400. Inline-flex with align-items:center fixes the
    slight vertical offset against neighbour links. */
@@ -802,7 +802,7 @@ img[src$='#terminal'] {
   max-width: 60ch;
 }
 
-/* Hero CTA — mirrors the frontend's <Button mode="primary" size="normal">:
+/* Hero CTA, mirrors the frontend's <Button mode="primary" size="normal">:
    wosmongton-700 bg, 2px border same colour, rounded-xl, h-[56px], px-6,
    hover to wosmongton-400. */
 .hero-cta {
@@ -960,7 +960,7 @@ img[src$='#terminal'] {
   line-height: 1.5;
 }
 
-/* Featured card variant — for "if you read nothing else, read this".
+/* Featured card variant, for "if you read nothing else, read this".
    Spans two grid columns, larger title, brighter border, subtle gradient
    wash. Use sparingly: 1 per section, never more. */
 .homepage-card.featured {
@@ -988,7 +988,7 @@ img[src$='#terminal'] {
   background-color: var(--docs-color-primary-tint);
 }
 
-/* Single-column / sub-section grids — don't span 2 cols there. */
+/* Single-column / sub-section grids, don't span 2 cols there. */
 .has-sub-sections .homepage-card.featured,
 .two-cols .homepage-card.featured {
   grid-column: span 1;
@@ -1030,7 +1030,7 @@ img[src$='#terminal'] {
    ─────────────────────────────────────────────────────────────────────
    Docusaurus renders <DocCardList /> as a grid of `.card` links, each
    prefixed with a generic emoji (📄 / 🔗 / 🗃️). We can't drop the emoji
-   without swizzling the DocCard component, so we tone it down — small,
+   without swizzling the DocCard component, so we tone it down, small,
    muted, and treat it like the icon-frame on our HomepageCard.
 
    The card itself is restyled to match `.homepage-card` so the visual
@@ -1063,13 +1063,13 @@ article .card h2 {
   margin-top: 0;
   margin-bottom: 0.375rem;
   color: var(--docs-color-text);
-  /* The generic page emoji (📄 / 🔗 / 🗃️) is text inside the h2 — we
+  /* The generic page emoji (📄 / 🔗 / 🗃️) is text inside the h2, we
      can't strip it without swizzling, so soften it via the first letter
      until each page has a real icon mapping. */
   font-variant-emoji: text;
 }
 
-/* Tone down the leading emoji — first-letter targets the emoji glyph
+/* Tone down the leading emoji, first-letter targets the emoji glyph
    since it's the first character in the title node. */
 article .card h2::first-letter {
   font-size: 1.1em;
@@ -1084,7 +1084,7 @@ article .card p {
   margin: 0;
 }
 
-/* DocCardList grid spacing — slightly looser than Docusaurus default. */
+/* DocCardList grid spacing, slightly looser than Docusaurus default. */
 article .row > .col {
   margin-bottom: 1rem;
 }
@@ -1099,7 +1099,7 @@ article .row > .col {
    the last two articles (`article:nth-last-child(-n + 2)`) on the
    assumption of a 2-col grid where they share a row. Once we collapse
    to a single column those two are stacked, so we need the gap back
-   between them — restore margin-bottom on every article except the
+   between them, restore margin-bottom on every article except the
    actual last one. */
 @media (min-width: 997px) {
   article.col {
@@ -1118,7 +1118,7 @@ article .row > .col {
    wraps the rendered prose). The goal is to make wall-of-text pages feel
    less blocky without forcing every author to restructure their markdown:
 
-   - Cap the reading measure (~72ch) — long lines hurt readability more than
+   - Cap the reading measure (~72ch), long lines hurt readability more than
      people expect. The doc body retains the full container width for code
      blocks, tables, and embedded images; only flowing prose is capped.
    - Loosen paragraph leading by one notch.
@@ -1152,7 +1152,7 @@ article .row > .col {
   margin-top: 0;
 }
 
-/* Lede paragraph — the first <p> directly under the page heading. */
+/* Lede paragraph, the first <p> directly under the page heading. */
 .theme-doc-markdown > p:first-of-type,
 .theme-doc-markdown header + p {
   font-size: 1.125rem;
@@ -1174,7 +1174,7 @@ article .row > .col {
   margin-top: 0.375rem;
 }
 
-/* Blockquotes — used occasionally for asides. Make them feel intentional. */
+/* Blockquotes, used occasionally for asides. Make them feel intentional. */
 .theme-doc-markdown blockquote {
   border-left: 3px solid var(--docs-color-primary);
   background-color: var(--docs-color-background-100);

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import Layout from '@theme/Layout';
-import { useHistory } from '@docusaurus/router';
-import { DyteButton } from '@dytesdk/react-ui-kit';
 
-import {
-  HomepageCard as Card,
-  HomepageSection as Section,
-} from '../components/HomepageComponents';
 import {
   APIReferenceIcon,
   TerminalIcon,
@@ -22,11 +16,32 @@ import {
   Transaction,
   OsmosisCore,
   Contribute,
+  Guide,
+  Network,
+  ChainIcon,
 } from '../icons';
+import {
+  HomepageCard as Card,
+  HomepageSection as Section,
+} from '../components/HomepageComponents';
+
+/** Opens the Algolia DocSearch modal by dispatching the Ctrl+K shortcut
+ *  it already listens for. Docusaurus doesn't expose a public API for this. */
+function openSearch(event) {
+  event.preventDefault();
+  const keyEvent = new KeyboardEvent('keydown', {
+    key: 'k',
+    code: 'KeyK',
+    keyCode: 75,
+    which: 75,
+    ctrlKey: true,
+    metaKey: true,
+    bubbles: true,
+  });
+  document.dispatchEvent(keyEvent);
+}
 
 export default function Homepage() {
-  const router = useHistory();
-
   return (
     <Layout
       description="The Osmosis blockchain is a decentralized network, run by 150+ validators and full nodes, with many front-ends and development teams on it."
@@ -34,43 +49,30 @@ export default function Homepage() {
     >
       <div className="pad">
         <div className="center homepage-content">
-          <div className='margin-bottom--lg'>
-            <h2>Osmosis Docs</h2>
+          <section id="hero">
+            <span className="hero-eyebrow">Osmosis / Docs</span>
+            <h2>Build on the leading Cosmos DEX</h2>
             <p>
-              The Osmosis blockchain is a decentralized network, run by 150+ validators and full nodes, with many front-ends and development teams on it. Explore our docs and examples to quickly learn, develop & integrate with the Osmosis blockchain.
+              The Osmosis blockchain is a decentralized network run by 150+
+              validators and full nodes, with many front-ends and development
+              teams building on it. Explore the docs and examples to learn,
+              develop, and integrate with Osmosis.
             </p>
-            <DyteButton onClick={() => router.push('/osmosis-core/')}>
+            <a
+              className="hero-cta"
+              href="#search"
+              onClick={openSearch}
+              aria-label="Search the docs"
+            >
               Get Started &rarr;
-            </DyteButton>
-          </div>
-
-          <Section title="What's the latest">
-            <Card
-              title="Osmosis Outpost Docs"
-              description="An Osmosis outpost is a platform that makes it much simpler to perform swaps
-              on different Cosmos chains without having to manually send the tokens to 
-              Osmosis to trade them, or worse, to build their own DEX. Learn more about it here."
-              to="/osmosis-outpost"
-            />
-            <Card
-              title="Osmosis Testnet-5 is live"
-              description="Now live and ready for exploration. Join the testnet to gain hands-on experience with the newest features and take advantage of the expanded network options available."
-              to="/overview/endpoints"
-            />
-
-            <Card
-              title="Introducing the Osmosis Web CLI"
-              description=" Whether you're a seasoned developer or a curious enthusiast, this user-friendly interface provides a quick and intuitive way to access and leverage the power of Osmosis."
-              to="https://cli.osmosis.zone/"
-            />
-          </Section>
-
-
+            </a>
+          </section>
 
           <Section title="Learn about Osmosis">
             <Card
+              featured
               title="What is Osmosis?"
-              description="Osmosis is the premier cross-chain DEX and DeFi hub for the Cosmos ecosystem and beyond."
+              description="Osmosis is the premier cross-chain DEX and DeFi hub for the Cosmos ecosystem and beyond. Start here if you're new."
               to="/overview/educate/osmosis"
               icon={<OsmosisCore />}
             />
@@ -78,196 +80,167 @@ export default function Homepage() {
               title="How to use the Osmosis DEX"
               description="Learn about how to swap, provide liquidity and more."
               to="/overview/educate/getting-started"
+              icon={<Guide />}
             />
             <Card
               title="Explore the Ecosystem"
               description="Osmosis is home to a wide array of protocols and tools, find documentation relating to these on their sites"
               to="https://app.osmosis.zone/apps"
+              icon={<Network />}
             />
             <Card
               title="List on Osmosis"
               description="Learn how to list your project's token on Osmosis"
               to="/overview/integrate"
+              icon={<AssetIcon />}
             />
             <Card
               title="Join the Chain"
               description="Learn how to run an Osmosis node or validator"
               to="/overview/validate"
+              icon={<ChainIcon />}
             />
           </Section>
 
-          <Section title="Developers" id="web-sdks" hasSubSections>
-            <Section
-              title="⚙️ Chain Development"
-              id="core-sdks"
-              HeadingTag="h4"
-              description={
-                <>
-                  Everything that is needed to learn about the Osmosis core chain development.
-                </>
-              }
-            >
-
-
-              <Card
-                title="Build and Test Osmosis Source Code"
-                description="Getting started with building and testing Osmosis codebase"
-                to="/osmosis-core/build"
-                icon={<OsmosisCore />}
-              />
-              <Card
-                title="IDE Setup"
-                description="Recommended IDE setup for developing on Osmosis in Go"
-                to="/osmosis-core/ide-guide"
-                icon={<IDEIcon />}
-              />
-              <Card
-                title="Osmosisd CLI"
-                description="Install osmosisd to join the network or simple query it."
-                to="/osmosis-core/osmosisd"
-                icon={<TerminalIcon />}
-                svgFile="/icons/cli.svg"
-              />
-              <Card
-                title="Modules"
-                description="Osmosis modules and their respective CLI commands"
-                to="/osmosis-core/modules"
-                icon={<ModulesIcon />}
-                svgFile="/icons/modules.svg"
-              />
-              <Card
-                title="Relaying"
-                description=" Relay IBC packets between Osmosis and other chains"
-                to="/osmosis-core/relaying"
-                icon=""
-                svgFile="/icons/relayer.svg"
-              />
-              <Card
-                title="Assets"
-                description="     Currently supported assets on Osmosis with their corresponding channels and IBC denoms."
-                to="/osmosis-core/asset-info"
-                icon={<AssetIcon />}
-              />
-              <Card
-                title="Key Management"
-                description="Managing keys via CLI and advanced operations such as multisig wallets"
-                to="/osmosis-core/category/keys-management"
-                icon={<KeysIcon />}
-              />
-              <Card
-                title="Transaction Structure"
-                description=" Understanding the structure of a transaction on the Osmosis blockchain"
-                to="/osmosis-core/guides/structure"
-                icon={<Transaction />}
-                svgFile="/icons/transaction.svg"
-              />
-              <Card
-                title="Contributing"
-                description=" Guidelines to contributing to Osmosis core development."
-                to="/osmosis-core/contributing"
-                icon={<Contribute />}
-                svgFile="/icons/octocat.svg"
-              />
-
-            </Section>
-          </Section>
-
-
-          <Section title="Osmosis Frontend" id="web-sdks" hasSubSections >
-
-            <Section>
-              <Card
-                title="Osmosis Frontend"
-                description="Web interface for Osmosis Zone"
-                to="/frontend/osmosis-frontend"
-                icon=""
-                svgFile="/icons/osmo.svg" />
-
-              <Card
-                title="OsmoJS"
-                description="Compose and broadcast Osmosis and Cosmos messages, with all of the proto and amino encoding handled for you."
-                to="/osmojs"
-                icon={<Osmojs />}
-                svgFile=""
-              />
-
-              <Card
-                title="Osmosis-Labs Math"
-                description="NPM package with math functions related to Osmosis AMM. Useful for estimating state changes to propose reasonable min/max amounts in transactions."
-                to="https://www.npmjs.com/package/@osmosis-labs/math"
-                icon={<Tscodegen />}
-                svgFile="/icons/math.svg"
-              />
-              <Card
-                title="Osmosis-Labs Pools"
-                description="NPM package that defines pool interface and pool routing logic for the Osmosis Dex."
-                to="https://www.npmjs.com/package/@osmosis-labs/pools"
-                icon={<Tscodegen />}
-                svgFile="/icons/pools.svg"
-              />
-              <Card
-                title="Osmosis-Labs Stores"
-                description="NPM package which contains observable stores via mobx data storage framework for the Osmosis front-end"
-                to="https://www.npmjs.com/package/@osmosis-labs/stores"
-                icon={<Tscodegen />}
-                svgFile="/icons/store.svg"
-              />
-            </Section>
-          </Section>
-
-          <Section title="Frontend SDK Libraries & Utilities" id="web-sdks" hasSubSections >
-
-            <Section>
-
-              <Card
-                title="Cosmos Kit"
-                description="A wallet adapter for react with mobile WalletConnect support for the Cosmos ecosystem."
-                to="https://github.com/cosmology-tech/cosmos-kit"
-                icon=""
-                svgFile="/icons/bag.svg"
-              />
-              <Card
-                title="Telescope"
-                description="TypeScript Transpiler for Cosmos Protobufs. Telescope is used to generate libraries for Cosmos blockchains."
-                to="/telescope"
-                icon={<Telescope />}
-                svgFile=""
-              />
-              <Card
-                title="Create Cosmos App"
-                description="Set up a modern Cosmos app by running one command"
-                to="https://github.com/cosmology-tech/create-cosmos-app"
-                icon={<Createapp />}
-                svgFile="/icons/create-cosmos-app.svg"
-              />
-              <Card
-                title="Chain Registry"
-                description="The npm package for the Official Cosmos chain registry"
-                to="https://github.com/cosmology-tech/chain-registry"
-                icon={<Cosmoskit />}
-                svgFile="/icons/registry.svg"
-              />
-              <Card
-                title="TS Codegen"
-                description="The quickest and easiest way to interact with CosmWasm Contracts"
-                to="https://github.com/CosmWasm/ts-codegen"
-                icon={<Tscodegen />}
-                svgFile="/icons/tscodegen.svg"
-              />
-
-
-
-            </Section>
-          </Section>
-
-
-          <Section title="🛠 Tools">
+          <Section title="Osmosis Chain">
+            <Card
+              featured
+              title="Build and Test Osmosis Source Code"
+              description="The starting point for working on the chain itself — set up your toolchain, compile, and run the test suite."
+              to="/osmosis-core/build"
+              icon={<OsmosisCore />}
+            />
+            <Card
+              title="IDE Setup"
+              description="Recommended IDE setup for developing on Osmosis in Go"
+              to="/osmosis-core/ide-guide"
+              icon={<IDEIcon />}
+            />
             <Card
               title="Osmosisd CLI"
-              description="A command line tool to get things done quick!"
+              description="Install osmosisd to join the network or simple query it."
               to="/osmosis-core/osmosisd"
               icon={<TerminalIcon />}
               svgFile="/icons/cli.svg"
+            />
+            <Card
+              title="Modules"
+              description="Osmosis modules and their respective CLI commands"
+              to="/osmosis-core/modules"
+              icon={<ModulesIcon />}
+              svgFile="/icons/modules.svg"
+            />
+            <Card
+              title="Relaying"
+              description="Relay IBC packets between Osmosis and other chains"
+              to="/osmosis-core/relaying"
+              svgFile="/icons/relayer.svg"
+            />
+            <Card
+              title="Assets"
+              description="Currently supported assets on Osmosis with their corresponding channels and IBC denoms."
+              to="/osmosis-core/asset-info"
+              icon={<AssetIcon />}
+            />
+            <Card
+              title="Key Management"
+              description="Managing keys via CLI and advanced operations such as multisig wallets"
+              to="/osmosis-core/category/keys-management"
+              icon={<KeysIcon />}
+            />
+            <Card
+              title="Transaction Structure"
+              description="Understanding the structure of a transaction on the Osmosis blockchain"
+              to="/osmosis-core/guides/structure"
+              icon={<Transaction />}
+              svgFile="/icons/transaction.svg"
+            />
+            <Card
+              title="Contributing"
+              description="Guidelines to contributing to Osmosis core development."
+              to="/osmosis-core/contributing"
+              icon={<Contribute />}
+              svgFile="/icons/octocat.svg"
+            />
+          </Section>
+
+          <Section title="Osmosis Frontend">
+            <Card
+              featured
+              title="Osmosis Frontend"
+              description="The web interface for app.osmosis.zone — architecture, contributing, and local setup."
+              to="/frontend/osmosis-frontend"
+              svgFile="/icons/osmo.svg"
+            />
+            <Card
+              title="OsmoJS"
+              description="Compose and broadcast Osmosis and Cosmos messages, with all of the proto and amino encoding handled for you."
+              to="/osmojs"
+              icon={<Osmojs />}
+            />
+            <Card
+              title="Osmosis-Labs Math"
+              description="NPM package with math functions related to Osmosis AMM. Useful for estimating state changes to propose reasonable min/max amounts in transactions."
+              to="https://www.npmjs.com/package/@osmosis-labs/math"
+              icon={<Tscodegen />}
+              svgFile="/icons/math.svg"
+            />
+            <Card
+              title="Osmosis-Labs Pools"
+              description="NPM package that defines pool interface and pool routing logic for the Osmosis Dex."
+              to="https://www.npmjs.com/package/@osmosis-labs/pools"
+              icon={<Tscodegen />}
+              svgFile="/icons/pools.svg"
+            />
+            <Card
+              title="Osmosis-Labs Stores"
+              description="NPM package which contains observable stores via mobx data storage framework for the Osmosis front-end"
+              to="https://www.npmjs.com/package/@osmosis-labs/stores"
+              icon={<Tscodegen />}
+              svgFile="/icons/store.svg"
+            />
+          </Section>
+
+          <Section title="Tooling and References">
+            <Card
+              featured
+              title="API Reference"
+              description="The complete RPC, LCD, and gRPC endpoint reference for integrating against Osmosis."
+              to="/api/"
+              icon={<APIReferenceIcon />}
+            />
+            <Card
+              title="Cosmos Kit"
+              description="A wallet adapter for react with mobile WalletConnect support for the Cosmos ecosystem."
+              to="https://github.com/cosmology-tech/cosmos-kit"
+              svgFile="/icons/bag.svg"
+            />
+            <Card
+              title="Telescope"
+              description="TypeScript Transpiler for Cosmos Protobufs. Telescope is used to generate libraries for Cosmos blockchains."
+              to="/telescope"
+              icon={<Telescope />}
+            />
+            <Card
+              title="Create Cosmos App"
+              description="Set up a modern Cosmos app by running one command"
+              to="https://github.com/cosmology-tech/create-cosmos-app"
+              icon={<Createapp />}
+              svgFile="/icons/create-cosmos-app.svg"
+            />
+            <Card
+              title="Chain Registry"
+              description="The npm package for the Official Cosmos chain registry"
+              to="https://github.com/cosmology-tech/chain-registry"
+              icon={<Cosmoskit />}
+              svgFile="/icons/registry.svg"
+            />
+            <Card
+              title="TS Codegen"
+              description="The quickest and easiest way to interact with CosmWasm Contracts"
+              to="https://github.com/CosmWasm/ts-codegen"
+              icon={<Tscodegen />}
+              svgFile="/icons/tscodegen.svg"
             />
             <Card
               title="Cw-orchestrator"
@@ -277,16 +250,6 @@ export default function Homepage() {
               svgFile="/icons/cw-orch.svg"
             />
           </Section>
-
-          <Section title="📜 API Reference">
-            <Card
-              title="API Reference"
-              description="Osmosis RPC and LCD API Reference"
-              to="/api/"
-              icon={<APIReferenceIcon />}
-            />
-          </Section>
-
         </div>
       </div>
     </Layout>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -25,20 +25,13 @@ import {
   HomepageSection as Section,
 } from '../components/HomepageComponents';
 
-/** Opens the Algolia DocSearch modal by dispatching the Ctrl+K shortcut
- *  it already listens for. Docusaurus doesn't expose a public API for this. */
+/** Opens the Algolia DocSearch modal by clicking the existing
+ *  .DocSearch-Button in the navbar. The synthetic Ctrl+K alternative is
+ *  brittle (Mac uses Cmd+K, screen readers cannot see the synthetic event,
+ *  and DocSearch may rebind its listener target between versions). */
 function openSearch(event) {
   event.preventDefault();
-  const keyEvent = new KeyboardEvent('keydown', {
-    key: 'k',
-    code: 'KeyK',
-    keyCode: 75,
-    which: 75,
-    ctrlKey: true,
-    metaKey: true,
-    bubbles: true,
-  });
-  document.dispatchEvent(keyEvent);
+  document.querySelector('.DocSearch-Button')?.click();
 }
 
 export default function Homepage() {
@@ -106,7 +99,7 @@ export default function Homepage() {
             <Card
               featured
               title="Build and Test Osmosis Source Code"
-              description="The starting point for working on the chain itself — set up your toolchain, compile, and run the test suite."
+              description="The starting point for working on the chain itself, set up your toolchain, compile, and run the test suite."
               to="/osmosis-core/build"
               icon={<OsmosisCore />}
             />
@@ -168,7 +161,7 @@ export default function Homepage() {
             <Card
               featured
               title="Osmosis Frontend"
-              description="The web interface for app.osmosis.zone — architecture, contributing, and local setup."
+              description="The web interface for app.osmosis.zone, architecture, contributing, and local setup."
               to="/frontend/osmosis-frontend"
               svgFile="/icons/osmo.svg"
             />


### PR DESCRIPTION
Visually align the docs with app.osmosis.zone while keeping the docs' identity as a technical reference. Three logical commits.

### Commit 1: style(docs): modernize site styling
  CSS tokens, homepage, prose readability, and the contributor convention guide.

  - Remap --docs-color-* values to the osmoverse/wosmongton palette. Page background stays #161616. Borders and surfaces pick up a purple tint.
  - Add Poppins for headings (Inter remains for body, Fira Code for mono). Tighten heading tracking.
  - Bump radii from 4–8px to 10–14px across cards, buttons, and the sidebar collapse toggle. Restyle navbar buttons to match the frontend's <Button mode="primary">. Widen DocSearch input.
  - Drop the Launch Dex, Discord, and Telegram navbar items.
  - Restyle the built-in DocCardList card grid to match HomepageCard. Tone down (but can't remove without swizzling) the generic page emoji prefixes.
  - Hero CTA changed from DyteButton to a styled <a> that opens the search modal via a synthetic Ctrl+K keydown.
  - Add a featured prop to HomepageCard (spans 2 columns, brighter border, larger title). One featured card per section.
  - Flatten the homepage to 4 top-level sections (Learn / Osmosis Chain / Osmosis Frontend / Tooling and References), no hasSubSections wrappers.
  - Cap reading measure at 72ch on flowing prose; code blocks, tables, admonitions, and cards opt out and keep full width.
  - Loosen paragraph leading, tighten heading-to-paragraph rhythm, lede paragraph renders one size up.
  - Document the new "Docs page conventions" in CONTRIBUTING.md: lede paragraphs, breaking walls of text with admonitions, heading density, intro paragraphs above card grids, featured-card rule.

###  Commit 2: docs: rewrite section landing pages

  Replace same-icon spam and hasSubSections wrappers with focused intros and varied iconography. No content links removed.

  - osmosis-core/README.mdx: new lede framing the section as chain-development reference.
  - cosmwasm/README.mdx: lede explaining the local-to-mainnet path. Flatten 4 redundant wrappers. Each card now has a distinct icon (LocalOsmosis, Network, Beaker, Contribute, KeysIcon, Osmojs, Guide) instead of 7 identical CosmWasm flasks. Feature CosmWasm on LocalOsmosis  as the starting card.
  - frontend/README.mdx: fix broken Chain icon import. Rename "Frontend SDK Libraries & Utilities" to "Cosmos Ecosystem" (the actual distinction). Lean on per-card SVG files instead of duplicate Tscodegen icons. Feature Osmosis Frontend.
  - osmosis-outpost/README.md: tighten the wall-of-text lede to two scannable sentences. Pull the call-out into a :::tip admonition. Promote the 📡/📖/📞 subsections to h2.
  - beaker/README.md: strip the bare-HTML p align="center" badge block at the top, replace with a one-sentence lede and a :::info admonition linking to the GitHub source. TOC and anchored content below are untouched.

###  Commit 3: docs(overview): add description frontmatter and tighten section ledes

  Every page under docs/overview/ now has a description frontmatter field, so the auto-generated DocCardList cards render with intentional one-sentence summaries instead of truncated first paragraphs.

  - 34 pages touched across educate, features, integrate, validate, plus external_projects and the endpoints landing.
  - Rewrote the boilerplate "The guides on this page will explain..." intros on each section landing page. Each now opens with a lede that frames what's in the cards below.

 ## Test plan

- [x] yarn build succeeds (verified locally before commit).
- [ ] Visual check on / (homepage): hero, gradient CTA, 4 sections, featured cards.
- [ ] Visual check on a docs page (e.g. /osmosis-core/build): Poppins headings, wosmongton purple links, purple-tinted code blocks, 72ch measure.
- [ ] Visual check on the section landings: /cosmwasm, /frontend, /osmosis-outpost, /beaker.
- [ ] Visual check on the auto-generated index pages: /overview/integrate, /overview/educate, /overview/validate. Cards  should match the homepage card style and pick up the new descriptions.
- [ ] Light-mode toggle works in both palettes.
- [ ] /api/ (Stoplight Elements) still renders correctly.
- [ ] Click "Get Started" on the homepage. Search modal opens.
- [ ] Hard refresh: confirm Poppins loads from Google Fonts without FOUT.