### PR TITLE
docs(tmkms): update protocol_version to v0.38 for CometBFT 0.38

### DIFF
--- a/docs/osmosis-core/keys/tmkms.md
+++ b/docs/osmosis-core/keys/tmkms.md
@@ -124,7 +124,7 @@ path = "/root/tmkms/config/secrets/priv_validator_key"
 chain_id = "osmosis-1"
 addr = "tcp://123.456.32.123:26659"
 secret_key = "/root/tmkms/config/secrets/secret_connection_key"
-protocol_version = "v0.34"
+protocol_version = "v0.38"
 reconnect = true
 ```
 


### PR DESCRIPTION
## Summary

Fixes the one genuinely-stale HIGH finding that slipped through the MTN-85 content-accuracy sweep.

`docs/osmosis-core/keys/tmkms.md` pinned the validator config `protocol_version = "v0.34"`. Osmosis runs **CometBFT v0.38.22** (`osmosis/go.mod`). The current TMKMS `ProtocolVersion` enum (verified in `iqlusioninc/tmkms` source) has exactly two values:

- `"v0.34"` — legacy
- `"v0.38"` — default, correct for a CometBFT 0.38 chain

Validators copy this config block verbatim, so the stale value was a real footgun. Changed to `"v0.38"`.

## On the other "missed finding"

The MTN-85 review flagged two HIGH findings as missed. The second one — `osmosisd in-place-testnet` in `localtesting.md` — turned out to be a **false positive in the original 2026-05-11 audit**, not a real bug:

- The command is registered on `osmosisd` via `server.AddTestnetCreatorCommand(rootCmd, ...)` at `cmd/osmosisd/cmd/root.go:833`. It comes from the cosmos-sdk v0.50 server package, which is why grepping osmosis's own `cmd/` for the string found nothing (that's what misled the audit).
- The documented syntax `osmosisd in-place-testnet <chain-id> <operator-address>` matches the SDK command.

No change made there; the doc is correct as written.

## Verification

- [x] `yarn build` passes (client + server compiled, static files generated)
- [x] TMKMS `protocol_version` value confirmed valid against `iqlusioninc/tmkms` `ProtocolVersion` enum source
- [x] CometBFT version confirmed v0.38.22 in `osmosis/go.mod`
- [x] `in-place-testnet` command registration confirmed at `cmd/osmosisd/cmd/root.go:833`

Relates to MTN-75 / MTN-85.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an example config line; no runtime or application code is modified.
> 
> **Overview**
> Updates the TMKMS validator example in `docs/osmosis-core/keys/tmkms.md` so **`protocol_version`** is **`"v0.38"`** instead of **`"v0.34"`**, matching Osmosis on CometBFT 0.38 and the TMKMS protocol options validators are expected to copy from the doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e49be16eee86a66a3779751d1293d38c990828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->