### PR TITLE
docs(integrate): fix stale gRPC/IBC/homepage references (MTN-85)

### DIFF
--- a/docs/overview/integrate/grpc.md
+++ b/docs/overview/integrate/grpc.md
@@ -108,7 +108,7 @@ grpcurl  -plaintext \
 It's also possible to execute an RPC call to query the node for information:
 
 ```bash
-grpcurl -plaintext grpc.dev-osmosis.zone:443 osmosis.gamm.v1beta1.Query.Pools
+grpcurl -plaintext grpc.osmosis.zone:9090 osmosis.gamm.v1beta1.Query.Pools
 ```
 
 

--- a/docs/overview/integrate/transfer.md
+++ b/docs/overview/integrate/transfer.md
@@ -17,7 +17,7 @@ This document lays out the prerequisites and the process that is needed to ensur
 ## Enabling IBC transfers
 Because only IBC assets that have been transferred to Osmosis can be traded on Osmosis, the native chain of the asset must have IBC transfers enabled. Cosmos defines the fungible IBC token transfer standard in [ICS20](https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer) specification.
 
-At this time, only chains using Cosmos-SDK v0.40+ (aka Stargate) can support IBC transfers.
+The counterparty chain must support IBC transfers (any IBC-enabled Cosmos chain does).
 
 IBC transfers can be enabled:
 1. as part of a software upgrade, or

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -29,7 +29,7 @@ export default function Homepage() {
 
   return (
     <Layout
-      description="The Osmosis blockchain is a decentralized network, run by 150+ validators and full nodes, with many front-ends and development teams on it."
+      description="The Osmosis blockchain is a decentralized network of validators and full nodes, with many front-ends and development teams on it."
       wrapperClassName="homepage"
     >
       <div className="pad">
@@ -37,7 +37,7 @@ export default function Homepage() {
           <div className='margin-bottom--lg'>
             <h2>Osmosis Docs</h2>
             <p>
-              The Osmosis blockchain is a decentralized network, run by 150+ validators and full nodes, with many front-ends and development teams on it. Explore our docs and examples to quickly learn, develop & integrate with the Osmosis blockchain.
+              The Osmosis blockchain is a decentralized network of validators and full nodes, with many front-ends and development teams on it. Explore our docs and examples to quickly learn, develop & integrate with the Osmosis blockchain.
             </p>
             <DyteButton onClick={() => router.push('/osmosis-core/')}>
               Get Started &rarr;


### PR DESCRIPTION
Part of the MTN-85 content-accuracy sweep — the **integration** section. As with the validators PR, each catalogue finding was re-verified against current source/chain rather than trusted; most were already fixed, so this PR is small.

## Fixed

- **grpc.md**: the `grpcurl` example used `grpc.dev-osmosis.zone:443` — an inconsistent `dev-` host and the wrong port for plaintext gRPC. Changed to `grpc.osmosis.zone:9090` (the endpoint used everywhere else on the page).
- **transfer.md**: dropped the archaic "only chains using Cosmos-SDK v0.40+ (aka Stargate) can support IBC transfers" framing; any IBC-enabled chain works.
- **src/pages/index.jsx** (homepage): said the network is "run by 150+ validators". The active set is a governance parameter (currently 70), so reworded to drop the stale number. **Net-new finding** — the 2026-05-11 content audit only scanned `docs/`, not `src/` UI text.

## Catalogue items checked, no change needed (already fixed or not actually problems)

- `grpc.md` `:9000` port typo and the ":443 near future" note — already gone.
- `rest.md` Cosmos SDK link — already `/v0.50/`.
- `endpoints/index.mdx` Celatone link — already well-formed.
- `pool-setup.mdx` pool-types list — already surfaces Orderbook + Alloyed (done during #314/#315).
- `cli.md` `:443` — that's a valid HTTPS port on RPC URLs, not a bug.
- `airdrops.md` — `export-derive-balances` still exists (`cmd/osmosisd/cmd/balances_from_state_export.go`); the 2021 block height is an illustrative example, not a stale instruction. No deprecation needed.

## Verifying

`yarn build` clean, no broken links.

Part of MTN-85. Note: this surfaced that the original audit excluded `src/` and isn't an exhaustive page-by-page check — flagging on the issue for a completeness re-sweep.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and marketing copy only; no runtime, auth, or chain logic changes.
> 
> **Overview**
> **Docs accuracy sweep (MTN-85)** — integration docs and homepage copy only; no code or API behavior changes.
> 
> The **gRPC** guide’s `grpcurl` example for `Query.Pools` now uses **`grpc.osmosis.zone:9090`** instead of **`grpc.dev-osmosis.zone:443`**, matching the rest of the page’s plaintext gRPC examples (correct host and port).
> 
> **IBC transfer** prerequisites drop the outdated “Cosmos-SDK v0.40+ (Stargate)” wording and state that any **IBC-enabled** counterparty chain can support transfers.
> 
> The **homepage** (`index.jsx`) meta description and hero text no longer claim **“150+ validators”**; they describe the network generically as validators and full nodes (active set size is governance-driven, not a fixed marketing number).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c56ce0459d4053c06cfdc2f51084b564f68919c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->