### PR TITLE
docs: refresh module README accuracy (MTN-85 sec 3)

### DIFF
--- a/docs/osmosis-core/contributing.md
+++ b/docs/osmosis-core/contributing.md
@@ -72,11 +72,11 @@ and take look at the graphviz output!
 
 Note that if you are doing things that are low-level / small, the overhead of cpuprofile may mess with cache effects, etc. However for things like epoch code, or relatively large txs, this totally works!
 
-### Branch structure of releases on v7, v6, v4
+### Branch structure and backports
 
-People still need those versions for querying old versions of the chain, and syncing a node from genesis, so we keep these updated!
+Each major release has a long-lived release branch (for example `v31.x`). Older release branches are kept updated, since people still need those versions for querying old versions of the chain and syncing a node from genesis.
 
-For v6.x, and v4.x, most PRs to them should go to main and get a "backport" label. We typically use mergify for backporting. Backporting often takes place after a PR has been merged to main
+Most PRs land on `main` first. State-compatible fixes are then backported to the latest major release branch with a `backport` label. We typically use mergify for backporting, which takes place after a PR has been merged to main.
 
 ### How to build proto files. (rm -rf vendor/ && make build-reproducible once docker is installed)
 

--- a/docs/osmosis-core/guides/create-ibc-pool.md
+++ b/docs/osmosis-core/guides/create-ibc-pool.md
@@ -19,7 +19,7 @@ This document lays out the prerequisites and the process that's needed to ensure
 ### 0. Enabling IBC transfers
 Because only IBC assets that have been transferred to Osmosis can be traded on Osmosis, the native chain of the asset must have IBC transfers enabled. Cosmos defines the fungible IBC token transfer standard in [ICS20](https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer) specification.
 
-At this time, only chains using Cosmos-SDK v0.40+ (aka Stargate) can support IBC transfers.
+The counterparty chain must support IBC transfers (any IBC-enabled Cosmos chain does).
 
 Note that IBC transfers can be enabled via:
 1. as part of a software upgrade, or

--- a/docs/overview/features/concentrated-liquidity.md
+++ b/docs/overview/features/concentrated-liquidity.md
@@ -131,7 +131,7 @@ There are precision issues that we must be considerate of in our design.
 Consider the balancer pool between `arb` base unit and `uosmo`:
 
 ```bash
-osmosisd q gamm pool 1011
+osmosisd query poolmanager pool 1011
 pool:
   '@type': /osmosis.gamm.v1beta1.Pool
   address: osmo1pv6ffw8whyle2nyxhh8re44k4mu4smqd7fd66cu2y8gftw3473csxft8y5
@@ -183,7 +183,7 @@ However, in our core logic it is represented as:
 or
 
 ```python
-osmosisd q gamm spot-price 1011 uosmo ibc/10E5E5B06D78FFBB61FD9F89209DEE5FD4446ED0550CBB8E3747DA79E10D9DC6
+osmosisd query poolmanager spot-price 1011 uosmo ibc/10E5E5B06D78FFBB61FD9F89209DEE5FD4446ED0550CBB8E3747DA79E10D9DC6
 spot_price: "0.000000000002155018"
 ```
 


### PR DESCRIPTION
Part of the MTN-85 content-accuracy sweep (section 3, module READMEs).

## What changed
- **contributing.md** — the `### Branch structure of releases on v7, v6, v4` section was a stale verbatim copy of the upstream osmosis `CONTRIBUTING.md` (which itself never updated past v4/v6/v7). Generalized it to the current policy described in upstream's own *Patch and Minor Releases / Backport Flow* section: each major release has a long-lived release branch (e.g. `v31.x`), PRs land on `main`, state-compatible fixes are backported to the latest major release branch via a `backport` label (mergify).
- **create-ibc-pool.md** — dropped the outdated `only chains using Cosmos-SDK v0.40+ (aka Stargate)` claim. Any IBC-enabled Cosmos chain qualifies; the SDK-version framing is years stale.
- **concentrated-liquidity.md** — the two query examples used module-specific `osmosisd q gamm pool/spot-price`. Switched to the unified `osmosisd query poolmanager pool/spot-price` path. Same positional arg shape (verified against `x/poolmanager/client/cli/query.go`), so the reproduced output stays valid; this is the canonical cross-pool-type query path.

## Verification
- poolmanager `pool` and `spot-price` CLI arg shapes confirmed identical to gamm's (positional pool id + denoms) in current source — clean swap, output blocks unchanged.
- contributing rewrite lifted from the current upstream Backport Flow section, not invented.
- `yarn build` passes (client + server compiled, static files generated).

## Deliberately not changed
- `guides/structure/README.md` block `2836990` references (14 occurrences): left as-is. It is a self-consistent frozen worked example whose actual reproduced JSON output and companion fixture files (`block-2836990.md`, `txs-block-2836990.md`) all correspond to that one block. Genericizing the height would break the command-to-output correspondence and orphan the fixtures. By design, not a bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only edits with no runtime, auth, or on-chain behavior changes.
> 
> **Overview**
> Documentation-only accuracy pass for three guides: **contributing** now describes current release branches and backport flow (e.g. `v31.x`, `main` → `backport` via mergify) instead of obsolete v4/v6/v7 wording. **create-ibc-pool** drops the Stargate / Cosmos-SDK v0.40+ requirement in favor of any IBC-enabled counterparty chain. **concentrated-liquidity** example commands use `osmosisd query poolmanager pool` and `spot-price` instead of legacy `q gamm` paths, with the same positional args so sample output stays valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03c3c2bbf177047141fc4111e6a8e217503d5451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->