### PR TITLE
fix(docs): disable Algolia contextualSearch to restore search

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 build
 node_modules
 *.cjs
+*.min.js
 
 sidebars-*.js

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -292,7 +292,11 @@ const config = {
         appId: 'O18C1RUI3F',
         apiKey: '7e6702351d8d0157591e9c8d417f47dd',
         indexName: 'Docs',
-        contextualSearch: true,
+        // Disabled: the deployed index has no `attributesForFaceting`, so the
+        // `docusaurus_tag` facet filter that contextual search appends to every
+        // query matches zero records and search returns nothing. Re-enable only
+        // once the index is crawled with faceting settings applied.
+        contextualSearch: false,
         searchParameters: {},
       },
     }),


### PR DESCRIPTION
@-

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only config and lint ignore changes; no runtime app or security impact.
> 
> **Overview**
> **Docs site search** was broken because Algolia **contextual search** adds a `docusaurus_tag` facet filter on every query, but the live index is not configured with `attributesForFaceting`, so queries matched no records. The PR sets **`contextualSearch` to `false`** and documents that contextual search should stay off until the index is re-crawled with the right faceting settings.
> 
> **`.eslintignore`** now ignores **`*.min.js`** so minified bundles are not linted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc1ee7ee68b93cf3de9d7ed58f0883122c08d734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->