### PR TITLE
feat(docs): add Orderbook integration page

### DIFF
--- a/docs/overview/integrate/orderbook.md
+++ b/docs/overview/integrate/orderbook.md
@@ -8,21 +8,19 @@ The Osmosis orderbook is a CosmWasm contract that implements a sumtree-backed li
 
 This page covers the integration surface: how to discover live orderbook pools, place and cancel orders, query state, and connect to the orderbook from a routing layer such as SQS.
 
-For the high-level mechanism (constant-time limit placements, log-time cancellations, tick math), see the [sumtree-orderbook repository](https://github.com/osmosis-labs/orderbook).
-
-## Where the orderbook lives on-chain
+## Where the orderbook lives onchain
 
 Each orderbook market is a separately instantiated CosmWasm contract. Discovery options:
 
 - **SQS**: the [`/pools`](https://docs.osmosis.zone/overview/integrate/sqs) endpoint returns orderbook pools alongside CFMM and concentrated-liquidity pools. This is the recommended path for any frontend or bot that needs to know the active orderbook markets.
-- **On-chain via cosmwasm-pool module**: orderbooks are registered as `x/cosmwasmpool` pool types; their pool IDs are addressable through `osmosis.poolmanager.v1beta1.Query.Pool` like any other pool.
+- **Onchain via cosmwasm-pool module**: orderbooks are registered as `x/cosmwasmpool` pool types; their pool IDs are addressable through `osmosis.poolmanager.v1beta1.Query.Pool` like any other pool.
 - **Direct contract address**: once you know an orderbook's contract address you can talk to it with `osmosisd query wasm contract-state smart <contract-addr> '<query-json>'`.
 
-Code IDs for the canonical orderbook contract are governance-managed and may change with each upgrade. Read the live SQS pools list or chain-state at submission time rather than hardcoding a code ID in client code.
+Code IDs for the canonical orderbook contract are governance-managed and may change. Read the live SQS pools list or chain-state at submission time rather than hardcoding a code ID in client code.
 
 ## Instantiation parameters
 
-When a new orderbook market is instantiated, the parameters are:
+When a new orderbook market is instantiated, the parameters follow the format:
 
 ```json
 {
@@ -43,7 +41,7 @@ osmosisd tx wasm execute <ORDERBOOK_CONTRACT_ADDR> '{
     "tick_id": 123456,
     "order_direction": "bid",
     "quantity": "1000000",
-    "claim_bounty": "0.001"
+    "claim_bounty": "0.0001"
   }
 }' --amount "1000000uusdc" --from <KEY> --gas auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
 ```
@@ -53,7 +51,7 @@ Fields:
 - `tick_id`: signed integer addressing the price tick at which to rest the order. Tick semantics match the CL convention; the corresponding price is derivable from the tick math in [`orderbook.rs`](https://github.com/osmosis-labs/orderbook/blob/main/contracts/sumtree-orderbook/src/orderbook.rs).
 - `order_direction`: `"bid"` (offering quote to buy base) or `"ask"` (offering base to sell into quote).
 - `quantity`: an integer string. For bids this is the quote-denom amount the order will spend if fully filled at `tick_id`; for asks it is the base-denom amount being offered.
-- `claim_bounty` (optional, decimal string): the fraction of the order's payout the placer is willing to pay any third party that claims the filled order on their behalf. Enables the claimbot economic flywheel described below.
+- `claim_bounty` (optional, decimal string): the fraction of the order's payout the placer is willing to pay any third party that claims the filled order on their behalf. Enables the claimbot economic flywheel described below. The Osmosis frontend currently sets this to `0.0001` (0.01%) for every limit order it places.
 
 The `--amount` flag must equal `quantity` of the appropriate denom for the side of the order (quote for bids, base for asks). The contract returns the assigned `order_id` for the placed order in the execution response.
 
@@ -101,7 +99,7 @@ The contract exposes both CosmWasm-pool-compatible queries (for routing) and ord
 These match the interface that the `x/cosmwasmpool` module expects so the orderbook can participate in chain-level routing:
 
 - `spot_price { quote_asset_denom, base_asset_denom }`: current best price.
-- `calc_out_amt_given_in { token_in, token_out_denom, swap_fee }`: quote a swap of an exact input.
+- `calc_out_amount_given_in { token_in, token_out_denom, swap_fee }`: quote a swap of an exact input.
 - `get_total_pool_liquidity {}`: pool's aggregate liquidity in both denoms.
 - `get_swap_fee {}`: the contract's swap fee parameter.
 
@@ -110,12 +108,12 @@ These match the interface that the `x/cosmwasmpool` module expects so the orderb
 For book inspection and order lookup:
 
 - `denoms {}`: returns the configured `base_denom` and `quote_denom`.
-- `orderbook_state {}`: the full `Orderbook` struct including `next_bid_tick`, `next_ask_tick`, and active flag.
+- `orderbook_state {}`: returns the orderbook's denoms and the current tick cursors as flat fields: `quote_denom`, `base_denom`, `current_tick`, `next_bid_tick`, `next_ask_tick`.
 - `is_active {}`: returns `true` if the contract accepts new orders.
 - `all_ticks { start_from, end_at, limit }`: paginated list of all ticks with state. Used by SQS to build its in-memory tick representation.
 - `ticks_by_id { tick_ids }`: batch fetch specific ticks.
-- `orders_by_owner { owner, start_from, end_at, limit }`: every order placed by an address.
-- `orders_by_tick { tick_id, start_from, end_at, limit }`: every order resting at a tick.
+- `orders_by_owner { owner, start_from, end_at, limit }`: every order placed by an address. Returns `{ orders, count }` where `count` is the number of orders in the response (useful for paginating).
+- `orders_by_tick { tick_id, start_from, end_at, limit }`: every order resting at a tick. Returns `{ orders, count }` where `count` is the number of orders in the response.
 - `get_maker_fee {}`: the configured maker fee.
 - `get_unrealized_cancels { tick_ids }`: for advanced users tracking realized-vs-unrealized accounting.
 
@@ -123,22 +121,72 @@ For book inspection and order lookup:
 
 SQS implements a dedicated routable pool type for orderbooks in [`routable_cw_orderbook_pool.go`](https://github.com/osmosis-labs/sqs/blob/main/router/usecase/pools/routable_cw_orderbook_pool.go). This means an end-user swap routed through `/router/quote` can transparently use orderbook liquidity alongside CFMM and CL pools.
 
-Operationally this means:
+### Discovery
+
+SQS recognises a CosmWasm pool as an orderbook by matching its `code_id` against a configured list (`OrderbookCodeIDs` in [`domain/config.go`](https://github.com/osmosis-labs/sqs/blob/main/domain/config.go)). Once a market is instantiated on chain from a recognised code id, SQS picks it up automatically as soon as it has ingested the pool state, without any operator action.
+
+When multiple orderbook contracts exist for the same base/quote pair, SQS continuously tracks which one has the highest liquidity cap and promotes it to "canonical" for that pair. Two dedicated endpoints expose this view:
+
+- `GET /pools/canonical-orderbook?base=<denom>&quote=<denom>` returns the canonical orderbook pool id for a single pair.
+- `GET /pools/canonical-orderbooks` returns the canonical orderbook for every supported pair.
+
+The non-canonical orderbooks still appear in `/pools` and remain reachable through direct-quote queries; they just are not the default routing target.
+
+### Quote and fill flow
 
 - A swap quote returned by SQS may include an orderbook pool in its route. The pool entry's `type` indicates the pool kind.
-- The orderbook contract is queried with `calc_out_amt_given_in` to price the swap, and the actual fill happens via a standard `osmosis.poolmanager.v1beta1.MsgSwapExactAmountIn` against the orderbook's pool id.
-- The router treats the orderbook like any other pool from the integrator's perspective; you do not need to construct a `place_limit` execute message yourself when swapping.
+- SQS quotes orderbook swaps in-process. It walks the orderbook's ticks in Go and prices each tick locally via `TickToPrice`, using state ingested from the chain. It does not call `calc_out_amount_given_in` on the contract at quote time.
+- The actual fill happens via a standard `osmosis.poolmanager.v1beta1.MsgSwapExactAmountIn` against the orderbook's pool id, not a CosmWasm execute message. The router treats the orderbook like any other pool from the integrator's perspective; you do not need to construct a `place_limit` execute message yourself when swapping.
 
-If you operate a new orderbook market and want it surfaced in SQS routing, the contract code id needs to be registered in the SQS deployment. Coordinate with the SQS team (see [Adding a custom CosmWasm pool to SQS](https://docs.osmosis.zone/overview/integrate/sqs#adding-a-custom-cosmwasm-pool-to-sqs)).
+### When a new orderbook code id needs registering
+
+A brand-new orderbook *contract instance* spawned from an already-registered code id needs no SQS action. A brand-new *code id* (a new orderbook contract version, typically tied to a chain upgrade) does: it has to be added to `OrderbookCodeIDs` in the SQS deployment config and the service redeployed. See [Adding a custom CosmWasm pool to SQS](https://docs.osmosis.zone/overview/integrate/sqs#adding-a-custom-cosmwasm-pool-to-sqs).
 
 ## Admin and moderator messages
 
-The contract has a two-tier permissioned interface for administrative operations:
+The contract has two privileged roles, each with its own offer-and-claim transfer flow. All admin and moderator messages are sent through the `auth` execute namespace, for example:
 
-- **Admin**: can transfer adminship, set the maker fee, set the maker-fee recipient, and renounce. Adminship transfers go through a two-step `transfer_admin` then `claim_admin` flow with a separate `cancel_admin_transfer` and `reject_admin_transfer` for safety.
-- **Moderator**: can pause the contract via `set_active { active: false }` to stop new orders. Used in incident response.
+```bash
+osmosisd tx wasm execute <ORDERBOOK_CONTRACT_ADDR> '{
+  "auth": { "set_active": { "active": false } }
+}' --from <KEY>
+```
 
-Both roles are settable via the `auth` execute submessage namespace. See [`msg.rs`](https://github.com/osmosis-labs/orderbook/blob/main/contracts/sumtree-orderbook/src/msg.rs) for the full `AuthExecuteMsg` and `AuthQueryMsg` enums.
+The contract sets its admin and moderator at instantiation and are hardcoded:
+- **Admin** is set to `osmo10d07y265gmmuvt4z0w9aw880jnsr700jjeq4qp`, the Osmosis governance module account. Adminship can only be transferred by an onchain governance proposal that executes `auth { transfer_admin }` followed by the recipient calling `claim_admin`.
+- **Moderator** is set to `osmo1peuxfjj66n2qt2v5jmqlvzz8neakjgduez7vttvemw58uug6546sr60ngl`, a DAODAO subDAO designated as a circuit breaker.
+
+### Admin
+
+Permissions verified by [`ensure_is_admin`](https://github.com/osmosis-labs/orderbook/blob/main/contracts/sumtree-orderbook/src/auth.rs) in `auth.rs`. Admin-only execute messages:
+
+- `transfer_admin { new_admin }`: writes the address into the admin-offer slot. Does not change the active admin.
+- `cancel_admin_transfer {}`: admin clears their own pending offer.
+- `renounce_adminship {}`: removes the admin entirely. After this the contract has no admin.
+- `offer_moderator { new_moderator }`: writes the address into the moderator-offer slot. The offered address still has to claim it (see below).
+- `set_maker_fee { fee }`: updates the contract's maker fee. Despite living in the enum's "Shared messages" section, the dispatcher enforces admin-only.
+- `set_maker_fee_recipient { recipient }`: updates the maker-fee recipient. Also admin-only despite the enum categorisation.
+
+Messages callable by the *address offered admin*, not the current admin:
+
+- `claim_admin {}`: the offered address accepts the offer and becomes admin.
+- `reject_admin_transfer {}`: the offered address rejects the offer.
+
+### Moderator
+
+The moderator role exists for incident response; it can pause new orders without giving the holder economic privileges over the orderbook.
+
+- `set_active { active }`: pause or unpause the contract. This is the only "shared" message that actually accepts both admin and moderator (`ensure_is_admin_or_moderator`).
+- `claim_moderator {}`: the address offered moderatorship accepts the offer and becomes the moderator.
+- `reject_moderator_offer {}`: the offered address rejects.
+
+Note that moderator transfer is one-sided: the admin offers via `offer_moderator`, and only the offered address can accept or reject. There is no `cancel_moderator_offer` message; the admin can overwrite a pending offer by calling `offer_moderator` again.
+
+### Auth queries
+
+`AuthQueryMsg` exposes four read-only queries through the `auth` query namespace: `admin`, `admin_offer`, `moderator`, `moderator_offer`. Each returns the current address holding that slot (or `null` if empty).
+
+See [`msg.rs`](https://github.com/osmosis-labs/orderbook/blob/main/contracts/sumtree-orderbook/src/msg.rs) for the complete `AuthExecuteMsg` and `AuthQueryMsg` definitions and [`auth.rs`](https://github.com/osmosis-labs/orderbook/blob/main/contracts/sumtree-orderbook/src/auth.rs) for the dispatchers.
 
 ## Repository references
 

--- a/docs/overview/integrate/orderbook.md
+++ b/docs/overview/integrate/orderbook.md
@@ -1,0 +1,147 @@
+---
+sidebar_position: 14
+---
+
+# Orderbook
+
+The Osmosis orderbook is a CosmWasm contract that implements a sumtree-backed limit-order venue. Each market is its own contract instance with one quote denom and one base denom, and the contract participates in the chain's pool routing graph alongside CFMM and concentrated-liquidity pools.
+
+This page covers the integration surface: how to discover live orderbook pools, place and cancel orders, query state, and connect to the orderbook from a routing layer such as SQS.
+
+For the high-level mechanism (constant-time limit placements, log-time cancellations, tick math), see the [sumtree-orderbook repository](https://github.com/osmosis-labs/orderbook).
+
+## Where the orderbook lives on-chain
+
+Each orderbook market is a separately instantiated CosmWasm contract. Discovery options:
+
+- **SQS**: the [`/pools`](https://docs.osmosis.zone/overview/integrate/sqs) endpoint returns orderbook pools alongside CFMM and concentrated-liquidity pools. This is the recommended path for any frontend or bot that needs to know the active orderbook markets.
+- **On-chain via cosmwasm-pool module**: orderbooks are registered as `x/cosmwasmpool` pool types; their pool IDs are addressable through `osmosis.poolmanager.v1beta1.Query.Pool` like any other pool.
+- **Direct contract address**: once you know an orderbook's contract address you can talk to it with `osmosisd query wasm contract-state smart <contract-addr> '<query-json>'`.
+
+Code IDs for the canonical orderbook contract are governance-managed and may change with each upgrade. Read the live SQS pools list or chain-state at submission time rather than hardcoding a code ID in client code.
+
+## Instantiation parameters
+
+When a new orderbook market is instantiated, the parameters are:
+
+```json
+{
+  "base_denom": "uatom",
+  "quote_denom": "uusdc"
+}
+```
+
+The quote denom is the asset that prices are expressed in; the base denom is the asset being bought or sold. A single orderbook contract pairs exactly one quote denom against one base denom. To support a different pair, instantiate a new contract from the same code ID.
+
+## Placing an order
+
+Limit orders are placed with `ExecuteMsg::PlaceLimit`:
+
+```bash
+osmosisd tx wasm execute <ORDERBOOK_CONTRACT_ADDR> '{
+  "place_limit": {
+    "tick_id": 123456,
+    "order_direction": "bid",
+    "quantity": "1000000",
+    "claim_bounty": "0.001"
+  }
+}' --amount "1000000uusdc" --from <KEY> --gas auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+```
+
+Fields:
+
+- `tick_id`: signed integer addressing the price tick at which to rest the order. Tick semantics match the CL convention; the corresponding price is derivable from the tick math in [`orderbook.rs`](https://github.com/osmosis-labs/orderbook/blob/main/contracts/sumtree-orderbook/src/orderbook.rs).
+- `order_direction`: `"bid"` (offering quote to buy base) or `"ask"` (offering base to sell into quote).
+- `quantity`: an integer string. For bids this is the quote-denom amount the order will spend if fully filled at `tick_id`; for asks it is the base-denom amount being offered.
+- `claim_bounty` (optional, decimal string): the fraction of the order's payout the placer is willing to pay any third party that claims the filled order on their behalf. Enables the claimbot economic flywheel described below.
+
+The `--amount` flag must equal `quantity` of the appropriate denom for the side of the order (quote for bids, base for asks). The contract returns the assigned `order_id` for the placed order in the execution response.
+
+## Cancelling an order
+
+```bash
+osmosisd tx wasm execute <ORDERBOOK_CONTRACT_ADDR> '{
+  "cancel_limit": {
+    "tick_id": 123456,
+    "order_id": 42
+  }
+}' --from <KEY> --gas auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+```
+
+Only the original order placer can cancel. Cancelling a partially-filled order returns the unfilled remainder; the filled portion remains claimable.
+
+## Claiming filled orders
+
+Once an order is fully filled, it remains in the contract until claimed. The original placer can claim it themselves:
+
+```bash
+osmosisd tx wasm execute <ORDERBOOK_CONTRACT_ADDR> '{
+  "claim_limit": { "tick_id": 123456, "order_id": 42 }
+}' --from <KEY>
+```
+
+Or a third party can claim on the placer's behalf via `batch_claim`, capturing the `claim_bounty` if one was set when the order was placed:
+
+```bash
+osmosisd tx wasm execute <ORDERBOOK_CONTRACT_ADDR> '{
+  "batch_claim": {
+    "orders": [[123456, 42], [123457, 43]]
+  }
+}' --from <KEY>
+```
+
+The `batch_claim` flow is what [orderbook-claimbot](https://github.com/osmosis-labs/orderbook-claimbot) automates: scan ticks past `next_bid_tick` and before `next_ask_tick`, push their order ids onto a queue, batch up to 100 per transaction, and capture any configured bounty as revenue. The repo's README is the canonical reference for the scanning logic and architecture.
+
+## Querying state
+
+The contract exposes both CosmWasm-pool-compatible queries (for routing) and orderbook-specific queries (for UIs and bots). Run them with `osmosisd query wasm contract-state smart <contract-addr> '<query-json>'`.
+
+### Pool-compatible queries
+
+These match the interface that the `x/cosmwasmpool` module expects so the orderbook can participate in chain-level routing:
+
+- `spot_price { quote_asset_denom, base_asset_denom }`: current best price.
+- `calc_out_amt_given_in { token_in, token_out_denom, swap_fee }`: quote a swap of an exact input.
+- `get_total_pool_liquidity {}`: pool's aggregate liquidity in both denoms.
+- `get_swap_fee {}`: the contract's swap fee parameter.
+
+### Orderbook-specific queries
+
+For book inspection and order lookup:
+
+- `denoms {}`: returns the configured `base_denom` and `quote_denom`.
+- `orderbook_state {}`: the full `Orderbook` struct including `next_bid_tick`, `next_ask_tick`, and active flag.
+- `is_active {}`: returns `true` if the contract accepts new orders.
+- `all_ticks { start_from, end_at, limit }`: paginated list of all ticks with state. Used by SQS to build its in-memory tick representation.
+- `ticks_by_id { tick_ids }`: batch fetch specific ticks.
+- `orders_by_owner { owner, start_from, end_at, limit }`: every order placed by an address.
+- `orders_by_tick { tick_id, start_from, end_at, limit }`: every order resting at a tick.
+- `get_maker_fee {}`: the configured maker fee.
+- `get_unrealized_cancels { tick_ids }`: for advanced users tracking realized-vs-unrealized accounting.
+
+## Routing through SQS
+
+SQS implements a dedicated routable pool type for orderbooks in [`routable_cw_orderbook_pool.go`](https://github.com/osmosis-labs/sqs/blob/main/router/usecase/pools/routable_cw_orderbook_pool.go). This means an end-user swap routed through `/router/quote` can transparently use orderbook liquidity alongside CFMM and CL pools.
+
+Operationally this means:
+
+- A swap quote returned by SQS may include an orderbook pool in its route. The pool entry's `type` indicates the pool kind.
+- The orderbook contract is queried with `calc_out_amt_given_in` to price the swap, and the actual fill happens via a standard `osmosis.poolmanager.v1beta1.MsgSwapExactAmountIn` against the orderbook's pool id.
+- The router treats the orderbook like any other pool from the integrator's perspective; you do not need to construct a `place_limit` execute message yourself when swapping.
+
+If you operate a new orderbook market and want it surfaced in SQS routing, the contract code id needs to be registered in the SQS deployment. Coordinate with the SQS team (see [Adding a custom CosmWasm pool to SQS](https://docs.osmosis.zone/overview/integrate/sqs#adding-a-custom-cosmwasm-pool-to-sqs)).
+
+## Admin and moderator messages
+
+The contract has a two-tier permissioned interface for administrative operations:
+
+- **Admin**: can transfer adminship, set the maker fee, set the maker-fee recipient, and renounce. Adminship transfers go through a two-step `transfer_admin` then `claim_admin` flow with a separate `cancel_admin_transfer` and `reject_admin_transfer` for safety.
+- **Moderator**: can pause the contract via `set_active { active: false }` to stop new orders. Used in incident response.
+
+Both roles are settable via the `auth` execute submessage namespace. See [`msg.rs`](https://github.com/osmosis-labs/orderbook/blob/main/contracts/sumtree-orderbook/src/msg.rs) for the full `AuthExecuteMsg` and `AuthQueryMsg` enums.
+
+## Repository references
+
+- Contract: [`osmosis-labs/orderbook`](https://github.com/osmosis-labs/orderbook). Cargo workspace, single contract under `contracts/sumtree-orderbook/`.
+- Claimbot: [`osmosis-labs/orderbook-claimbot`](https://github.com/osmosis-labs/orderbook-claimbot). Producer-consumer scanner that batches `batch_claim` transactions.
+- SQS routing: [`router/usecase/pools/routable_cw_orderbook_pool.go`](https://github.com/osmosis-labs/sqs/blob/main/router/usecase/pools/routable_cw_orderbook_pool.go) in the SQS repo.

--- a/docs/overview/integrate/orderbook.md
+++ b/docs/overview/integrate/orderbook.md
@@ -108,30 +108,95 @@ The `batch_claim` flow is what [orderbook-claimbot](https://github.com/osmosis-l
 
 ## Querying state
 
-The contract exposes both CosmWasm-pool-compatible queries (for routing) and orderbook-specific queries (for UIs and bots). Run them with `osmosisd query wasm contract-state smart <contract-addr> '<query-json>'`.
+The contract exposes both CosmWasm-pool-compatible queries (for routing) and orderbook-specific queries (for UIs and bots). All are read-only smart queries:
+
+```bash
+osmosisd query wasm contract-state smart <CONTRACT_ADDR> '<QUERY_JSON>'
+```
 
 ### Pool-compatible queries
 
-These match the interface that the `x/cosmwasmpool` module expects so the orderbook can participate in chain-level routing:
+These match the interface that the `x/cosmwasmpool` module expects so the orderbook can participate in chain-level routing.
 
-- `spot_price { quote_asset_denom, base_asset_denom }`: current best price.
-- `calc_out_amount_given_in { token_in, token_out_denom, swap_fee }`: quote a swap of an exact input.
-- `get_total_pool_liquidity {}`: pool's aggregate liquidity in both denoms.
-- `get_swap_fee {}`: the contract's swap fee parameter.
+```json
+{ "spot_price": { "quote_asset_denom": "<denom>", "base_asset_denom": "<denom>" } }
+```
+
+Current best price.
+
+```json
+{ "calc_out_amount_given_in": { "token_in": { "denom": "<denom>", "amount": "<amount>" }, "token_out_denom": "<denom>", "swap_fee": "0" } }
+```
+
+Quote a swap of an exact input.
+
+```json
+{ "get_total_pool_liquidity": {} }
+```
+
+The pool's aggregate liquidity in both denoms.
+
+```json
+{ "get_swap_fee": {} }
+```
+
+The contract's swap fee parameter.
 
 ### Orderbook-specific queries
 
-For book inspection and order lookup:
+```json
+{ "denoms": {} }
+```
 
-- `denoms {}`: returns the configured `base_denom` and `quote_denom`.
-- `orderbook_state {}`: returns the orderbook's denoms and the current tick cursors as flat fields: `quote_denom`, `base_denom`, `current_tick`, `next_bid_tick`, `next_ask_tick`.
-- `is_active {}`: returns `true` if the contract accepts new orders.
-- `all_ticks { start_from, end_at, limit }`: paginated list of all ticks with state. Used by SQS to build its in-memory tick representation.
-- `ticks_by_id { tick_ids }`: batch fetch specific ticks.
-- `orders_by_owner { owner, start_from, end_at, limit }`: every order placed by an address. `start_from` and `end_at` are `[tick_id, order_id]` tuples (inclusive); `limit` defaults to 100. Returns `{ orders, count }` where `count` is the number of orders in the response (useful for paginating).
-- `orders_by_tick { tick_id, start_from, end_at, limit }`: every order resting at a tick. Returns `{ orders, count }` where `count` is the number of orders in the response.
-- `get_maker_fee {}`: the configured maker fee.
-- `get_unrealized_cancels { tick_ids }`: for advanced users tracking realized-vs-unrealized accounting.
+The configured `base_denom` and `quote_denom`.
+
+```json
+{ "orderbook_state": {} }
+```
+
+The orderbook's denoms and current tick cursors as flat fields: `quote_denom`, `base_denom`, `current_tick`, `next_bid_tick`, `next_ask_tick`.
+
+```json
+{ "is_active": {} }
+```
+
+Returns `true` if the contract accepts new orders.
+
+```json
+{ "all_ticks": { "start_from": "<tick_id>", "end_at": "<tick_id>", "limit": 100 } }
+```
+
+Paginated list of all ticks with state. Used by SQS to build its in-memory tick representation.
+
+```json
+{ "ticks_by_id": { "tick_ids": ["<tick_id>"] } }
+```
+
+Batch fetch specific ticks.
+
+```json
+{ "orders_by_owner": { "owner": "<address>", "start_from": ["<tick_id>", "<order_id>"], "end_at": ["<tick_id>", "<order_id>"], "limit": 100 } }
+```
+
+Every order placed by an address. `start_from` and `end_at` are `[tick_id, order_id]` tuples (inclusive); `limit` defaults to 100. Returns `{ orders, count }` where `count` is the number of orders in the response (useful for paginating).
+
+```json
+{ "orders_by_tick": { "tick_id": "<tick_id>", "start_from": "<order_id>", "end_at": "<order_id>", "limit": 100 } }
+```
+
+Every order resting at a tick. Returns `{ orders, count }` where `count` is the number of orders in the response.
+
+```json
+{ "get_maker_fee": {} }
+```
+
+The configured maker fee.
+
+```json
+{ "get_unrealized_cancels": { "tick_ids": ["<tick_id>"] } }
+```
+
+For advanced users tracking realized-vs-unrealized accounting.
 
 ## Routing through SQS
 

--- a/docs/overview/integrate/orderbook.md
+++ b/docs/overview/integrate/orderbook.md
@@ -4,7 +4,7 @@ sidebar_position: 14
 
 # Orderbook
 
-The Osmosis orderbook is a CosmWasm contract that implements a sumtree-backed limit-order venue. Each market is its own contract instance with one quote denom and one base denom, and the contract participates in the chain's pool routing graph alongside CFMM and concentrated-liquidity pools.
+The Osmosis orderbook is a CosmWasm contract that implements a sumtree-backed limit-order venue. Each market is its own contract instance with one quote denom and one base denom, and the contract participates in the chain's pool routing graph alongside [CFMM](/osmosis-core/modules/gamm) (Balancer-style weighted and stableswap) and [concentrated liquidity](/overview/features/concentrated-liquidity) pools.
 
 This page covers the integration surface: how to discover live orderbook pools, place and cancel orders, query state, and connect to the orderbook from a routing layer such as SQS.
 
@@ -12,9 +12,7 @@ This page covers the integration surface: how to discover live orderbook pools, 
 
 Each orderbook market is a separately instantiated CosmWasm contract. Discovery options:
 
-{/* TODO(after #310 merges): relativise the SQS links on this page from
-    https://docs.osmosis.zone/overview/integrate/sqs to ./sqs. */}
-- **SQS**: the [`/pools`](https://docs.osmosis.zone/overview/integrate/sqs) endpoint returns orderbook pools alongside CFMM and concentrated-liquidity pools. This is the recommended path for any frontend or bot that needs to know the active orderbook markets.
+- **SQS**: the [`/pools`](./sqs) endpoint returns orderbook pools alongside CFMM and concentrated liquidity pools. This is the recommended path for any frontend or bot that needs to know the active orderbook markets.
 - **Onchain via cosmwasm-pool module**: orderbooks are registered as `x/cosmwasmpool` pool types; their pool IDs are addressable through `osmosis.poolmanager.v1beta1.Query.Pool` like any other pool.
 - **Direct contract address**: once you know an orderbook's contract address you can talk to it with `osmosisd query wasm contract-state smart <contract-addr> '<query-json>'`.
 
@@ -45,8 +43,10 @@ osmosisd tx wasm execute <ORDERBOOK_CONTRACT_ADDR> '{
     "quantity": "1000000",
     "claim_bounty": "0.0001"
   }
-}' --amount "1000000uusdc" --from <KEY> --gas auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+}' --amount "1000000uusdc" --from <KEY> --gas auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
+
+The `--gas-prices` here is illustrative. Osmosis sets a dynamic minimum gas price via its [EIP-1559 fee market](/overview/features/eip-1559), so query the current base fee (`osmosisd query txfees base-fee` or the `osmosis/txfees/v1beta1/cur_eip_base_fee` LCD endpoint) and pass a value at or above it.
 
 Fields:
 
@@ -65,7 +65,7 @@ osmosisd tx wasm execute <ORDERBOOK_CONTRACT_ADDR> '{
     "tick_id": 123456,
     "order_id": 42
   }
-}' --from <KEY> --gas auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+}' --from <KEY> --gas auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 Only the original order placer can cancel. Cancellation is all-or-nothing: the contract rejects with `CancelFilledOrder` if any portion of the order has been filled. To recover a partial fill, claim the filled portion first; the unfilled remainder cannot be cancelled separately under the current contract.
@@ -142,7 +142,7 @@ The non-canonical orderbooks still appear in `/pools` and remain reachable throu
 
 ### When a new orderbook code id needs registering
 
-A brand-new orderbook *contract instance* spawned from an already-registered code id needs no SQS action. A brand-new *code id* (a new orderbook contract version, typically tied to a chain upgrade) does: it has to be added to `OrderbookCodeIDs` in the SQS deployment config and the service redeployed. See [Adding a custom CosmWasm pool to SQS](https://docs.osmosis.zone/overview/integrate/sqs#adding-a-custom-cosmwasm-pool-to-sqs).
+A brand-new orderbook *contract instance* spawned from an already-registered code id needs no SQS action. A brand-new *code id* (a new orderbook contract version, typically tied to a chain upgrade) does: it has to be added to `OrderbookCodeIDs` in the SQS deployment config and the service redeployed. See [Adding a custom CosmWasm pool to SQS](./sqs#adding-a-custom-cosmwasm-pool-to-sqs).
 
 ## Admin and moderator messages
 

--- a/docs/overview/integrate/orderbook.md
+++ b/docs/overview/integrate/orderbook.md
@@ -16,20 +16,34 @@ Each orderbook market is a separately instantiated CosmWasm contract. Discovery 
 - **Onchain via cosmwasm-pool module**: orderbooks are registered as `x/cosmwasmpool` pool types; their pool IDs are addressable through `osmosis.poolmanager.v1beta1.Query.Pool` like any other pool.
 - **Direct contract address**: once you know an orderbook's contract address you can talk to it with `osmosisd query wasm contract-state smart <contract-addr> '<query-json>'`.
 
-Code IDs for the canonical orderbook contract are governance-managed and may change. Read the live SQS pools list or chain-state at submission time rather than hardcoding a code ID in client code.
+### Finding the current orderbook code id
 
-## Instantiation parameters
+The orderbook code id is whitelisted by governance and can change across contract versions, so query it at submission time rather than hardcoding it. Two ways:
 
-When a new orderbook market is instantiated, the parameters follow the format:
+```bash
+# Every code id whitelisted as a cosmwasm pool (the orderbook id is one of these)
+osmosisd q cosmwasmpool params
 
-```json
-{
-  "base_denom": "uatom",
-  "quote_denom": "uusdc"
-}
+# The code id backing a specific orderbook pool, via SQS
+curl -s "https://sqs.osmosis.zone/pools?IDs=1930" | jq '.[0].chain_model.code_id'
 ```
 
-The quote denom is the asset that prices are expressed in; the base denom is the asset being bought or sold. A single orderbook contract pairs exactly one quote denom against one base denom. To support a different pair, instantiate a new contract from the same code ID.
+Read the live whitelist or SQS pools list rather than hardcoding a code id in client code.
+
+## Creating a market
+
+Creating a new orderbook market is **permissionless**: anyone can instantiate a market for a new base/quote pair from an already-whitelisted code id, without a governance proposal. (Only whitelisting a *new* code id is governance-gated, see [below](#when-a-new-orderbook-code-id-needs-registering).) Markets are instantiated through the `x/cosmwasmpool` module, not a raw `wasm instantiate`:
+
+```bash
+osmosisd tx cosmwasmpool create-pool <CODE_ID> '{
+  "base_denom": "uatom",
+  "quote_denom": "uusdc"
+}' --from <KEY> --gas auto --gas-prices 0.05uosmo --gas-adjustment 1.3
+```
+
+The quote denom is the asset that prices are expressed in; the base denom is the asset being bought or sold. A single orderbook contract pairs exactly one quote denom against one base denom; to support a different pair, create another market from the same code id. The `--gas-prices` value is illustrative, see the note under [Placing an order](#placing-an-order) for the dynamic fee.
+
+For the full pool-creation walkthrough (creation fee, denom-casing caveats, the `osmosisd` version requirement), see the [Pool Setup guide](./pool-setup).
 
 ## Placing an order
 

--- a/docs/overview/integrate/orderbook.md
+++ b/docs/overview/integrate/orderbook.md
@@ -142,7 +142,9 @@ The non-canonical orderbooks still appear in `/pools` and remain reachable throu
 
 ### When a new orderbook code id needs registering
 
-A brand-new orderbook *contract instance* spawned from an already-registered code id needs no SQS action. A brand-new *code id* (a new orderbook contract version, typically tied to a chain upgrade) does: it has to be added to `OrderbookCodeIDs` in the SQS deployment config and the service redeployed. See [Adding a custom CosmWasm pool to SQS](./sqs#adding-a-custom-cosmwasm-pool-to-sqs).
+A brand-new orderbook *contract instance* spawned from an already-registered code id needs no SQS action. 
+
+A brand-new *code id* (a new orderbook contract version, uploaded and whitelisted as a cosmwasm pool ID via chain governance) does: it has to be added to `OrderbookCodeIDs` in the SQS deployment config and the service redeployed.
 
 ## Admin and moderator messages
 

--- a/docs/overview/integrate/orderbook.md
+++ b/docs/overview/integrate/orderbook.md
@@ -12,6 +12,8 @@ This page covers the integration surface: how to discover live orderbook pools, 
 
 Each orderbook market is a separately instantiated CosmWasm contract. Discovery options:
 
+{/* TODO(after #310 merges): relativise the SQS links on this page from
+    https://docs.osmosis.zone/overview/integrate/sqs to ./sqs. */}
 - **SQS**: the [`/pools`](https://docs.osmosis.zone/overview/integrate/sqs) endpoint returns orderbook pools alongside CFMM and concentrated-liquidity pools. This is the recommended path for any frontend or bot that needs to know the active orderbook markets.
 - **Onchain via cosmwasm-pool module**: orderbooks are registered as `x/cosmwasmpool` pool types; their pool IDs are addressable through `osmosis.poolmanager.v1beta1.Query.Pool` like any other pool.
 - **Direct contract address**: once you know an orderbook's contract address you can talk to it with `osmosisd query wasm contract-state smart <contract-addr> '<query-json>'`.
@@ -50,8 +52,8 @@ Fields:
 
 - `tick_id`: signed integer addressing the price tick at which to rest the order. Tick semantics match the CL convention; the corresponding price is derivable from the tick math in [`orderbook.rs`](https://github.com/osmosis-labs/orderbook/blob/main/contracts/sumtree-orderbook/src/orderbook.rs).
 - `order_direction`: `"bid"` (offering quote to buy base) or `"ask"` (offering base to sell into quote).
-- `quantity`: an integer string. For bids this is the quote-denom amount the order will spend if fully filled at `tick_id`; for asks it is the base-denom amount being offered.
-- `claim_bounty` (optional, decimal string): the fraction of the order's payout the placer is willing to pay any third party that claims the filled order on their behalf. Enables the claimbot economic flywheel described below. The Osmosis frontend currently sets this to `0.0001` (0.01%) for every limit order it places.
+- `quantity`: an integer string. The exact amount the order deposits up front: quote-denom for bids, base-denom for asks. The `--amount` flag below must match this value and denom exactly.
+- `claim_bounty` (optional, decimal string between `0` and `0.01`): the fraction of the order's payout the placer is willing to pay any third party that claims the filled order on their behalf. Enables the claimbot economic flywheel described below. The contract enforces a 1% hard cap (`InvalidClaimBounty`); the Osmosis frontend currently sets this to `0.0001` (0.01%) for every limit order it places.
 
 The `--amount` flag must equal `quantity` of the appropriate denom for the side of the order (quote for bids, base for asks). The contract returns the assigned `order_id` for the placed order in the execution response.
 
@@ -66,7 +68,7 @@ osmosisd tx wasm execute <ORDERBOOK_CONTRACT_ADDR> '{
 }' --from <KEY> --gas auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
 ```
 
-Only the original order placer can cancel. Cancelling a partially-filled order returns the unfilled remainder; the filled portion remains claimable.
+Only the original order placer can cancel. Cancellation is all-or-nothing: the contract rejects with `CancelFilledOrder` if any portion of the order has been filled. To recover a partial fill, claim the filled portion first; the unfilled remainder cannot be cancelled separately under the current contract.
 
 ## Claiming filled orders
 
@@ -112,7 +114,7 @@ For book inspection and order lookup:
 - `is_active {}`: returns `true` if the contract accepts new orders.
 - `all_ticks { start_from, end_at, limit }`: paginated list of all ticks with state. Used by SQS to build its in-memory tick representation.
 - `ticks_by_id { tick_ids }`: batch fetch specific ticks.
-- `orders_by_owner { owner, start_from, end_at, limit }`: every order placed by an address. Returns `{ orders, count }` where `count` is the number of orders in the response (useful for paginating).
+- `orders_by_owner { owner, start_from, end_at, limit }`: every order placed by an address. `start_from` and `end_at` are `[tick_id, order_id]` tuples (inclusive); `limit` defaults to 100. Returns `{ orders, count }` where `count` is the number of orders in the response (useful for paginating).
 - `orders_by_tick { tick_id, start_from, end_at, limit }`: every order resting at a tick. Returns `{ orders, count }` where `count` is the number of orders in the response.
 - `get_maker_fee {}`: the configured maker fee.
 - `get_unrealized_cancels { tick_ids }`: for advanced users tracking realized-vs-unrealized accounting.
@@ -123,7 +125,7 @@ SQS implements a dedicated routable pool type for orderbooks in [`routable_cw_or
 
 ### Discovery
 
-SQS recognises a CosmWasm pool as an orderbook by matching its `code_id` against a configured list (`OrderbookCodeIDs` in [`domain/config.go`](https://github.com/osmosis-labs/sqs/blob/main/domain/config.go)). Once a market is instantiated on chain from a recognised code id, SQS picks it up automatically as soon as it has ingested the pool state, without any operator action.
+SQS recognises a CosmWasm pool as an orderbook by matching its `code_id` against a configured list (`OrderbookCodeIDs` in [`domain/config.go`](https://github.com/osmosis-labs/sqs/blob/main/domain/config.go); `[885]` at the time of writing — read the live config for the current set). Once a market is instantiated on chain from a recognised code id, SQS picks it up automatically as soon as it has ingested the pool state, without any operator action.
 
 When multiple orderbook contracts exist for the same base/quote pair, SQS continuously tracks which one has the highest liquidity cap and promotes it to "canonical" for that pair. Two dedicated endpoints expose this view:
 

--- a/docs/overview/integrate/orderbook.md
+++ b/docs/overview/integrate/orderbook.md
@@ -125,7 +125,7 @@ SQS implements a dedicated routable pool type for orderbooks in [`routable_cw_or
 
 ### Discovery
 
-SQS recognises a CosmWasm pool as an orderbook by matching its `code_id` against a configured list (`OrderbookCodeIDs` in [`domain/config.go`](https://github.com/osmosis-labs/sqs/blob/main/domain/config.go); `[885]` at the time of writing — read the live config for the current set). Once a market is instantiated on chain from a recognised code id, SQS picks it up automatically as soon as it has ingested the pool state, without any operator action.
+SQS recognises a CosmWasm pool as an orderbook by matching its `code_id` against a configured list (`OrderbookCodeIDs` in [`domain/config.go`](https://github.com/osmosis-labs/sqs/blob/main/domain/config.go); `[885]` at the time of writing, read the live config for the current set). Once a market is instantiated onchain from a recognised code id, SQS picks it up automatically as soon as it has ingested the pool state, without any operator action.
 
 When multiple orderbook contracts exist for the same base/quote pair, SQS continuously tracks which one has the highest liquidity cap and promotes it to "canonical" for that pair. Two dedicated endpoints expose this view:
 


### PR DESCRIPTION
New page at `docs/overview/integrate/orderbook.md` documenting the sumtree-orderbook CosmWasm contract as an integration surface for the Osmosis docs site.

[Direct Link](https://docs-git-feat-orderbook-integration-docs.vercel.dev-osmosis.zone/overview/integrate/orderbook)

### What the page covers

- **Discovery onchain**: SQS `/pools`, the `x/cosmwasmpool` queries, and direct contract addressing. Plus recipes for finding the current orderbook code id live (`osmosisd q cosmwasmpool params` for the whitelist, or SQS `/pools` `.chain_model.code_id` for a specific pool) so integrators don't hardcode it.
- **Creating a market**: documents that market creation is **permissionless**, anyone can instantiate a market for a new base/quote pair from an already-whitelisted code id via `osmosisd tx cosmwasmpool create-pool` (only whitelisting a *new* code id is governance-gated). Cross-links the Pool Setup guide for the full creation walkthrough.
- **Roles**: the **admin is hardcoded to the Osmosis governance module account** and the **moderator to a DAODAO circuit-breaker subDAO** at compile time (verified via `constants.rs` and live `auth.admin` / `auth.moderator` queries against pool 1930).
- **Placing, cancelling, and claiming orders** with `osmosisd tx wasm execute` examples for `place_limit`, `cancel_limit`, `claim_limit`, and `batch_claim`. The `place_limit` example uses `claim_bounty: "0.0001"` to match the hardcoded value in [`osmosis-frontend/packages/web/hooks/limit-orders/use-place-limit.ts`](https://github.com/osmosis-labs/osmosis-frontend/blob/master/packages/web/hooks/limit-orders/use-place-limit.ts).
- **Querying state** — every query verified against pool 1930 on mainnet:
  - Pool-compatible: `spot_price`, `calc_out_amount_given_in`, `get_total_pool_liquidity`, `get_swap_fee`.
  - Orderbook-specific: `denoms`, `orderbook_state` (with its actual flat-field response shape), `is_active`, `all_ticks`, `ticks_by_id`, `orders_by_owner` and `orders_by_tick` (both with the `{ orders, count }` response shape), `get_maker_fee`, `get_unrealized_cancels`.
- **Routing through SQS**, sourced from `routable_cw_orderbook_pool.go` and `pools_usecase.go` rather than the SQS README:
  - SQS recognises an orderbook by matching `code_id` against the configured `OrderbookCodeIDs` list. New contract instances from an existing code id are picked up automatically.
  - The canonical-orderbook concept (highest-liquidity contract per pair), with the public `/pools/canonical-orderbook` and `/pools/canonical-orderbooks` endpoints.
  - SQS quotes orderbook swaps in-process by walking ticks via `TickToPrice`; it does not call the contract at quote time. The fill is a standard `osmosis.poolmanager.v1beta1.MsgSwapExactAmountIn`.
  - The "register your code id with SQS" caveat is narrowed: it only applies to brand-new orderbook code ids, not new contract instances.
- **Admin and moderator messages**, sourced from `auth.rs` and reconciled against the `ensure_is_*` checks in each dispatcher. Notes the inconsistency where `set_maker_fee` and `set_maker_fee_recipient` are admin-only despite appearing in the enum's "Shared messages" section.

## Sources

Every claim was verified against either the live contract on pool 1930 (via direct LCD queries) or the upstream Osmosis-labs source:

- `osmosis-labs/orderbook` — `contracts/sumtree-orderbook/src/{msg.rs,auth.rs,order.rs,constants.rs}`
- `osmosis-labs/orderbook-claimbot` — README and inspector source for the claim-bot scanning algorithm
- `osmosis-labs/sqs` — `router/usecase/pools/routable_cw_orderbook_pool.go`, `pools/usecase/pools_usecase.go`, `domain/config.go`
- `osmosis-labs/osmosis-frontend` — `packages/web/hooks/limit-orders/use-place-limit.ts` for the live `claim_bounty` constant

## Notes for the reviewer

- **Lands together with #310 (SQS page).** Cross-references to the SQS page use relative `./sqs` links, which resolve once both PRs are on `main`. (A local build warns on `./sqs` until #310 merges; expected.)
- `sidebar_position: 14` slots immediately after `sqs.md` (13), next to the API-integration cluster.
- No contract addresses or code ids are hardcoded as authoritative. Market creation is permissionless and the whitelisted code id can change, so integrators are pointed at SQS or chain state at submission time.
- Gas-price examples use `0.05uosmo` (above the current EIP-1559 base fee) with a note that the minimum is dynamic, consistent with the repo-wide normalization in #317 (MTN-81).

## Verification

- [x] `yarn build` clean (only the expected `./sqs` warning until #310 lands).
- [x] Every query example and the role addresses verified live against pool 1930 (allBTC/USDC, code id 885).
- [x] Code-id discovery confirmed live: `cosmwasmpool params` `code_id_whitelist` includes 885; SQS `/pools` exposes `.chain_model.code_id`.
- [x] **Reviewer spot-check** that the `place_limit` example reads correctly — `--amount` must match `quantity` of the side's collateral denom (quote for bids, base for asks).
- [x] Execute-message arg shapes (`place_limit` etc.) and the `cosmwasmpool create-pool` flow are source/chain-verified but not broadcast end-to-end (read-only environment).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no changes to chain code, contracts, or deployed services.
> 
> **Overview**
> Adds **`docs/overview/integrate/orderbook.md`** (`sidebar_position: 14`) as a new **Integrate** guide for the sumtree CosmWasm orderbook—no runtime or contract changes.
> 
> The page documents **how integrators work with orderbook markets**: discovering pools (SQS `/pools`, `x/cosmwasmpool`, wasm smart queries), resolving the live **code id** without hardcoding, **permissionless** `create-pool` for new base/quote pairs, and **`place_limit` / `cancel_limit` / `claim_limit` / `batch_claim`** with `osmosisd` examples (including dynamic EIP-1559 gas notes). It catalogs **pool-compatible and orderbook-specific** query JSON shapes, explains **SQS** discovery (`OrderbookCodeIDs`), canonical orderbook selection, in-process tick quoting vs on-chain **`MsgSwapExactAmountIn`**, and when operators must redeploy SQS for a **new code id** only. **Admin/moderator** `auth` execute/query flows and links to the orderbook, claimbot, and SQS repos are included; relative links point at **`./sqs`** and **`./pool-setup`** (SQS page expected from a companion docs PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f66e1ea4e051cfe5c456a1b95f0cb6eefc9c249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->