### PR TITLE
fix(docs): point Algolia search at the maintained index

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -289,13 +289,18 @@ const config = {
         ],
       },
       algolia: {
-        appId: 'O18C1RUI3F',
-        apiKey: '7e6702351d8d0157591e9c8d417f47dd',
+        // App 6QKGHF2S6F is the index the docsearch-scraper GitHub Action
+        // (BETA_APPLICATION_ID / BETA_API_KEY) actually populates. The previous
+        // app (O18C1RUI3F) was a stale, unmaintained index in a lost account
+        // that the scraper no longer wrote to, so live search served old data.
+        // This key is search-only (search/listIndexes/settings/browse).
+        appId: '6QKGHF2S6F',
+        apiKey: '85c9d989b84d2b73fce5c8d1fccb6415',
         indexName: 'Docs',
-        // Disabled: the deployed index has no `attributesForFaceting`, so the
-        // `docusaurus_tag` facet filter that contextual search appends to every
-        // query matches zero records and search returns nothing. Re-enable only
-        // once the index is crawled with faceting settings applied.
+        // Kept off through the MTN-88 single-instance migration: the new index
+        // has faceting configured, but page `docusaurus_tag` values will flip
+        // from per-section to `docs-default-current` on that merge and lag the
+        // index by one crawl. Re-enable once the structure has settled.
         contextualSearch: false,
         searchParameters: {},
       },


### PR DESCRIPTION
@-

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to public search-only Algolia credentials and comments; no auth, data, or runtime logic changes.
> 
> **Overview**
> **Docs site search** now queries the Algolia app (`6QKGHF2S6F`) that the `docsearch-scraper` GitHub Action actually updates via `BETA_APPLICATION_ID`, replacing a stale app the scraper no longer wrote to—so published search results can match the current crawl instead of an unmaintained index.
> 
> `contextualSearch` remains **disabled** on purpose: comments document re-enabling only after the MTN-88 single-instance migration settles, because `docusaurus_tag` values will change and can lag the index by one crawl even though the new index has faceting configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80765f7ed992b4982fac6867bac32d046b163999. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->