### PR TITLE
chore(docs): clean up docsearch crawler config

### DIFF
--- a/docsearch.config.json
+++ b/docsearch.config.json
@@ -5,11 +5,6 @@
   ],
   "start_urls": [
     {
-      "url": "https://docs.osmosis.zone/guides",
-      "tags": "guides",
-      "selectors_key": "guides"
-    },
-    {
       "url": "https://docs.osmosis.zone/osmosis-core",
       "tags": "osmosis-core",
       "selectors_key": "osmosis-core"
@@ -41,41 +36,16 @@
     },
     "https://docs.osmosis.zone"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "https://docs.osmosis.zone/api",
+    "https://docs.osmosis.zone/search"
+  ],
   "selectors": {
     "default": {
       "lvl0": {
         "selector": "",
         "global": true,
         "default_value": "Documentation"
-      },
-      "lvl1": "article h1",
-      "lvl2": "article h2",
-      "lvl3": "article h3",
-      "lvl4": "article h4",
-      "lvl5": "article h5, article td:first-child",
-      "lvl6": "article h6",
-      "text": "article p, article li, article td:last-child"
-    },
-    "guides": {
-      "lvl0": {
-        "selector": "",
-        "global": true,
-        "default_value": "Guides"
-      },
-      "lvl1": "article h1",
-      "lvl2": "article h2",
-      "lvl3": "article h3",
-      "lvl4": "article h4",
-      "lvl5": "article h5, article td:first-child",
-      "lvl6": "article h6",
-      "text": "article p, article li, article td:last-child"
-    },
-    "networks": {
-      "lvl0": {
-        "selector": "",
-        "global": true,
-        "default_value": "Networks"
       },
       "lvl1": "article h1",
       "lvl2": "article h2",


### PR DESCRIPTION
@-

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Search indexing configuration only; no application runtime or security behavior changes.
> 
> **Overview**
> This PR tightens the Algolia DocSearch crawler setup in `docsearch.config.json` so indexing matches the current docs site structure.
> 
> The **guides** crawl entry is removed from `start_urls`, and the dedicated **`guides`** and **`networks`** selector profiles are dropped so those sections rely on the shared **`default`** extraction rules (same as other remaining tagged areas).
> 
> **`stop_urls`** now excludes `https://docs.osmosis.zone/api` and `https://docs.osmosis.zone/search`, so API and search UI pages are not pulled into the Docs index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73a619c01d855cc026b2e7bb7737f3180f1b750f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->