### PR TITLE
feat(docs): enable Algolia Insights click events

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -302,6 +302,11 @@ const config = {
         // from per-section to `docs-default-current` on that merge and lag the
         // index by one crawl. Re-enable once the structure has settled.
         contextualSearch: false,
+        // Send click/conversion events to the Algolia Insights API so the
+        // dashboard can report which results users actually open. DocSearch
+        // emits these itself; the dashboard's "automatic events collection"
+        // toggle does not apply (it targets raw InstantSearch/Autocomplete).
+        insights: true,
         searchParameters: {},
       },
     }),


### PR DESCRIPTION
@-

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config flag for search analytics; uses the existing search-only API key and does not change indexing, auth, or application logic.
> 
> **Overview**
> Turns on **Algolia Insights** for the docs site search by setting `insights: true` in `docusaurus.config.js` under `themeConfig.algolia`.
> 
> DocSearch will send **click/conversion events** to the Algolia Insights API so the dashboard can show which search results users open. Inline comments note this is separate from the dashboard’s “automatic events collection” toggle (that path is for raw InstantSearch/Autocomplete, not DocSearch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c099aa5261a69599c157e819ec0b56c6aa1538ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->