### PR TITLE
docs(validate): correct stale validator-setup content (MTN-85)

### DIFF
--- a/docs/osmosis-core/osmosisd.md
+++ b/docs/osmosis-core/osmosisd.md
@@ -75,7 +75,7 @@ cd $HOME
 git clone https://github.com/osmosis-labs/osmosis
 cd osmosis
 
-git checkout v31.0.0
+git checkout v31.0.3
 
 make install
 ```

--- a/docs/overview/educate/terminology.md
+++ b/docs/overview/educate/terminology.md
@@ -8,7 +8,7 @@ Use this glossary to learn about terms used in Osmosis and the Cosmos ecosystem.
 
 ## Active set
 
-The top 120 validators that participate in consensus and receive rewards.
+The validators in the active set (currently the top 70, set by governance) that participate in consensus and receive rewards.
 
 ## Air drops
 
@@ -243,7 +243,7 @@ The amount of time a validator has been active in a given timeframe. Validators 
 
 ## Validator
 
-A Osmosis blockchain miner responsible for verifying transactions on the blockchain. Validators run programs called full nodes that allow them to participate in consensus, verify blocks, participate in governance, and receive rewards. The top 130 validators with the highest total stake can participate in consensus.
+A Osmosis blockchain miner responsible for verifying transactions on the blockchain. Validators run programs called full nodes that allow them to participate in consensus, verify blocks, participate in governance, and receive rewards. The validators with the highest total stake, up to the governance-set active-set size (currently 70), can participate in consensus.
 
 ## Weight
 

--- a/docs/overview/validate/joining-mainnet.md
+++ b/docs/overview/validate/joining-mainnet.md
@@ -36,23 +36,23 @@ Download and place the genesis file in the osmosis config folder:
 wget -O ~/.osmosisd/config/genesis.json https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json
 ```
 
-## Latest Version (v29) Upgrade Info
+## Node Requirements and Cosmovisor Setup
 
 ### Go Requirement
 
-You will need to be running go1.22.11 for this version of Osmosis. You can check if you are running go1.22.11 with the following command:
+You will need to be running go1.23.4 for this version of Osmosis. You can check if you are running go1.23.4 with the following command:
 
 ```{.sh}
 go version
 ```
 
-If this does not say go1.22.11, you need to upgrade/downgrade. One of the many ways to upgrade/downgrade to/from go1.22.11 on linux is as follows:
+If this does not say go1.23.4, you need to upgrade/downgrade. One of the many ways to upgrade/downgrade to/from go1.23.4 on linux is as follows:
 
 ```{.sh}
 sudo rm -rvf /usr/local/go/
-wget https://golang.org/dl/go1.22.11.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.22.11.linux-amd64.tar.gz
-rm go1.22.11.linux-amd64.tar.gz
+wget https://golang.org/dl/go1.23.4.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.23.4.linux-amd64.tar.gz
+rm go1.23.4.linux-amd64.tar.gz
 ```
 ### Memory Requirements
 
@@ -106,7 +106,7 @@ osmosisd version
 
 ## Download Chain Data
 
-Download the latest chain data from a snapshot provider. In the following commands, I will use <a href="https://quicksync.io/networks/osmosis.html" target="_blank">https://quicksync.io/networks/osmosis.html</a> to download the chain data. You may choose the default, pruned, or archive based on your needs.
+Download the latest chain data from a snapshot provider. The official source is <a href="https://snapshots.osmosis.zone/" target="_blank">https://snapshots.osmosis.zone/</a>, which publishes `osmosis-1` mainnet snapshots in both pruned (regular node) and archive (full history) forms. The snapshot URL is timestamped and rotates, so copy the current one from that page rather than hardcoding it.
 
 Download liblz4-tool to handle the compressed file:
 
@@ -114,96 +114,11 @@ Download liblz4-tool to handle the compressed file:
 sudo apt-get install wget liblz4-tool aria2 -y
 ```
 
-Download the chain data:
+Pick a pruned or archive snapshot from [snapshots.osmosis.zone](https://snapshots.osmosis.zone/) and extract it into the data directory. Replace `<SNAPSHOT_URL>` with the current URL copied from that page:
 
-- Select the tab to the desired node type (Default, Pruned, or Archive)
-- Select the tab to the region closest to you (Netherlands, Singapore, or San Francisco) and copy the commands
-
-
-<!-- #region -->
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-### Default
-<Tabs>
-  <TabItem value="netherlands" label="Netherlands" default>
-
-``` bash
-URL=`curl https://quicksync.io/osmosis.json|jq -r '.[] |select(.file=="osmosis-1-default")|select (.mirror=="Netherlands")|.url'`
-cd $HOME/.osmosisd/
-wget -O - $URL | lz4 -d | tar -xvf -
+```bash
+wget -q -O - <SNAPSHOT_URL> | lz4 -d | tar -C $HOME/.osmosisd -xvf -
 ```
-
-  </TabItem>
-  <TabItem value="singapore" label="Singapore">
-
-``` bash
-URL=`curl https://quicksync.io/osmosis.json|jq -r '.[] |select(.file=="osmosis-1-default")|select (.mirror=="Singapore")|.url'`
-cd $HOME/.osmosisd/
-wget -O - $URL | lz4 -d | tar -xvf -
-```
-
-  </TabItem>
-  <TabItem value="sanfrancisco" label="San Francisco">
-
-``` bash
-URL=`curl https://quicksync.io/osmosis.json|jq -r '.[] |select(.file=="osmosis-1-default")|select (.mirror=="SanFrancisco")|.url'`
-cd $HOME/.osmosisd/
-wget -O - $URL | lz4 -d | tar -xvf -
-```
-
-  </TabItem>
-</Tabs>
-
-### Pruned
-<Tabs>
-  <TabItem value="netherlands" label="Netherlands" default>
-
-``` bash
-URL=`curl https://quicksync.io/osmosis.json|jq -r '.[] |select(.file=="osmosis-1-pruned")|select (.mirror=="Netherlands")|.url'`
-cd $HOME/.osmosisd/
-wget -O - $URL | lz4 -d | tar -xvf -
-```
-
-  </TabItem>
-  <TabItem value="singapore" label="Singapore">
-
-``` bash
-URL=`curl https://quicksync.io/osmosis.json|jq -r '.[] |select(.file=="osmosis-1-pruned")|select (.mirror=="Singapore")|.url'`
-cd $HOME/.osmosisd/
-wget -O - $URL | lz4 -d | tar -xvf -
-```
-
-  </TabItem>
-  <TabItem value="sanfrancisco" label="San Francisco">
-
-``` bash
-URL=`curl https://quicksync.io/osmosis.json|jq -r '.[] |select(.file=="osmosis-1-pruned")|select (.mirror=="SanFrancisco")|.url'`
-cd $HOME/.osmosisd/
-wget -O - $URL | lz4 -d | tar -xvf -
-```
-
-  </TabItem>
-</Tabs>
-
-
-
-### Archive
-<Tabs>
-  <TabItem value="netherlands" label="Netherlands" default>
-
-``` bash
-URL=`curl https://quicksync.io/osmosis.json|jq -r '.[] |select(.file=="osmosis-1-archive")|select (.mirror=="Netherlands")|.url'`
-cd $HOME/.osmosisd/
-wget -O - $URL | lz4 -d | tar -xvf -
-```
-
-  </TabItem>
-
-</Tabs>
-
-
-<!-- #endregion -->
 
 ## Set Up Osmosis Service
 

--- a/docs/overview/validate/joining-testnet.md
+++ b/docs/overview/validate/joining-testnet.md
@@ -118,7 +118,7 @@ osmosisd unsafe-reset-all
 
 ## Download Chain Data
 
-Download the latest chain data from a snapshot provider. In the following commands, I will use <a href="https://quicksync.io/networks/osmosis.html" target="_blank">https://quicksync.io/networks/osmosis.html</a> to download the chain data. You may choose the pruned or archive based on your needs.
+Download the latest chain data from a snapshot provider. The official source is <a href="https://snapshots.osmosis.zone/" target="_blank">https://snapshots.osmosis.zone/</a>, which publishes pruned `osmo-test-5` testnet snapshots. The snapshot URL is timestamped and rotates, so copy the current one from that page rather than hardcoding it.
 
 Download liblz4-tool to handle the compressed file:
 
@@ -126,37 +126,11 @@ Download liblz4-tool to handle the compressed file:
 sudo apt-get install wget liblz4-tool aria2 -y
 ```
 
-Download the chain data:
+Download a pruned snapshot from [snapshots.osmosis.zone](https://snapshots.osmosis.zone/) and extract it into the data directory. Replace `<SNAPSHOT_URL>` with the current URL copied from that page:
 
-- Select the tab to the desired node type (Pruned or Archive)
-
-
-<!-- #region -->
-::::::: tabs :options="{ useUrlFragment: false }"
-
-:::::: tab Pruned
-
-``` bash
-URL=`curl https://quicksync.io/osmosis.json|jq -r '.[] |select(.file=="osmotestnet-4-pruned")|select (.mirror=="Netherlands")|.url'`
-cd $HOME/.osmosisd/
-wget -O - $URL | lz4 -d | tar -xvf -
+```bash
+wget -q -O - <SNAPSHOT_URL> | lz4 -d | tar -C $HOME/.osmosisd -xvf -
 ```
-
-::::::
-
-:::::: tab Archive
-
-``` bash
-URL=`curl https://quicksync.io/osmosis.json|jq -r '.[] |select(.file=="osmotestnet-4-archive")|select (.mirror=="Netherlands")|.url'`
-cd $HOME/.osmosisd/
-wget -O - $URL | lz4 -d | tar -xvf -
-```
-
-::::::
-
-:::::::
-
-<!-- #endregion -->
 
 ## Set Up Osmosis Service
 

--- a/docs/overview/validate/validating-mainnet.md
+++ b/docs/overview/validate/validating-mainnet.md
@@ -98,7 +98,7 @@ osmosisd query staking validators -o --limit 300 json | jq -r '.validators[] |
 
 If your bond status is `BOND_STATUS_BONDED`, congratulations, your validator is part of the active validator set!
 
-Please note, as of this writing, you must be in the top 150 validators (in other words, must have more OSMO delegated to your validator than the 100th validator in the active validator set) to be bonded. If you did everything above correct but do not have more OSMO delegated to your validator than the 100th validator, you will stay unbonded.
+Please note, you must be in the active validator set (currently the top 70, a governance-set parameter) to be bonded, meaning you must have more OSMO delegated to your validator than the lowest-ranked validator currently in the set. If you did everything above correctly but do not have enough delegated to break into the active set, you will stay unbonded. Query the live size with `osmosisd query staking params` (`max_validators`).
 
 ## Track Validator Signing
 


### PR DESCRIPTION
Part of the MTN-85 content-accuracy sweep — the **validators / node-setup** section. Each change was re-verified against the live chain and the osmosis source (the 2026-05-11 audit catalogue is stale, so I checked rather than trusted it).

## Fixed

- **Go version** `1.22.11` → `1.23.4` in `joining-mainnet.md` (from `go.mod`).
- **Active validator set** corrected from three conflicting figures (120 / 130 / 150) to **70**, the live governance-set `max_validators` (verified across 3 LCDs + actual bonded count). Worded as the current value with a `osmosisd query staking params` pointer. (`terminology.md` ×2, `validating-mainnet.md`)
- **Cosmovisor section header** "Latest Version (v29) Upgrade Info" → version-neutral; the upgrade walkthrough body was already templatized.
- **osmosisd build**: `git checkout v31.0.0` → `v31.0.3` (latest tag).
- **Snapshot download** (both `joining-mainnet.md` and `joining-testnet.md`): replaced the dead quicksync `osmotestnet-4` block with [snapshots.osmosis.zone](https://snapshots.osmosis.zone/). Mainnet shows pruned + archive; testnet pruned-only (testnet has no archive snapshot).

## Catalogue false positives (left unchanged)

- `in-place-testnet` (localtesting.md) **does exist** — it's an SDK command registered via the osmosis cosmos-sdk fork (`server/start.go`), so the doc is correct.
- The cosmovisor upgrade walkthrough was already templatized in an earlier PR.

## Verifying

`yarn build` clean, no broken links. The removed mainnet quicksync block also removed its orphaned `import Tabs`/`import TabItem` MDX lines.

Closes part of MTN-85.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only corrections to install, snapshot, and staking guidance with no runtime or security impact.
> 
> **Overview**
> Updates **validator and node-setup** docs to match the live chain and current Osmosis releases (MTN-85 accuracy sweep).
> 
> **Toolchain and binaries:** Mainnet join docs now require **Go 1.23.4** (was 1.22.11) and rename the Cosmovisor section to a version-neutral **“Node Requirements and Cosmovisor Setup”** (replacing “Latest Version (v29) Upgrade Info”). **`osmosisd.md`** bumps the example checkout tag from **`v31.0.0` to `v31.0.3`**.
> 
> **Staking / consensus:** Glossary and mainnet validation text align on the **governance-set active set (currently 70 validators)**, replacing conflicting figures (120 / 130 / 150) and pointing readers to **`osmosisd query staking params`** for `max_validators`.
> 
> **Snapshots:** **`joining-mainnet.md`** and **`joining-testnet.md`** drop QuickSync/MDX tab blocks (including obsolete `osmotestnet-4` URLs) in favor of **[snapshots.osmosis.zone](https://snapshots.osmosis.zone/)** with a single placeholder **`wget | lz4 | tar`** flow and guidance to copy rotating snapshot URLs from the site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea78c24399f3a4dee3db1b58ac6c2c44ba756614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->