### PR TITLE
chore: migrate Algolia DocSearch to org-owned account (MTN-94)

### DIFF
--- a/.github/workflows/docsearch-scraper.yml
+++ b/.github/workflows/docsearch-scraper.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Scrape the Site 🧽
         env:
-          APPLICATION_ID: ${{ secrets.BETA_APPLICATION_ID }}
-          API_KEY: ${{ secrets.BETA_API_KEY }}
+          APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
+          API_KEY: ${{ secrets.API_KEY }}
         run: |
           docker run \
           -e APPLICATION_ID -e API_KEY \

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -259,13 +259,11 @@ const config = {
         ],
       },
       algolia: {
-        // App 6QKGHF2S6F is the index the docsearch-scraper GitHub Action
-        // (BETA_APPLICATION_ID / BETA_API_KEY) actually populates. The previous
-        // app (O18C1RUI3F) was a stale, unmaintained index in a lost account
-        // that the scraper no longer wrote to, so live search served old data.
+        // Org-owned Algolia account. The docsearch-scraper GitHub Action
+        // (APPLICATION_ID / API_KEY secrets) populates the `Docs` index.
         // This key is search-only (search/listIndexes/settings/browse).
-        appId: '6QKGHF2S6F',
-        apiKey: '85c9d989b84d2b73fce5c8d1fccb6415',
+        appId: 'F26GLV8TNU',
+        apiKey: '0c5c06782dec165349c88655f2de36b6',
         indexName: 'Docs',
         // Kept off through the MTN-88 single-instance migration: the new index
         // has faceting configured, but page `docusaurus_tag` values will flip


### PR DESCRIPTION
Migrates Algolia DocSearch to the new org-owned Algolia account ([MTN-94](https://linear.app/osmosis/issue/MTN-94)), removing the account-ownership risk of the previous app.

## Changes
- `docusaurus.config.js` — repoint the search box to the org-owned app (`appId: F26GLV8TNU`) and its search-only key. Index name stays `Docs`. (Search-only keys are public by design and safe to commit.)
- `.github/workflows/docsearch-scraper.yml` — rename the scraper secrets `BETA_APPLICATION_ID` / `BETA_API_KEY` to `APPLICATION_ID` / `API_KEY`.

## Required outside this PR (maintainer action)
- [ ] In repo Settings → Secrets and variables → Actions, set **`APPLICATION_ID`** = `F26GLV8TNU` and **`API_KEY`** = the new app's **Admin (write)** key. (Remove the old `BETA_*` secrets.)
- [ ] After merge, run the **Scrape Docs Site** workflow (Actions → Run workflow) to populate the new `Docs` index, and confirm in the new Algolia dashboard that the index has records.
- [ ] Verify live search on docs.osmosis.zone returns results.
- [ ] Retire the old Algolia app once search is confirmed on the new account.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing search depends on new GitHub secrets and a post-merge scrape; misconfiguration would break docs search until fixed.
> 
> **Overview**
> Moves DocSearch to the org-owned Algolia app so the site and scraper use the same account instead of the old beta app.
> 
> **`docusaurus.config.js`** points the navbar search at app `F26GLV8TNU` with a new search-only API key; **`Docs`** index name and **`contextualSearch: false`** are unchanged. Comments now describe the org-owned setup.
> 
> **`.github/workflows/docsearch-scraper.yml`** passes **`secrets.APPLICATION_ID`** and **`secrets.API_KEY`** into the scraper (replacing **`BETA_*`**). Maintainers must set those Action secrets and run a scrape after merge or live search will hit an empty or stale index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b65fd60b0a111904902b0e136d21f00d0c966a97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->