### PR TITLE
chore: build tooling cleanup (webpack pin + husky guard) — MTN-86

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,4 +1,10 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-exec < /dev/tty && npx git-cz --hook || true
+# Only launch the interactive commitizen prompt when both stdin and stdout are
+# a TTY. Non-interactive commits (GitHub Desktop, CI, scripted commits) have no
+# controlling terminal; previously `exec < /dev/tty` failed there and aborted
+# the commit, which is why HUSKY=0 was needed as a manual workaround.
+if [ -t 0 ] && [ -t 1 ]; then
+  exec < /dev/tty && npx git-cz --hook || true
+fi

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "stream-browserify": "^3.0.0",
     "typedoc": "^0.23.7",
     "typedoc-plugin-markdown": "^3.13.3",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "webpack": "5.74.0"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -14855,7 +14855,7 @@ webpack-sources@^3.2.2, webpack-sources@^3.2.3:
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.73.0:
+webpack@5.74.0, webpack@^5.73.0:
   version "5.74.0"
   resolved "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz"
   integrity sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==


### PR DESCRIPTION
MTN-86 (Wave 6, build tooling). Two safe, independent fixes.

## webpack pin
`plugins/webpack-plugin.cjs` does `require('webpack')`, but webpack was only present transitively (Docusaurus pulls `webpack@^5.73.0`, resolving to 5.74.0). Added `webpack: "5.74.0"` as an explicit `devDependency` so that import is deterministic and won't drift on a Docusaurus bump.

The `yarn.lock` diff is a **single line** (the existing block now also satisfies `webpack@5.74.0`, same already-resolved 5.74.0, same integrity hash) — no new packages, no re-resolution churn. This also covers the issue's "yarn.lock cleanup / keep diffs minimal" point.

## husky guard
`.husky/prepare-commit-msg` ran `exec < /dev/tty && npx git-cz --hook || true`. In a non-interactive context (GitHub Desktop, CI, scripted commits) there is no controlling terminal, so `exec < /dev/tty` failed and aborted the commit — which is why `HUSKY=0` was needed as a manual workaround. Wrapped the prompt in a TTY check (`[ -t 0 ] && [ -t 1 ]`) so interactive commits still get commitizen and non-TTY commits cleanly skip it.

Verified: the hook now exits 0 in a simulated non-TTY context **without** `HUSKY=0`.

## Not included
- **Dead code (`UIKitReferencePlugins`)** — already removed; `grep` returns zero matches (done in #309).
- **Route deduplication** — already done in #309.

`yarn build` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev tooling and git hook behavior only; no runtime app, auth, or data-path changes.
> 
> **Overview**
> Pins **webpack 5.74.0** as an explicit dev dependency so `plugins/webpack-plugin.cjs`’s direct `require('webpack')` no longer relies on a transitive version from Docusaurus. The lockfile change only merges the new specifier onto the existing 5.74.0 resolution.
> 
> Updates **`.husky/prepare-commit-msg`** so Commitizen runs only when stdin and stdout are TTYs; non-interactive commits skip `exec < /dev/tty` instead of failing and forcing `HUSKY=0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8230ca519e1fe42fde970b3cdffce2ba53fac4fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->