### PR TITLE
refactor(docs): collapse to a single docs plugin instance (MTN-88 phase 1)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 build
 node_modules
 *.cjs
+*.min.js
 
 sidebars-*.js

--- a/docs/beaker/_category_.json
+++ b/docs/beaker/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Beaker",
-  "position": 1,
+  "position": 4,
   "collapsible": true,
   "collapsed": true,
   "className": "red",

--- a/docs/cosmwasm/_category_.json
+++ b/docs/cosmwasm/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "CosmWasm",
-  "position": 1,
+  "position": 3,
   "collapsible": true,
   "collapsed": false,
   "className": "red",

--- a/docs/frontend/_category_.json
+++ b/docs/frontend/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Frontend",
-  "position": 1,
+  "position": 5,
   "collapsible": true,
   "collapsed": false,
   "className": "red",

--- a/docs/osmojs/_category_.json
+++ b/docs/osmojs/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "OsmoJS",
-  "position": 1,
+  "position": 6,
   "collapsible": true,
   "collapsed": false,
   "className": "red",

--- a/docs/osmosis-core/modules/concentrated-liquidity/README.md
+++ b/docs/osmosis-core/modules/concentrated-liquidity/README.md
@@ -25,7 +25,7 @@ The traditional Balancer AMM relies on the following curve that tracks current r
 
 $$xy = k$$
 
-This formula allows for distributing liquidity along the $xy=k$ curve and across
+This formula allows for distributing liquidity along the $$xy=k$$ curve and across
 the entire price range of (0, &infin;).
 
 With the new architecture, we introduce the concept of a `position` that allows
@@ -41,9 +41,9 @@ Where `P_l` is the lower tick, `P_u` is the upper tick, and `L` is the amount
 of liquidity provided,
 $$L = \sqrt k$$
 
-This formula stems from the original $xy = k$ but with a limited range. In the
+This formula stems from the original $$xy = k$$ but with a limited range. In the
 traditional design, a pool's `x` and `y` tokens are tracked directly. However,
-with the concentrated design, we only track $L$ and $\sqrt P$, which can be
+with the concentrated design, we only track $$L$$ and $$\sqrt P$$, which can be
 calculated with:
 
 $$L = \sqrt {xy}$$
@@ -62,7 +62,7 @@ $$L = \Delta y / \Delta \sqrt{P}$$
 
 Since only one of the following changes at a time:
 
-- $L$: When an LP adds or removes liquidity
+- $$L$$: When an LP adds or removes liquidity
 - sqrt P: When a trader swaps
 
 We can use the above relationship to calculate the outcome of swaps as well as
@@ -108,7 +108,7 @@ In the current design, we hardcode `exponentAtPriceOne` as -6. When used with a
 tick spacing of 100, this effectively acts as an `exponentAtPriceOne` of -4,
 since only every 100 ticks are able to be initialized.
 
-When $exponentAtPriceOne = -6$ (and tick spacing is 100), each tick starting at
+When $$exponentAtPriceOne = -6$$ (and tick spacing is 100), each tick starting at
 0 and ending at the first factor of 10 will represents a spot price increase of 0.0001:
 
 - `tick_{0} = 1`
@@ -151,7 +151,7 @@ price and is less than gamm's max spot price which satisfies the initial design 
 
 After we define tick spacing (which effectively defines the `exponentAtPriceOne`,
 since `exponentAtPriceOne` is fixed), we can then calculate how many ticks must
-be crossed in order for $k$ to be incremented
+be crossed in order for $$k$$ to be incremented
 ( `geometricExponentIncrementDistanceInTicks` ).
 
 ![eq-10](./img/eq-10.png)

--- a/docs/osmosis-core/modules/gamm/pool-models/stableswap/README.md
+++ b/docs/osmosis-core/modules/gamm/pool-models/stableswap/README.md
@@ -5,9 +5,9 @@ There is a price ratio they are expected to be at, and the AMM offers low slippa
 There is still price impact for each trade, and as the liquidity becomes more lop-sided, the slippage drastically increases.
 
 This package implements the Solidly stableswap curve, namely a CFMM with
-invariant: $f(x, y) = xy(x^2 + y^2) = k$
+invariant: $$f(x, y) = xy(x^2 + y^2) = k$$
 
-It is generalized to the multi-asset setting as $f(a_1, ..., a_n) = a_1 * ... * a_n (a_1^2 + ... + a_n^2)$
+It is generalized to the multi-asset setting as $$f(a_1, ..., a_n) = a_1 * ... * a_n (a_1^2 + ... + a_n^2)$$
 
 ## Pool configuration
 
@@ -69,7 +69,7 @@ Then we show how these are used to give all of the swqp equations. --->
 
 Most operations we do only need to reason about two of the assets in a pool, and sometimes only one.
 We wish to have a simpler CFMM function to work within these cases.
-Due to the CFMM equation $f$ being a symmetric function, we can without loss of generality reorder the arguments to the function. Thus we put the assets of relevance at the beginning of the function. So if two assets $x, y$, we write: $f(x,y, a_3, ... a_n) = xy * a_3 * ... a_n (x^2 + y^2 + a_3^2 + ... + a_n^2)$.
+Due to the CFMM equation $$f$$ being a symmetric function, we can without loss of generality reorder the arguments to the function. Thus we put the assets of relevance at the beginning of the function. So if two assets $$x, y$$, we write: $$f(x,y, a_3, ... a_n) = xy * a_3 * ... a_n (x^2 + y^2 + a_3^2 + ... + a_n^2)$$.
 
 We then take a more convenient expression to work with, via variable substitution.
 
@@ -97,26 +97,26 @@ $$
 
 $$\text{then } g(x,y,v,w) = xyv(x^2 + y^2 + w) = f(x,y, a_3, ... a_n)$$
 
-As a corollary, notice that $g(x,y,v,w) = v * g(x,y,1,w)$, which will be useful when we have to compare before and after quantities. We will use $h(x,y,w) := g(x,y,1,w)$ as short-hand for this.
+As a corollary, notice that $$g(x,y,v,w) = v * g(x,y,1,w)$$, which will be useful when we have to compare before and after quantities. We will use $$h(x,y,w) := g(x,y,1,w)$$ as short-hand for this.
 
 ### Swaps
 
-The question we need to answer for a swap is "suppose I want to swap $a$ units of $x$, how many units $b$ of $y$ would I get out".
+The question we need to answer for a swap is "suppose I want to swap $$a$$ units of $$x$$, how many units $$b$$ of $$y$$ would I get out".
 
-Since we only deal with two assets at a time, we can then work with our prior definition of $g$. Let the input asset's reserves be $x$, the output asset's reserves be $y$, and we compute $v$ and $w$ given the other asset reserves, whose reserves are untouched throughout the swap.
+Since we only deal with two assets at a time, we can then work with our prior definition of $$g$$. Let the input asset's reserves be $$x$$, the output asset's reserves be $$y$$, and we compute $$v$$ and $$w$$ given the other asset reserves, whose reserves are untouched throughout the swap.
 
 First we note the direct way of solving this, its limitation, and then an iterative approximation approach that we implement.
 
 #### Direct swap solution
 
 The method to compute this under 0 swap fee is implied by the CFMM equation itself, since the constant refers to:
-$g(x_0, y_0, v, w) = k = g(x_0 + a, y_0 - b, v, w)$. As $k$ is linearly related to $v$, and $v$ is unchanged throughout the swap, we can simplify the equation to be reasoning about $k' = \frac{k}{v}$ as the constant, and $h$ instead of $g$
+$$g(x_0, y_0, v, w) = k = g(x_0 + a, y_0 - b, v, w)$$. As $$k$$ is linearly related to $$v$$, and $$v$$ is unchanged throughout the swap, we can simplify the equation to be reasoning about $$k' = \frac{k}{v}$$ as the constant, and $$h$$ instead of $$g$$
 
-We then model the solution by finding a function $\text{solve cfmm}(x, w, k') = y\text{ s.t. }h(x, y, w) = k'$.
-Then we can solve the swap amount out by first computing $k'$ as $k' = h(x_0, y_0, w)$, and
-computing $y_f := \text{solve cfmm}(x_0 + a, w, k')$. We then get that $b = y_0 - y_f$.
+We then model the solution by finding a function $$\text{solve cfmm}(x, w, k') = y\text{ s.t. }h(x, y, w) = k'$$.
+Then we can solve the swap amount out by first computing $$k'$$ as $$k' = h(x_0, y_0, w)$$, and
+computing $$y_f := \text{solve cfmm}(x_0 + a, w, k')$$. We then get that $$b = y_0 - y_f$$.
 
-So all we need is an equation for $\text{solve cfmm}$! Its essentially inverting a multi-variate polynomial, and in this case is solvable: [wolfram alpha link](https://www.wolframalpha.com/input?i=solve+for+y+in+x+*+y+*+%28x%5E2+%2B+y%5E2+%2B+w%29+%3D+k)
+So all we need is an equation for $$\text{solve cfmm}$$! Its essentially inverting a multi-variate polynomial, and in this case is solvable: [wolfram alpha link](https://www.wolframalpha.com/input?i=solve+for+y+in+x+*+y+*+%28x%5E2+%2B+y%5E2+%2B+w%29+%3D+k)
 
 Or if were clever with simplification in the two asset case, we can reduce it to: [desmos link](https://www.desmos.com/calculator/hag1f0wieg).
 
@@ -126,23 +126,23 @@ Instead there is a more generic way to compute these, which we detail in the nex
 
 #### Iterative search solution
 
-Instead of using the direct solution for $\text{solve cfmm}(x, w, k')$, instead notice that $h(x, y, w)$ is an increasing function in $y$.
-So we can simply binary search for $y$ such that $h(x, y, w) = k'$, and we are guaranteed convergence within some error bound.
+Instead of using the direct solution for $$\text{solve cfmm}(x, w, k')$$, instead notice that $$h(x, y, w)$$ is an increasing function in $$y$$.
+So we can simply binary search for $$y$$ such that $$h(x, y, w) = k'$$, and we are guaranteed convergence within some error bound.
 
-In order to do a binary search, we need bounds on $y$.
-The lowest lowerbound is $0$, and the largest upperbound is $\infty$.
-The maximal upperbound is obviously unworkable, and in general binary searching around wide ranges is unfortunate, as we expect most trades to be centered around $y_0$.
+In order to do a binary search, we need bounds on $$y$$.
+The lowest lowerbound is $$0$$, and the largest upperbound is $$\infty$$.
+The maximal upperbound is obviously unworkable, and in general binary searching around wide ranges is unfortunate, as we expect most trades to be centered around $$y_0$$.
 This would suggest that we should do something smarter to iteratively approach the right value for the upperbound at least.
-Notice that $h$ is super-linearly related in $y$, and at most cubically related to $y$.
-This means that $\forall c \in \mathbb{R}^+, c * h(x,y,w) < h(x,c*y,w) < c^3 * h(x,y,w)$.
-We can use this fact to get a pretty-good initial upperbound guess for $y$ using the linear estimate.
-In the lowerbound case, we leave it as lower-bounded by $0$, otherwise we would need to take a cubed root to get a better estimate.
+Notice that $$h$$ is super-linearly related in $$y$$, and at most cubically related to $$y$$.
+This means that $$\forall c \in \mathbb{R}^+, c * h(x,y,w) < h(x,c*y,w) < c^3 * h(x,y,w)$$.
+We can use this fact to get a pretty-good initial upperbound guess for $$y$$ using the linear estimate.
+In the lowerbound case, we leave it as lower-bounded by $$0$$, otherwise we would need to take a cubed root to get a better estimate.
 
 ##### Altering binary search equations due to error tolerance
 
 Great, we have a binary search to finding an input `new_y_reserve`, such that we get a value `k` within some error bound close to the true desired `k`! We can prove that an error by a factor of `e` in `k`, implies an error of a factor less than `e` in `new_y_reserve`. So we could set `e` to be close to some correctness bound we want. Except... `new_y_reserve >> y_in`, so we'd need an extremely high error tolerance for this to work. So we actually want to adapt the equations, to reduce the "common terms" in `k` that we need to binary search over, to help us search. To do this, we open up what are we doing again, and re-expose `y_out` as a variable we explicitly search over (and therefore get error terms in `k` implying error in `y_out`)
 
-What we are doing above in the binary search is setting `k_target` and searching over `y_f` until we get `k_iter` within tolerance to `k_target`. Sine we want to change to iterating over $y_{out}$, we unroll that $y_f = y_0 - y_{out}$ where they are defined as:
+What we are doing above in the binary search is setting `k_target` and searching over `y_f` until we get `k_iter` within tolerance to `k_target`. Sine we want to change to iterating over $$y_{out}$$, we unroll that $$y_f = y_0 - y_{out}$$ where they are defined as:
 $$k_{target} = x_0 y_0 (x_0^2 + y_0^2 + w)$$
 $$k_{iter}(y_0 - y_{out}) = h(x_f, y_0 - y_{out}, w) = x_f (y_0 - y_{out}) (x_f^2 + (y_0 - y_{out})^2 + w)$$
 
@@ -152,7 +152,7 @@ $$k_{target} = x_0 y_0 (x_0^2 + y_0^2 + w) / x_f$$
 
 $$k_{iter}(y_{out}) = (y_0 - y_{out}) (x_f^2 + (y_0 - y_{out})^2 + w) = (y_0 - y_{out}) (x_f^2 + w) + (y_0 - y_{out})^3$$
 
-So $k_{iter}(y_{out})$ is a cubic polynomial in $y_{out}$. Next we remove the terms that have no dependence on `y_{delta}` (the constant term in the polynomial). To do this first we rewrite this to make the polynomial clearer:
+So $$k_{iter}(y_{out})$$ is a cubic polynomial in $$y_{out}$$. Next we remove the terms that have no dependence on `y_{delta}` (the constant term in the polynomial). To do this first we rewrite this to make the polynomial clearer:
 
 $$k_{iter}(y_{out}) = (y_0 - y_{out}) (x_f^2 + w) + y_0^3 - 3y_0^2 y_{out} + 3 y_0 y_{out}^2 - y_{out}^3$$
 
@@ -176,7 +176,7 @@ We target an error of less than `10^{-8}` in `y_{out}`, so we conservatively set
 
 Now we want to wrap this binary search into `solve_cfmm`. We changed the API slightly, from what was previously denoted, to have this "y_0" term, in order to derive initial bounds.
 
-One complexity is that in the iterative search, we iterate over $y_f$, but then translate to $y_0$ in the internal equations.
+One complexity is that in the iterative search, we iterate over $$y_f$$, but then translate to $$y_0$$ in the internal equations.
 So we also use the
 
 ```python
@@ -254,7 +254,7 @@ And therefore we round up in both cases.
 
 ##### Further optimization
 
-- The astute observer may notice that the equation we are solving in $\text{solve cfmm}$ is actually a cubic polynomial in $y$, with an always-positive derivative.
+- The astute observer may notice that the equation we are solving in $$\text{solve cfmm}$$ is actually a cubic polynomial in $$y$$, with an always-positive derivative.
   We should then be able to use newton's root finding algorithm to solve for the solution with quadratic convergence.
   We do not pursue this today, due to other engineering tradeoffs, and insufficient analysis being done.
 
@@ -322,15 +322,15 @@ Something we have to be careful of is precision handling, notes on why and how w
 
 #### Proof that |e_y| &lt; 100|e_k|
 
-The function $f(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$ is monotonically increasing over the reals.
+The function $$f(y_{out}) = -y_{out}^3 + 3 y_0 y_{out}^2 - (x_f^2 + w + 3y_0^2)y_{out}$$ is monotonically increasing over the reals.
 You can prove this, by seeing that its [derivative's](https://www.wolframalpha.com/input?i=d%2Fdx+-x%5E3+%2B+3a+x%5E2+-+%28b+%2B+3a%5E2%29+x+) 0 values are both imaginary, and therefore has no local minima or maxima in the reals.
-Therefore, there exists exactly one real $y_{out}$ s.t. $f(y_{out}) = k$.
-Via binary search, we solve for a value $y_{out}^{\*}$ such that $\left|\frac{ k - k^{\*} }{k}\right| < e_k$, where $k^{\*} = f(y_{out}^{\*})$. We seek to then derive bounds on $e_y = \left|\frac{ y_{out} - y_{out}^{\*} }{y_{out}}\right|$ in relation to $e_k$.
+Therefore, there exists exactly one real $$y_{out}$$ s.t. $$f(y_{out}) = k$$.
+Via binary search, we solve for a value $$y_{out}^{\*}$$ such that $$\left|\frac{ k - k^{\*} }{k}\right| < e_k$$, where $$k^{\*} = f(y_{out}^{\*})$$. We seek to then derive bounds on $$e_y = \left|\frac{ y_{out} - y_{out}^{\*} }{y_{out}}\right|$$ in relation to $$e_k$$.
 
-**Theorem**: $e_y < 100 e_k$ as long as $|y_{out}| <= .9y_0$.
-**Informal**, we claim that for $.9y_0 < |y_{out}| < y_0$, `e_y` is "close" to `e_k` under expected parameterizations. And for $y_{out}$ significantly less than $.9y_0$, the error bounds are much better. (Often better than $e_k$)
+**Theorem**: $$e_y < 100 e_k$$ as long as $$|y_{out}| <= .9y_0$$.
+**Informal**, we claim that for $$.9y_0 < |y_{out}| < y_0$$, `e_y` is "close" to `e_k` under expected parameterizations. And for $$y_{out}$$ significantly less than $$.9y_0$$, the error bounds are much better. (Often better than $$e_k$$)
 
-Let $y_{out} - y_{out}^* = a_y$, we are going to assume that $a_y << y_{out}$, and will justify this later. But due to this, we treat $a_y^c = 0$ for $c > 1$. This then implies that $y_{out}^2 - y_{out}^{*2} = y_{out}^2 - (y_{out} - a_y)^2 \approx 2y_{out}a_y$, and similarly $y_{out}^3 - y_{out}^{*3} \approx 3y_{out}^2 a_y$
+Let $$y_{out} - y_{out}^* = a_y$$, we are going to assume that $$a_y << y_{out}$$, and will justify this later. But due to this, we treat $$a_y^c = 0$$ for $$c > 1$$. This then implies that $$y_{out}^2 - y_{out}^{*2} = y_{out}^2 - (y_{out} - a_y)^2 \approx 2y_{out}a_y$$, and similarly $$y_{out}^3 - y_{out}^{*3} \approx 3y_{out}^2 a_y$$
 
 Now we are prepared to start bounding this.
 $$k - k^{\*} = -(y_{out}^3 - y_{out}^{3\*}) + 3y_0(y_{out}^2 - y_{out}^{2\*}) - (x_f^2 + w + 3y_0^2)(y_{out} - y_{out}^{\*})$$
@@ -339,30 +339,30 @@ $$k - k^{\*} \approx -(3y_{out}^2 a_y) + 3y_0 (2y_{out}a_y) - (x_f^2 + w + 3y_0^
 
 $$k - k^{\*} \approx a_y(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))$$
 
-Rewrite $k = y_{out}(-y_{out}^2 + 3y_0y_{out} - (x_f^2 + w + 3y_0^2))$
+Rewrite $$k = y_{out}(-y_{out}^2 + 3y_0y_{out} - (x_f^2 + w + 3y_0^2))$$
 
 $$e_k > \left|\frac{ k - k^{\*} }{k}\right| = \left|\frac{a_y}{y_{out}} \frac{(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))}{(-y_{out}^2 + 3y_0y_{out} - (x_f^2 + w + 3y_0^2))}\right|$$
 
-Notice that $\left|\frac{a_y}{y_{out}}\right| = e_y$! Therefore
+Notice that $$\left|\frac{a_y}{y_{out}}\right| = e_y$$! Therefore
 
 $$e_k > e_y\left|\frac{(-3y_{out}^2 + 6y_0y_{out} - (x_f^2 + w + 3y_0^2))}{(-y_{out}^2 + 3y_0y_{out} - (x_f^2 + w + 3y_0^2))}\right|$$
 
-We bound the right hand side, with the assistance of wolfram alpha. Let $a = y_{out}, b = y_0, c = x_f^2 + w$. Then we see from [wolfram alpha here](https://www.wolframalpha.com/input?i=%7C%28-3a%5E2+%2B+6ab+-+%28c+%2B+3b%5E2%29%29+%2F+%28-a%5E2+%2B+3ab+-+%28c+%2B+3b%5E2%29%29+%7C+%3E+.01), that this right hand expression is provably greater than `.01` if some set of decisions hold. We describe the solution set that satisfies our use case here:
+We bound the right hand side, with the assistance of wolfram alpha. Let $$a = y_{out}, b = y_0, c = x_f^2 + w$$. Then we see from [wolfram alpha here](https://www.wolframalpha.com/input?i=%7C%28-3a%5E2+%2B+6ab+-+%28c+%2B+3b%5E2%29%29+%2F+%28-a%5E2+%2B+3ab+-+%28c+%2B+3b%5E2%29%29+%7C+%3E+.01), that this right hand expression is provably greater than `.01` if some set of decisions hold. We describe the solution set that satisfies our use case here:
 
-- When $y_{out} > 0$
-  - Use solution set: $a > 0, b > \frac{2}{3} a, c > \frac{1}{99} (-299a^2 + 597ab - 297b^2)$
-    - $a > 0$ by definition.
-    - $b > \frac{2}{3} a$, as that's equivalent to $y_0 > \frac{2}{3} y_{out}$. We already assume that $y_0 >= y_{out}$.
-    - Set $y_{out} = .9y_0$, per our theorem assumption. So $b = .9a$. Take $c = x^2 + w = 0$. Then [we can show that](https://www.wolframalpha.com/input?i=0+%3E+-299a%5E2+%2B+597ab+-+297b%5E2%2C+when+b%3D+.90a) $(-299a^2 + 597ab - 297b^2) < 0$ for all $a$. This completes the constraint set.
-- When $y_{out} < 0$
-  - Use solution set: $a < 0, b > \frac{2}{3} a, c > -a^2 + 3ab - 3b^2$
-    - $a < 0$ by definition.
-    - $b > \frac{2}{3} a$, as $y_0$ is positive.
-    - $c > 0$ is by definition, so we just need to bound when $-a^2 + 3ab - 3b^2 < 0$. This is always the case as long as one of $a$ or $b$ is non-zero, per [here](https://www.wolframalpha.com/input?i=-a%5E2+%2B+3ab+-+3b%5E2+%3C+0).
+- When $$y_{out} > 0$$
+  - Use solution set: $$a > 0, b > \frac{2}{3} a, c > \frac{1}{99} (-299a^2 + 597ab - 297b^2)$$
+    - $$a > 0$$ by definition.
+    - $$b > \frac{2}{3} a$$, as that's equivalent to $$y_0 > \frac{2}{3} y_{out}$$. We already assume that $$y_0 >= y_{out}$$.
+    - Set $$y_{out} = .9y_0$$, per our theorem assumption. So $$b = .9a$$. Take $$c = x^2 + w = 0$$. Then [we can show that](https://www.wolframalpha.com/input?i=0+%3E+-299a%5E2+%2B+597ab+-+297b%5E2%2C+when+b%3D+.90a) $$(-299a^2 + 597ab - 297b^2) < 0$$ for all $$a$$. This completes the constraint set.
+- When $$y_{out} < 0$$
+  - Use solution set: $$a < 0, b > \frac{2}{3} a, c > -a^2 + 3ab - 3b^2$$
+    - $$a < 0$$ by definition.
+    - $$b > \frac{2}{3} a$$, as $$y_0$$ is positive.
+    - $$c > 0$$ is by definition, so we just need to bound when $$-a^2 + 3ab - 3b^2 < 0$$. This is always the case as long as one of $$a$$ or $$b$$ is non-zero, per [here](https://www.wolframalpha.com/input?i=-a%5E2+%2B+3ab+-+3b%5E2+%3C+0).
 
-Tying this all together, we have that $e_k > .01e_y$. Therefore $e_y < 100 e_k$, satisfying our theoerem!
+Tying this all together, we have that $$e_k > .01e_y$$. Therefore $$e_y < 100 e_k$$, satisfying our theoerem!
 
-To show the informal claims, the constraint that led to this 100x error blowup was trying to accommodate high $y_{out}$. When $y_{out}$ is smaller, the error is far lower. (Often to the case that $e_y < e_k$, you can convince yourself of this by setting the ratio to being greater than 1 in wolfram alpha) When $y_{out}$ is bigger than $.9y_0$, we can rely on x_f^2 + w being much larger to lower this error. In these cases, the $x_f$ term must be large relative to $y_0$, which would yield a far better error bound.
+To show the informal claims, the constraint that led to this 100x error blowup was trying to accommodate high $$y_{out}$$. When $$y_{out}$$ is smaller, the error is far lower. (Often to the case that $$e_y < e_k$$, you can convince yourself of this by setting the ratio to being greater than 1 in wolfram alpha) When $$y_{out}$$ is bigger than $$.9y_0$$, we can rely on x_f^2 + w being much larger to lower this error. In these cases, the $$x_f$$ term must be large relative to $$y_0$$, which would yield a far better error bound.
 
 TODO: Justify `a_y << y_out`. (This should be easy, assume its not, that leads to e_k being high. Ratio test probably easiest. Maybe just add a sentence to that effect)
 
@@ -373,9 +373,9 @@ However for the stableswap equation, this is painful: [wolfram alpha link](https
 
 So instead we compute the spot price by approximating the derivative via a small swap.
 
-Let $\epsilon$ be a sentinel very small swap in amount.
+Let $$\epsilon$$ be a sentinel very small swap in amount.
 
-Then $\text{spot price} = \frac{\text{CalculateOutAmountGivenIn}(\epsilon)}{\epsilon}$.
+Then $$\text{spot price} = \frac{\text{CalculateOutAmountGivenIn}(\epsilon)}{\epsilon}$$.
 
 ### LP equations
 

--- a/docs/osmosis-core/modules/twap/README.md
+++ b/docs/osmosis-core/modules/twap/README.md
@@ -10,7 +10,7 @@ A time weighted average price is a function that takes a sequence of `(time, pri
 Using the arithmetic mean, the TWAP of a sequence `(t_i, p_i)`, from `t_0` to `t_n`, indexed by time in ascending order, is: $$\frac{1}{t_n - t_0}\sum_{i=0}^{n-1} p_i (t_{i+1} - t_i)$$
 Notice that the latest price `p_n` isn't used, as it has lasted for a time interval of `0` seconds in this range!
 
-To illustrate with an example, given the sequence: `(0s, $1), (4s, $6), (5s, $1)`, the arithmetic mean TWAP is: 
+To illustrate with an example, given the sequence: `(0s, $$1), (4s, $$6), (5s, $1)`, the arithmetic mean TWAP is: 
 $$\frac{\$1 * (4s - 0s) + \$6 * (5s - 4s)}{5s - 0s} = \frac{\$10}{5} = \$2$$
 
 ## Computation via accumulators method
@@ -19,7 +19,7 @@ The prior example for how to compute the TWAP takes linear time in the number of
 
 This is achieved by using an accumulator. In the case of an arithmetic TWAP, we can maintain an accumulator from `a_n`, representing the numerator of the TWAP expression for the interval `t_0...t_n`, namely 
 $$a_n = \sum_{i=0}^{n-1} p_i (t_{i+1} - t_i)$$
-If we maintain such an accumulator for every pool, with `t_0 = pool_creation_time` to `t_n = current_block_time`, we can easily compute the TWAP for any interval. The TWAP for the time interval of price points `t_i` to `t_j` is then $twap = \frac{a_j - a_i}{t_j - t_i}$, which is constant time given the accumulator values.
+If we maintain such an accumulator for every pool, with `t_0 = pool_creation_time` to `t_n = current_block_time`, we can easily compute the TWAP for any interval. The TWAP for the time interval of price points `t_i` to `t_j` is then $$twap = \frac{a_j - a_i}{t_j - t_i}$$, which is constant time given the accumulator values.
 
 In Osmosis, we maintain accumulator records for every pool, for the last 48 hours.
 We also maintain within each accumulator record in state, the latest spot price.

--- a/docs/overview/_category_.json
+++ b/docs/overview/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Overview",
+  "position": 1,
+  "collapsible": true,
+  "collapsed": false,
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/docs/telescope/_category_.json
+++ b/docs/telescope/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Telescope",
-  "position": 1,
+  "position": 7,
   "collapsible": true,
   "collapsed": false,
   "className": "red",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,61 +18,34 @@ const rehypeKatex = esmDefault(require('rehype-katex'));
   remarkPlugins: [[npm2yarn, { sync: true }]],
 };
 
-// KaTeX is enabled per-section, not globally. remark-math (v3) treats every
-// unescaped paired `$...$` as inline math and offers no option to disable that,
-// so enabling it everywhere would mangle currency ($500) and shell vars ($HOME,
-// $OSMO) in prose across the cosmwasm, validate, and endpoints pages. Only the
-// osmosis-core and overview sections carry real math (concentrated-liquidity,
-// stableswap, twap, apr), so the math plugins are scoped to just those two.
-// Within those sections, inline math uses `$...$` and display math uses
-// `$$...$$` (remark-math v3 supports no other delimiter). Prose dollar
-// amounts and shell vars in these sections are escaped as `\$` so they are
-// not parsed as math.
-const mathSettings = {
-  remarkPlugins: [remarkMath],
-  rehypePlugins: [rehypeKatex],
-};
+// Math (KaTeX) is applied globally to the single docs instance. remark-math 6
+// supports `singleDollarTextMath: false`, which requires `$$...$$` for inline
+// math and leaves a single `$` as literal text, so bare dollar signs in prose
+// and code (currency like $500, shell vars like $HOME / $CODE_ID across the
+// cosmwasm and validate pages) are NOT parsed as math. This removes the old
+// per-section scoping (a remark-math v3 limitation) that previously forced the
+// docs to be split into separate plugin instances. Inline math uses `$$...$$`
+// on the same line; display math uses `$$...$$` as its own block.
+const mathRemark = [remarkMath, { singleDollarTextMath: false }];
 
-/**
- * Defines a section with overridable defaults
- * @param {string} section
- * @param {import('@docusaurus/plugin-content-docs').Options} options
- */
-function defineSection(section, options = {}) {
-  return [
-    '@docusaurus/plugin-content-docs',
-    /** @type {import('@docusaurus/plugin-content-docs').Options} */
-    ({
-      path: `docs/${section}`,
-      routeBasePath: section,
-      id: section,
-      sidebarPath: require.resolve('./sidebars-default.js'),
-      breadcrumbs: false,
-      editUrl: 'https://github.com/osmosis-labs/docs/tree/main/',
-      ...defaultSettings,
-      ...options,
-      // Concatenate plugin arrays rather than letting `options` clobber the
-      // defaults, so a section can add math plugins without dropping npm2yarn.
-      remarkPlugins: [
-        ...(defaultSettings.remarkPlugins || []),
-        ...(options.remarkPlugins || []),
-      ],
-      rehypePlugins: [
-        ...(defaultSettings.rehypePlugins || []),
-        ...(options.rehypePlugins || []),
-      ],
-    }),
-  ];
-}
-
-const SECTIONS = [
-  defineSection('osmosis-core', mathSettings),
-  defineSection('cosmwasm'),
-  defineSection('frontend'),
-  defineSection('beaker'),
-  defineSection('telescope'),
-  defineSection('osmojs'),
-  defineSection('overview', mathSettings),
+// Single docs instance rooted at `docs/`, served at the site root so existing
+// URLs are preserved (docs/osmosis-core/... -> /osmosis-core/...). One sidebar
+// follows the reader across all sections (the fix for the former per-section
+// isolated sidebars). MTN-88 Phase 1: collapse only; the folder->taxonomy
+// reorganization and redirects come in a later phase.
+const docsPlugin = [
+  '@docusaurus/plugin-content-docs',
+  /** @type {import('@docusaurus/plugin-content-docs').Options} */
+  ({
+    path: 'docs',
+    routeBasePath: '/',
+    id: 'default',
+    sidebarPath: require.resolve('./sidebars-default.js'),
+    breadcrumbs: false,
+    editUrl: 'https://github.com/osmosis-labs/docs/tree/main/',
+    remarkPlugins: [...defaultSettings.remarkPlugins, mathRemark],
+    rehypePlugins: [rehypeKatex],
+  }),
 ];
 
 /** @type {import('@docusaurus/types').Config} */
@@ -122,7 +95,7 @@ const config = {
   ],
 
   plugins: [
-    ...SECTIONS,
+    docsPlugin,
     webpackPlugin,
   ],
 


### PR DESCRIPTION
## Summary

Phase 1 of the IA restructure ([MTN-88](https://linear.app/osmosis/issue/MTN-88/ia-path-b-single-docs-tree-purpose-driven-taxonomy-epic)): collapse the docs site from **7 separate `@docusaurus/plugin-content-docs` instances into one**. This is the structural foundation; it is deliberately **content- and URL-neutral** so it can land independently before the disruptive folder reorganization.

**No URLs change in this PR.** The folder reorganization into the new taxonomy, the redirect map, and the navbar rewrite are later phases.

## What changed

**Single docs instance (`docusaurus.config.js`)**
- Replaced the `SECTIONS` / `defineSection` loop (one instance per section: osmosis-core, cosmwasm, frontend, beaker, telescope, osmojs, overview) with a single instance rooted at `docs/`, served at the site root (`routeBasePath: '/'`).
- Because the instance serves `docs/` at root, every existing path is preserved: `docs/osmosis-core/modules/gamm` still resolves at `/osmosis-core/modules/gamm`, etc.
- **One sidebar now follows the reader across all sections.** Previously each section was its own instance with an isolated sidebar that reset when you navigated between sections (the root problem Path A did not fix).

**Math decoupled from sections**
- The old setup scoped remark-math/rehype-katex to only `osmosis-core` + `overview`, because remark-math v3 parsed every `$...$` as math and would mangle shell vars (`$HOME`, `$CODE_ID`) and currency in the other sections. That scoping is what forced the multi-instance split.
- remark-math 6 supports `singleDollarTextMath: false`: inline math requires `$$...$$`, and a single `$` stays literal text. Math is now applied **globally** with that flag, so bare `$` is safe everywhere and the section coupling is gone.
- Converted the ~115 existing inline single-`$` math spans on the three math pages (stableswap 106, concentrated-liquidity 7, twap 2) to `$$...$$`. Inline spans stay inline; display blocks are unchanged.

**Sidebar ordering**
- With one sidebar, the per-section `position` values now compete in a single list. Set a deterministic top-level order: **Overview (1), Chain Development (2), CosmWasm (3), Beaker (4), Frontend (5), OsmoJS (6), Telescope (7)**.
- Added `docs/overview/_category_.json` (it had none, so it was unpositioned and its label fell back to the lowercased folder name); label is now "Overview", position 1.

**CI**
- Add `*.min.js` to `.eslintignore` so the `lint:fix` pre-commit hook does not lint the vendored Stoplight bundle. Same fix as #327; the two converge harmlessly on merge.

## For the reviewer: what to check

Most of this is mechanical, but two behavioral changes (unified sidebar, math delimiter rule) are worth eyeballing on the Vercel preview. Suggested checks:

- [ ] **Sidebar is unified and ordered.** Open any page and confirm the left sidebar shows all sections in this order: Overview → Chain Development → CosmWasm → Beaker → Frontend → OsmoJS → Telescope, and that navigating from one section to another does **not** reset the sidebar. "Overview" is capitalized.
- [ ] **Math still renders.** Open [`/osmosis-core/modules/gamm/pool-models/stableswap`](https://docs-git-chore-mtn-88-single-docs-instance.vercel.dev-osmosis.zone/osmosis-core/modules/gamm/pool-models/stableswap/) (the heaviest math page, ~106 converted spans) and confirm formulas render as KaTeX, with **inline math staying inline** (not bumped onto its own centered line). Spot-check [`/osmosis-core/modules/concentrated-liquidity`](https://docs-git-chore-mtn-88-single-docs-instance.vercel.dev-osmosis.zone/osmosis-core/modules/concentrated-liquidity) and [`/osmosis-core/modules/twap`](https://docs-git-chore-mtn-88-single-docs-instance.vercel.dev-osmosis.zone/osmosis-core/modules/twap) too.
- [ ] **Bare `$` is NOT rendered as math.** Open [`/cosmwasm/local/localosmosis`](https://docs-git-chore-mtn-88-single-docs-instance.vercel.dev-osmosis.zone/cosmwasm/local/localosmosis) and confirm shell vars like `$HOME`, `$CODE_ID`, `$TX` show as literal text, not mangled into math. (This is the change that let math go global; the failure mode would be stretches of prose/commands turning into garbled math.)
- [ ] **A few representative URLs are unchanged.** e.g. [`/osmosis-core/modules/gamm`](https://docs-git-chore-mtn-88-single-docs-instance.vercel.dev-osmosis.zone/osmosis-core/modules/gamm), [`/cosmwasm`](https://docs-git-chore-mtn-88-single-docs-instance.vercel.dev-osmosis.zone/cosmwasm), [`/overview/educate/osmosis`](https://docs-git-chore-mtn-88-single-docs-instance.vercel.dev-osmosis.zone/overview/educate/osmosis), [`/beaker`](https://docs-git-chore-mtn-88-single-docs-instance.vercel.dev-osmosis.zone/beaker), [`/telescope`](https://docs-git-chore-mtn-88-single-docs-instance.vercel.dev-osmosis.zone/telescope) all still resolve (no 404s). This PR should not have moved anything.
- [ ] **Sanity:** the homepage ([`/`](https://docs-git-chore-mtn-88-single-docs-instance.vercel.dev-osmosis.zone/)) and [`/api`](https://docs-git-chore-mtn-88-single-docs-instance.vercel.dev-osmosis.zone/api)` still load (the docs-at-root change should not have touched the custom pages).

If a future inline `$...$` (single dollar) shows up unrendered anywhere, that is the expected new behavior, inline math now requires `$$...$$`. Flag any page where that regressed real math.

## What I already verified (local build)

- `yarn build` green; one docs instance in `.docusaurus`; sidebar order confirmed from the rendered nav (Overview → Chain Development → … → Telescope).
- Old section URLs build at the same locations; math pages emit KaTeX with inline staying inline; `cosmwasm/local/localosmosis` shows `$HOME`/`$CODE_ID`/`$TX` as literal text.

## Risk

Low. No content moves, no URL changes. The two behavioral changes are the unified sidebar (intended) and the math delimiter rule (`$$` now required for inline math, verified on the three math pages).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No content moves or URL changes; risk is limited to sidebar UX and verifying math/shell-var rendering after the delimiter change.
> 
> **Overview**
> **Phase 1 (MTN-88)** replaces seven separate `@docusaurus/plugin-content-docs` instances with **one** plugin rooted at `docs/` and `routeBasePath: '/'`, so paths like `/osmosis-core/...` stay the same while **one sidebar** spans all sections instead of resetting per section.
> 
> **KaTeX/remark-math** is enabled site-wide with `singleDollarTextMath: false`, so a lone `$` stays literal (shell vars, currency) and inline math uses `$$...$$`. Math-heavy module docs (concentrated liquidity, stableswap, twap) were updated from single-`$` inline spans to `$$...$$`.
> 
> **Sidebar ordering:** new `docs/overview/_category_.json` at position 1; Beaker, CosmWasm, Frontend, OsmoJS, and Telescope category positions renumbered (3–7).
> 
> **CI:** `.eslintignore` adds `*.min.js` so vendored minified bundles are not linted on pre-commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 221ac2ded6deef3c75e1b63f21391730135cd05c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


