### PR TITLE
chore(docs): pin Yarn version + ignore minified JS in eslint (MTN-89)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 build
 node_modules
 *.cjs
+*.min.js
 
 sidebars-*.js

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "engines": {
     "node": ">=18.0"
   },
+  "packageManager": "yarn@1.22.22",
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
## Summary

Closes out the toolchain-floor half of [MTN-89](https://linear.app/osmosis/issue/MTN-89/residual-dependency-debt-not-covered-by-docusaurus-3-migration) (residual dependency debt). Two small changes:

- **Pin the package manager:** add `"packageManager": "yarn@1.22.22"` to `package.json`, matching the installed Yarn. Pairs with the existing `engines.node >=18.0` floor (added in the Docusaurus 3 migration) to close the reproducibility gap, previously Node was pinned but the Yarn version was unspecified.
- **Ignore minified JS in ESLint:** add `*.min.js` to `.eslintignore`. The vendored Stoplight web-components bundle (`static/assets/js/elements-web-components.min.js`, added with the D3 migration) sits under `static/`, which ESLint was not ignoring, so the `lint:fix` pre-commit hook tried to lint a 2 MB third-party minified file, produced hundreds of errors, and mutated the bundle under `--fix`. This mirrors the `*.min.js` codespell skip already in place.

## Context: the dependency audit (no code change here)

The other half of MTN-89 was a post-migration dependency triage, recorded on the Linear issue. Headline: **756 to 103 vulnerabilities** after the D3 migration (0 critical, down from 28). The remainder is overwhelmingly build/release/test tooling (semantic-release, commitizen, jest, the build-time Docusaurus chain), not the shipped site. The only client-bundle exposure is `@stoplight/elements`'s transitive tree, which is deeply nested, not directly bumpable, and best resolved by the search-tool decision in MTN-95 rather than a fragile `resolutions` override. Conclusion: **no urgent dependency fixes required.**

## Status (updated)

- **All checks green / non-blocking:** codespell pass, Cursor Bugbot pass, Vercel pass.
- **Socket fresh whole-tree scan ran and is clean.** This PR was opened in part to trigger a current-state Socket scan against post-migration `main` (an earlier export was stale, still showing the pre-migration `webpack` direct pin). The fresh Project Report: **19 alerts, 0 critical, 2 high, rest medium**, mostly deprecation notices in dev/CI tooling. The two high CVEs (`lodash`, `semver`) are build/release tooling. Independently of `yarn audit`, Socket also lands on `@stoplight/elements` as the **only** client-facing dependency surface (it flags `@sentry/browser` there; `yarn audit` flagged `js-cookie`). Both resolve via the MTN-95 Stoplight replacement, not here.
- **The Socket "Warn" comment on this PR is a false positive** (replied inline): it flags `entities@4.5.0` as "obfuscated," but (a) this PR changes no dependencies (only `package.json` + `.eslintignore`, no `yarn.lock`), so Socket is diffing against a missing baseline, and (b) `entities` is the ubiquitous Docusaurus transitive entity codec whose machine-generated lookup tables trip the obfuscation heuristic. The Socket PR-alerts check is "skipping" (neutral), not blocking.

## Risk

Minimal. One reproducibility field and one lint-ignore pattern. No runtime/site change, no `yarn.lock` change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only changes (package manager pin and lint ignore); no runtime, lockfile, or site behavior changes.
> 
> **Overview**
> Pins **Yarn 1.22.22** via `"packageManager"` in `package.json`, alongside the existing Node `>=18.0` engine constraint, so installs use a consistent Yarn version.
> 
> Adds **`*.min.js`** to `.eslintignore` so ESLint (including `lint:fix` in pre-commit) skips vendored minified bundles under `static/`—avoiding noise and accidental `--fix` edits on third-party files such as the Stoplight web-components bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4944b915b11ee7f7ac14864276e539d6b04a0ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
