### PR TITLE
docs: normalize stale gas prices above the EIP-1559 base fee

### DIFF
--- a/docs/beaker/config/README.md
+++ b/docs/beaker/config/README.md
@@ -10,7 +10,7 @@ The following list is the configuration references for beaker which can be used 
 # Default Config
 ```toml
 name = ''
-gas_price = '0.025uosmo'
+gas_price = '0.05uosmo'
 gas_adjustment = 1.3
 account_prefix = 'osmo'
 derivation_path = '''m/44'/118'/0'/0/0'''

--- a/docs/beaker/config/global.md
+++ b/docs/beaker/config/global.md
@@ -136,7 +136,7 @@
 
 ```toml
 name = ''
-gas_price = '0.025uosmo'
+gas_price = '0.05uosmo'
 gas_adjustment = 1.3
 account_prefix = 'osmo'
 derivation_path = '''m/44'/118'/0'/0/0'''

--- a/docs/cosmwasm/local/localosmosis.md
+++ b/docs/cosmwasm/local/localosmosis.md
@@ -178,7 +178,7 @@ You can deploy the contract to localOsmosis or a testnet.  In this example we wi
 
 ```
 cd artifacts
-osmosisd tx wasm store cw_tpl_osmosis.wasm  --from <unsafe-test-key-name> --chain-id=<chain-id> --gas-prices 0.1uosmo --gas auto --gas-adjustment 1.3 -b block -y
+osmosisd tx wasm store cw_tpl_osmosis.wasm  --from <unsafe-test-key-name> --chain-id=<chain-id> --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b block -y
 ```
 
 `<unsafe-test-key-name>` = Name of your local key.
@@ -192,7 +192,7 @@ Save the CODE_ID from the output of the command above as a local variable `CODE_
 Instead of looking for the code_id the command above, you can also run the following command to set the CODE_ID as a variable.
     
 ```
-TX=$(osmosisd tx wasm store cw_tpl_osmosis.wasm  --from <unsafe-test-key-name> --chain-id=<chain-id> --gas-prices 0.1uosmo --gas auto --gas-adjustment 1.3 -b block --output json -y | jq -r '.txhash')
+TX=$(osmosisd tx wasm store cw_tpl_osmosis.wasm  --from <unsafe-test-key-name> --chain-id=<chain-id> --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b block --output json -y | jq -r '.txhash')
 CODE_ID=$(osmosisd query tx $TX --output json | jq -r '.logs[0].events[-1].attributes[0].value')
 echo "Your contract code_id is $CODE_ID"
 ```
@@ -204,13 +204,13 @@ If this is a brand new localOsmosis instance it should be `1`
  
 ```
 INITIAL_STATE='{"count":100}'
-osmosisd tx wasm instantiate $CODE_ID $INITIAL_STATE --amount 50000uosmo  --label "Counter Contract" --from <unsafe-test-key-name> --chain-id <chain-id> --gas-prices 0.1uosmo --gas auto --gas-adjustment 1.3 -b block -y --no-admin
+osmosisd tx wasm instantiate $CODE_ID $INITIAL_STATE --amount 50000uosmo  --label "Counter Contract" --from <unsafe-test-key-name> --chain-id <chain-id> --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b block -y --no-admin
 ```
 
 Example
 ```
 INITIAL_STATE='{"count":100}'
-osmosisd tx wasm instantiate $CODE_ID $INITIAL_STATE --amount 50000uosmo  --label "Counter Contract" --from c1 --chain-id localosmosis --gas-prices 0.1uosmo --gas auto --gas-adjustment 1.3 -b block -y --no-admin
+osmosisd tx wasm instantiate $CODE_ID $INITIAL_STATE --amount 50000uosmo  --label "Counter Contract" --from c1 --chain-id localosmosis --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b block -y --no-admin
 ```
 
 ### Get contract address

--- a/docs/cosmwasm/local/submit-wasm-proposal.md
+++ b/docs/cosmwasm/local/submit-wasm-proposal.md
@@ -61,7 +61,7 @@ VAL=$(osmosisd keys show -a validator --keyring-backend test)
 osmosisd tx gov submit-proposal wasm-store $CONTRACT.wasm --title "Add $CONTRACT" \
   --description "Let's upload this contract" --run-as $VAL \
   --from validator --keyring-backend test --chain-id $CHAIN_ID -y -b block \
-  --gas 9000000 --gas-prices 0.025uosmo
+  --gas 9000000 --gas-prices 0.05uosmo
 ```
 
 ## Query proposal
@@ -72,13 +72,13 @@ osmosisd query gov proposal $PROPOSAL
 ## Deposit on proposal
 ```
 osmosisd tx gov deposit $PROPOSAL 10000000uosmo --from validator --keyring-backend test \
-    --chain-id $CHAIN_ID -y -b block --gas 6000000 --gas-prices 0.025uosmo
+    --chain-id $CHAIN_ID -y -b block --gas 6000000 --gas-prices 0.05uosmo
 ```
 
 ## Vote
 ```
 osmosisd tx gov vote $PROPOSAL yes --from validator --keyring-backend test \
-    --chain-id $CHAIN_ID -y -b block --gas 600000 --gas-prices 0.025uosmo
+    --chain-id $CHAIN_ID -y -b block --gas 600000 --gas-prices 0.05uosmo
 ```
 
 ## Check the results

--- a/docs/cosmwasm/testnet/cosmwasm-deployment.md
+++ b/docs/cosmwasm/testnet/cosmwasm-deployment.md
@@ -174,7 +174,7 @@ We have the wasm binary executable ready. Now it is time to store the code to th
 
 ```bash
 # broadcast the store-code tx; --output json prints the txhash we need
-TX=$(osmosisd tx wasm store artifacts/cw_tpl_osmosis.wasm --from wallet --gas-prices 0.1uosmo --gas auto --gas-adjustment 1.3 -y --output json -b sync)
+TX=$(osmosisd tx wasm store artifacts/cw_tpl_osmosis.wasm --from wallet --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -y --output json -b sync)
 TXHASH=$(echo "$TX" | jq -r '.txhash')
 
 # wait a few seconds for inclusion, then query the receipt
@@ -227,7 +227,7 @@ INIT='{"count":100}'
 
 # instantiate the contract
 osmosisd tx wasm instantiate $CODE_ID "$INIT" \
-    --from wallet --label "my first contract" --gas-prices 0.025uosmo --gas auto --gas-adjustment 1.3 -b sync -y --no-admin
+    --from wallet --label "my first contract" --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b sync -y --no-admin
 ```
 
 - `osmosisd tx wasm instantiate` : instantiate a wasm contract using CODE_ID of the uploaded binary.
@@ -269,7 +269,7 @@ If you run the `get_count` query again after sending the `increment` transaction
 
 ```bash
 TRY_INCREMENT='{"increment": {}}'
-osmosisd tx wasm execute $CONTRACT_ADDR "$TRY_INCREMENT" --from wallet --gas-prices 0.025uosmo --gas auto --gas-adjustment 1.3 -y --chain-id osmo-test-5
+osmosisd tx wasm execute $CONTRACT_ADDR "$TRY_INCREMENT" --from wallet --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -y --chain-id osmo-test-5
 ```
 
 - `osmosisd tx wasm execute` : execute a command on a wasm contract
@@ -282,7 +282,7 @@ Lastly, let’s send a `reset` transaction. Like increment, reset transaction al
 
 ```bash
 RESET='{"reset": {"count": 0}}'
-osmosisd tx wasm execute $CONTRACT_ADDR "$RESET" --from wallet --gas-prices 0.025uosmo --gas auto --gas-adjustment 1.3 -y
+osmosisd tx wasm execute $CONTRACT_ADDR "$RESET" --from wallet --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -y
 ```
 
 ![](https://user-images.githubusercontent.com/70956926/172295239-ddf95369-5b9a-4096-a84d-aecc1ef30484.png)

--- a/docs/osmosis-core/modules/gov/README.md
+++ b/docs/osmosis-core/modules/gov/README.md
@@ -74,7 +74,7 @@ osmosisd tx gov submit-proposal [flags]
 ```
 
 typical flags would be:  
-* `--gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3` to auto-calculate gas required
+* `--gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3` to auto-calculate gas required. The `--gas-prices` value is illustrative: Osmosis sets a dynamic minimum gas price via its [EIP-1559 fee market](/overview/features/eip-1559), so query the current base fee (`osmosisd query txfees base-fee`) and pass a value at or above it.
 * `--from WALLET_ADDRESS` to set the running wallet
 * `--deposit=400000000uosmo` to provide the initial 400 OSMO (25% of total) deposit for putting a proposal on chain
 
@@ -102,7 +102,7 @@ osmosisd tx gov submit-proposal --type=text --title="" --description="" --from W
 Create a text signaling proposals to match external incentives for a `DOGE/OSMO` and `DOGE/ATOM` pair.
 
 ```bash
-osmosisd tx gov submit-proposal --type=text --title="Match External Incentives for DOGE/OSMO and DOGE/ATOM pairs" --description="Input description" --from WALLET_ADDRESS --deposit=400000000uosmo --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal --type=text --title="Match External Incentives for DOGE/OSMO and DOGE/ATOM pairs" --description="Input description" --from WALLET_ADDRESS --deposit=400000000uosmo --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 ### submit-proposal (param change)
@@ -118,7 +118,7 @@ osmosisd tx gov submit-proposal param-change [proposal-file] --from WALLET_ADDRE
 Change the parameter MaxValidators (maximum number of validator) in the staking module:
  
 ```bash
-osmosisd tx gov submit-proposal param-change proposal.json --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal param-change proposal.json --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 The proposal.json file would look as follows:
 
@@ -150,7 +150,7 @@ osmosisd tx gov submit-proposal community-pool-spend [proposal-file] --from WALL
 Submit a proposal to use community funds to fund a DAO:
 
 ```bash
-osmosisd tx gov submit-proposal community-pool-spend proposal.json --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal community-pool-spend proposal.json --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 The proposal.json would look as follows:
@@ -179,7 +179,7 @@ osmosisd tx gov submit-proposal software-upgrade [proposal-file] --from WALLET_A
 Update Osmosis to V11:
 
 ```bash
-osmosisd tx gov submit-proposal software-upgrade v11 --upgrade-height 5432450 --upgrade-info https://raw.githubusercontent.com/osmosis-labs/osmosis/main//osmosis-1/upgrades/v11/mainnet/upgrade_11_binaries.json  --title="Osmosis v11 Upgrade" --description="" --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal software-upgrade v11 --upgrade-height 5432450 --upgrade-info https://raw.githubusercontent.com/osmosis-labs/osmosis/main//osmosis-1/upgrades/v11/mainnet/upgrade_11_binaries.json  --title="Osmosis v11 Upgrade" --description="" --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 ### submit-proposal (cancel upgrade)
@@ -187,7 +187,7 @@ osmosisd tx gov submit-proposal software-upgrade v11 --upgrade-height 5432450 --
 Cancel the planned software upgrade before the upgrade height is reached.
 
 ```bash
-osmosisd tx gov submit-proposal cancel-software-upgrade --title="" --description"" --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal cancel-software-upgrade --title="" --description"" --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 The software upgrade does not have to be specified, as this will cancel the currently active software upgrade proposal. 
@@ -198,7 +198,7 @@ The software upgrade does not have to be specified, as this will cancel the curr
 Update the weight of specified pool gauges in regards to their share of incentives.
 
 ```bash
-osmosisd tx gov submit-proposal update-pool-incentives [gaugeIDs] [weights] --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal update-pool-incentives [gaugeIDs] [weights] --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 **Example**
@@ -215,7 +215,7 @@ osmosisd tx gov submit-proposal update-pool-incentives 0,1 5000,20000 --from WAL
 Enable a pool as eligible for Superfluid Staking, allowing a portion of the OSMO within the pool to be staked - providing additional security for Osmosis as well as staking rewards and voting power for Liquidity Providers
 
 ```bash
-osmosisd tx gov submit-proposal set-superfluid-assets-proposal --superfluid-assets= [GAMM] --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal set-superfluid-assets-proposal --superfluid-assets= [GAMM] --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 **Example**
@@ -223,7 +223,7 @@ osmosisd tx gov submit-proposal set-superfluid-assets-proposal --superfluid-asse
 Add Superfluid Staking to Pool 831.
 
 ```bash
-osmosisd tx gov submit-proposal set-superfluid-assets-proposal --superfluid-assets="gamm/pool/831" --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal set-superfluid-assets-proposal --superfluid-assets="gamm/pool/831" --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 ### submit-proposal (remove superfluid asset)
@@ -231,7 +231,7 @@ osmosisd tx gov submit-proposal set-superfluid-assets-proposal --superfluid-asse
 Disable a pool as eligible for Superfluid Staking, this prevents OSMO in a pool from being able to also be staked.
 
 ```bash
-osmosisd tx gov submit-proposal remove-superfluid-assets-proposal --superfluid-assets= [GAMM] --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal remove-superfluid-assets-proposal --superfluid-assets= [GAMM] --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 **Example**
@@ -239,7 +239,7 @@ osmosisd tx gov submit-proposal remove-superfluid-assets-proposal --superfluid-a
 Remove Superfluid Staking from Pool 831.
 
 ```bash
-osmosisd tx gov submit-proposal remove-superfluid-assets-proposal --superfluid-assets="gamm/pool/831" --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal remove-superfluid-assets-proposal --superfluid-assets="gamm/pool/831" --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 ### submit-proposal (wasm-store)
@@ -247,14 +247,14 @@ osmosisd tx gov submit-proposal remove-superfluid-assets-proposal --superfluid-a
 Upload a CosmWasm contract to Osmosis for subsequent instantiation.
 
 ```bash
-osmosisd tx gov wasm-store [contract.wasm] --title="" --description="" --code-hash [checksum] --code-source-url [source] --builder [builder] --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov wasm-store [contract.wasm] --title="" --description="" --code-hash [checksum] --code-source-url [source] --builder [builder] --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 **Example**
 Upload Crosschain Swaps contract.
 
 ```bash
-osmosisd tx gov submit-proposal wasm-store crosschain_swaps.wasm --title="Upload Crosschain Swaps contract" --description="" --code-hash e7cfd4ec2cf594de9d15863c6e324025045de39236186c03483af7c9e06d4949 --code-source-url "https://github.com/osmosis-labs/osmosis/raw/v31.x/tests/ibc-hooks/bytecode/crosschain_swaps.wasm" --builder "cosmwasm/workspace-optimizer:0.12.10" --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal wasm-store crosschain_swaps.wasm --title="Upload Crosschain Swaps contract" --description="" --code-hash e7cfd4ec2cf594de9d15863c6e324025045de39236186c03483af7c9e06d4949 --code-source-url "https://github.com/osmosis-labs/osmosis/raw/v31.x/tests/ibc-hooks/bytecode/crosschain_swaps.wasm" --builder "cosmwasm/workspace-optimizer:0.12.10" --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 ### submit-proposal (update unpool whitelist)
@@ -262,7 +262,7 @@ osmosisd tx gov submit-proposal wasm-store crosschain_swaps.wasm --title="Upload
 Enable immediate unpooling on a pool, allowing users to choose to freeze their impermanent loss during the unbonding period in the event of unexpected severe conditions.
 
 ```bash
-osmosisd tx gov submit-proposal update-unpool-whitelist --pool-ids [PoolIDs] --title="" --description="" --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal update-unpool-whitelist --pool-ids [PoolIDs] --title="" --description="" --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 **Example**
@@ -270,7 +270,7 @@ osmosisd tx gov submit-proposal update-unpool-whitelist --pool-ids [PoolIDs] --t
 Allow immediate unpooling of pools 1, 2 and 3.
 
 ```bash
-osmosisd tx gov submit-proposal update-unpool-whitelist --pool-ids "1, 2, 3" --title="Allow Immediate Unpooling of Pools 1, 2 and 3" --description="" --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov submit-proposal update-unpool-whitelist --pool-ids "1, 2, 3" --title="Allow Immediate Unpooling of Pools 1, 2 and 3" --description="" --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 ### deposit
@@ -278,7 +278,7 @@ osmosisd tx gov submit-proposal update-unpool-whitelist --pool-ids "1, 2, 3" --t
 Deposit tokens for an active proposal
 
 ```bash
-osmosisd tx gov deposit [proposal-id] [deposit] --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov deposit [proposal-id] [deposit] --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ``` 
 
 **Example**
@@ -286,7 +286,7 @@ osmosisd tx gov deposit [proposal-id] [deposit] --from WALLET_ADDRESS --gas=auto
 If proposal number 12 is in the deposit period and you would like to help bring it to a vote, you could deposit 1200 OSMO to that proposal as follows:
 
 ```bash
-osmosisd tx gov deposit 12 1200000000uosmo --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov deposit 12 1200000000uosmo --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 ### vote
@@ -294,7 +294,7 @@ osmosisd tx gov deposit 12 1200000000uosmo --from WALLET_ADDRESS --gas=auto --ga
 Vote for an active proposal
 
 ```bash
-osmosisd tx gov vote [proposal-id] [option] --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov vote [proposal-id] [option] --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 Valid value of ```option``` field is ```yes```, ```no```, ```no_with_veto``` and ```abstain```. 
@@ -304,7 +304,7 @@ Valid value of ```option``` field is ```yes```, ```no```, ```no_with_veto``` and
 To vote yes for proposal 12:
 
 ```bash
-osmosisd tx gov vote 12 yes --from WALLET_ADDRESS --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx gov vote 12 yes --from WALLET_ADDRESS --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
 
 

--- a/docs/overview/integrate/incentives.md
+++ b/docs/overview/integrate/incentives.md
@@ -55,8 +55,10 @@ The command to run takes the format:
 
 **Example Supercharged command**
 
-`osmosisd tx incentives create-gauge 0 1355000000uosmo 1081 --epochs 30 --duration 60s --start-time 1698328800 --from Wosmongton --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3`
+`osmosisd tx incentives create-gauge 0 1355000000uosmo 1081 --epochs 30 --duration 60s --start-time 1698328800 --from Wosmongton --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3`
 
 **Example Classic Pool command**
 
-`osmosisd tx incentives create-gauge gamm/pool/1 1355000000uosmo 0 --duration 336h --epochs 30 --start-time 1698328800 --from Wosmongton --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3`
+`osmosisd tx incentives create-gauge gamm/pool/1 1355000000uosmo 0 --duration 336h --epochs 30 --start-time 1698328800 --from Wosmongton --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3`
+
+The `--gas-prices` value above is illustrative. Osmosis sets a dynamic minimum gas price via its [EIP-1559 fee market](/overview/features/eip-1559), so query the current base fee (`osmosisd query txfees base-fee`) and pass a value at or above it.

--- a/docs/overview/integrate/pool-setup.mdx
+++ b/docs/overview/integrate/pool-setup.mdx
@@ -79,7 +79,7 @@ tick spacing, and spread factors must all be authorized by the concentrated liqu
 Example:
 
 ```bash
-osmosisd tx concentratedliquidity create-pool ibc/... uosmo 100 0.01 --from val --chain-id osmosis-1 -b block --gas auto --gas-adjustment 1.3 --gas-prices 0.025uosmo
+osmosisd tx concentratedliquidity create-pool ibc/... uosmo 100 0.01 --from val --chain-id osmosis-1 -b block --gas auto --gas-adjustment 1.3 --gas-prices 0.05uosmo
 ```
 
 There are recommendations for creating CL pools:
@@ -123,7 +123,7 @@ osmosisd tx concentratedliquidity create-position [pool-id] [lower-tick] [upper-
 Example:
 
 ```bash
-osmosisd tx concentratedliquidity create-position 1 "[-108000000]" 342000000 10000ibc/...,10000uosmo 100 100 --from val --chain-id osmosis-1 -b block --gas auto --gas-adjustment 1.3 --gas-prices 0.025uosmo
+osmosisd tx concentratedliquidity create-position 1 "[-108000000]" 342000000 10000ibc/...,10000uosmo 100 100 --from val --chain-id osmosis-1 -b block --gas auto --gas-adjustment 1.3 --gas-prices 0.05uosmo
 ```
 
 For parameter values:
@@ -164,8 +164,10 @@ osmosisd tx cosmwasmpool create-pool [code-id] '{"base_denom":"[base-denom]","qu
 
 Example creation of an OSMO/USDC orderbook:
 ```bash
-osmosisd tx cosmwasmpool create-pool 885 '{"base_denom":"uosmo","quote_denom":"ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"}' --from poolcreator --gas=auto --gas-prices 0.0025uosmo --gas-adjustment 1.3
+osmosisd tx cosmwasmpool create-pool 885 '{"base_denom":"uosmo","quote_denom":"ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"}' --from poolcreator --gas=auto --gas-prices 0.05uosmo --gas-adjustment 1.3
 ```
+
+The `--gas-prices` value is illustrative. Osmosis sets a dynamic minimum gas price via its [EIP-1559 fee market](/overview/features/eip-1559), so query the current base fee (`osmosisd query txfees base-fee`) and pass a value at or above it.
 
 Order books have a built-in moderator account that can freeze and unfreeze liquidity in the pools in the event of a security issue. This may be viewed [here](https://daodao.zone/dao/osmo1peuxfjj66n2qt2v5jmqlvzz8neakjgduez7vttvemw58uug6546sr60ngl)
 

--- a/docs/overview/validate/validating-testnet.md
+++ b/docs/overview/validate/validating-testnet.md
@@ -94,8 +94,10 @@ out of gas in location: WritePerByte; gasWanted: 177140, gasUsed: 177979: out of
 Please try substituting:
 ```
 --gas="auto" \
---gas-prices="0.0025uosmo"
+--gas-prices="0.05uosmo"
 ```
+
+The `--gas-prices` value is illustrative. Osmosis sets a dynamic minimum gas price via its [EIP-1559 fee market](/overview/features/eip-1559), so query the current base fee (`osmosisd query txfees base-fee`) and pass a value at or above it.
 
 with
 


### PR DESCRIPTION
Closes MTN-81 (sub-issue of MTN-75).

`osmosisd tx` examples across the docs used stale `--gas-prices` values predating the EIP-1559 dynamic fee market. The current base fee is ~`0.03uosmo` (live `osmosis/txfees/v1beta1/cur_eip_base_fee`), so the two low values were causing transactions to be **rejected for insufficient fee**:

- `0.0025uosmo` (the pre-EIP-1559 static floor) — 12x too low
- `0.025uosmo` — just below the base fee
- `0.1uosmo` — high enough to work, normalized for consistency

## What changed

Normalized **all** gas prices to `0.05uosmo` (comfortably above the base fee) across 36 occurrences in 9 files. Added a one-line note on the content/integration pages that the minimum gas price is dynamic, pointing at the [EIP-1559](/overview/features/eip-1559) page and the `osmosisd query txfees base-fee` query. Beaker/cosmwasm local+testnet examples got value-only changes (no note).

## Verifying

`yarn build` clean, no broken links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to example flags and default config snippets; no runtime or on-chain behavior changes.
> 
> **Overview**
> Updates documentation so **`osmosisd` CLI examples and Beaker default config** no longer use pre–EIP-1559 `--gas-prices` / `gas_price` values (`0.0025uosmo`, `0.025uosmo`, `0.1uosmo`) that fall below the chain’s dynamic minimum and cause **insufficient-fee rejections**.
> 
> All touched examples are normalized to **`0.05uosmo`**. On gov, incentives, pool setup, and testnet validator troubleshooting pages, short notes were added that the figure is illustrative: readers should use **`osmosisd query txfees base-fee`** and meet or exceed the current EIP-1559 base fee (with a link to the EIP-1559 overview). CosmWasm/Beaker local guides only change the numeric examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9505f2be27bd2c2d137d4510cce3056cddff673d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->