### PR TITLE
style(docs): modernize styling to match the Osmosis frontend (MTN-84)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,3 +84,14 @@ Others will give constructive feedback.
 This is a time for discussion and improvements,
 and making the necessary changes will be required before we can
 merge the contribution.
+
+# Docs page conventions
+
+A few conventions keep pages scannable and consistent with the site styling.
+
+- **Open with a lede.** The first paragraph should frame what the page covers in one or two sentences, before any subheading. It renders one size up.
+- **Break up walls of text.** Pull important caveats, warnings, and tips into admonitions (`:::tip`, `:::info`, `:::warning`, `:::danger`) rather than burying them in prose.
+- **Keep heading density reasonable.** Use headings to chunk content, but avoid a heading for every paragraph. Flowing prose is capped at a comfortable reading measure; code blocks, tables, admonitions, and card grids stay full width.
+- **Intro before card grids.** A landing page with a `<DocCardList />` (or `HomepageCard` grid) should have a short intro paragraph above the cards explaining what the cards lead to.
+- **Featured cards.** On the homepage, each section may feature one card (`featured` prop) that spans two of the three columns. A featured card pairs with four regular cards so the grid fills two clean rows; only feature a section when it has the cards to balance.
+- **House style.** No em-dashes (use commas, parentheses, or colons). Write "onchain", not "on-chain". Do not put issue-tracker IDs or PR numbers in page content.

--- a/docs/build/cosmwasm/beaker/README.md
+++ b/docs/build/cosmwasm/beaker/README.md
@@ -1,3 +1,7 @@
+---
+description: Scaffold, deploy, and interact with contracts using Beaker.
+---
+
 # Beaker
 
 <p align="center">

--- a/docs/build/cosmwasm/cosmwasm-deployment.md
+++ b/docs/build/cosmwasm/cosmwasm-deployment.md
@@ -1,4 +1,5 @@
 ---
+description: Deploy a CosmWasm contract to a public testnet with osmosisd.
 sidebar_position: 4
 ---
 

--- a/docs/build/cosmwasm/cosmwasm-verify-contract.md
+++ b/docs/build/cosmwasm/cosmwasm-verify-contract.md
@@ -1,4 +1,5 @@
 ---
+description: Reproducibly verify a deployed CosmWasm contract.
 sidebar_position: 7
 ---
 

--- a/docs/build/cosmwasm/cw-orch.md
+++ b/docs/build/cosmwasm/cw-orch.md
@@ -1,4 +1,5 @@
 ---
+description: Script, test, and deploy CosmWasm contracts with cw-orchestrator.
 title: Scripts and Tests with cw-orchestrator
 sidebar_position: 8
 ---

--- a/docs/build/cosmwasm/index.mdx
+++ b/docs/build/cosmwasm/index.mdx
@@ -13,4 +13,4 @@ CosmWasm lets you write smart contracts in Rust and run them on Osmosis. This se
 
 If you are building UIs or SDK integrations rather than contracts, see Frontend.
 
-<DocCardList />
+<DocCardList className="single-column-cards" />

--- a/docs/build/cosmwasm/javascript.md
+++ b/docs/build/cosmwasm/javascript.md
@@ -1,4 +1,5 @@
 ---
+description: Call deployed CosmWasm contracts from a JavaScript runtime.
 sidebar_position: 9
 ---
 

--- a/docs/build/cosmwasm/localosmosis.md
+++ b/docs/build/cosmwasm/localosmosis.md
@@ -1,4 +1,5 @@
 ---
+description: Develop and test a contract against a local Osmosis chain.
 title: Cosmwasm & LocalOsmosis
 sidebar_position: 3
 ---

--- a/docs/build/cosmwasm/submit-wasm-proposal.md
+++ b/docs/build/cosmwasm/submit-wasm-proposal.md
@@ -1,4 +1,5 @@
 ---
+description: Store a contract via a CosmWasm governance proposal.
 sidebar_position: 6
 ---
 

--- a/docs/build/developer-environment/cli.md
+++ b/docs/build/developer-environment/cli.md
@@ -1,4 +1,5 @@
 ---
+description: Query and submit transactions with the osmosisd CLI.
 title: Interact with the CLI
 sidebar_position: 4
 ---

--- a/docs/build/developer-environment/ide-guide.md
+++ b/docs/build/developer-environment/ide-guide.md
@@ -1,4 +1,5 @@
 ---
+description: Recommended IDE setup for developing on Osmosis in Go.
 title: IDE Setup
 sidebar_position: 2
 ---

--- a/docs/build/developer-environment/keys/keys-cli.md
+++ b/docs/build/developer-environment/keys/keys-cli.md
@@ -1,3 +1,7 @@
+---
+description: Create, import, and manage keys with the CLI.
+---
+
 # Basic Key Management
 
 Create, import, export and delete keys using the CLI keyring. 

--- a/docs/build/developer-environment/keys/multisig.md
+++ b/docs/build/developer-environment/keys/multisig.md
@@ -1,3 +1,7 @@
+---
+description: Create and use multisig keys and accounts.
+---
+
 # Multisig
 
 A **multisig account** is an Osmosis account with a special key that can require more than one signature to sign transactions. This can be useful for increasing the security of the account or for requiring the consent of multiple parties to make transactions. Multisig accounts can be created by specifying:

--- a/docs/build/developer-environment/localtesting.md
+++ b/docs/build/developer-environment/localtesting.md
@@ -1,4 +1,5 @@
 ---
+description: Spin up a containerized LocalOsmosis chain to develop against.
 title: Local Testing
 sidebar_position: 6
 ---

--- a/docs/build/developer-environment/osmosisd.md
+++ b/docs/build/developer-environment/osmosisd.md
@@ -1,4 +1,5 @@
 ---
+description: Install the osmosisd binary, build from source, and the command reference.
 title: Install osmosisd
 sidebar_position: 3
 ---

--- a/docs/build/frontend/cosmos-kit.mdx
+++ b/docs/build/frontend/cosmos-kit.mdx
@@ -1,3 +1,7 @@
+---
+description: A React wallet adapter for the Cosmos ecosystem.
+---
+
 # CosmosKit Documentation
 
 CosmosKit is a wallet adapter for developers to build apps that quickly and easily interact with Cosmos blockchains and wallets. It provides a set of hooks and components to help you integrate Cosmos functionality into your application.

--- a/docs/build/frontend/index.mdx
+++ b/docs/build/frontend/index.mdx
@@ -13,4 +13,4 @@ The tools for building applications and user interfaces on top of Osmosis in Typ
 
 These are client-side libraries for consuming Osmosis. For querying the chain's data and routing surfaces (SQS, RPC, REST), see Integrate; for smart contracts, see CosmWasm.
 
-<DocCardList />
+<DocCardList className="single-column-cards" />

--- a/docs/build/frontend/osmosis-frontend.mdx
+++ b/docs/build/frontend/osmosis-frontend.mdx
@@ -1,3 +1,7 @@
+---
+description: Architecture of the app.osmosis.zone web interface.
+---
+
 # Osmosis Frontend 
 Osmosis is a decentralized exchange built on top of the Cosmos SDK, which provides a platform for exchanging and trading digital assets. The Osmosis Frontend is a user interface for the Osmosis network that allows users to easily trade and manage their assets.
 

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -1,4 +1,5 @@
 ---
+description: Guidelines for contributing to the Osmosis repositories.
 title: Contributing
 sidebar_position: 6
 ---

--- a/docs/community/ibc-relayers-list.md
+++ b/docs/community/ibc-relayers-list.md
@@ -1,4 +1,5 @@
 ---
+description: A directory of relaying operators connecting Osmosis to the interchain.
 title: IBC Relayer List
 sidebar_position: 4
 ---

--- a/docs/community/translating.mdx
+++ b/docs/community/translating.mdx
@@ -1,3 +1,7 @@
+---
+description: Help translate the Osmosis interface into new languages.
+---
+
 
 # Frontend translations
 

--- a/docs/integrate/channels.md
+++ b/docs/integrate/channels.md
@@ -1,4 +1,5 @@
 ---
+description: How assets reach Osmosis over IBC and where to find channel and denom mappings.
 title: IBC Channels
 sidebar_position: 4
 ---

--- a/docs/integrate/data-recipes/_category_.json
+++ b/docs/integrate/data-recipes/_category_.json
@@ -1,1 +1,1 @@
-{ "label": "Data Recipes", "position": 10, "collapsible": true, "collapsed": true, "link": { "type": "generated-index", "description": "Task-oriented data guides: snapshotting accounts for airdrops and calculating pool APRs." } }
+{"label": "Data Recipes", "position": 10, "collapsible": true, "collapsed": true, "link": {"type": "doc", "id": "integrate/data-recipes/index"}}

--- a/docs/integrate/data-recipes/airdrops.md
+++ b/docs/integrate/data-recipes/airdrops.md
@@ -1,4 +1,5 @@
 ---
+description: Snapshot Osmosis accounts at a height to derive airdrop balances.
 title: Airdrop Snapshots
 sidebar_position: 3
 ---

--- a/docs/integrate/data-recipes/apr.md
+++ b/docs/integrate/data-recipes/apr.md
@@ -1,4 +1,5 @@
 ---
+description: Calculate pool APRs from incentives and swap fees.
 sidebar_position: 11
 ---
 

--- a/docs/integrate/data-recipes/index.mdx
+++ b/docs/integrate/data-recipes/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Data Recipes
+description: Task-oriented data guides, from snapshotting accounts for airdrops to calculating pool APRs.
+---
+
+import DocCardList from '@theme/DocCardList';
+
+# Data Recipes
+
+Task-oriented data guides for working with Osmosis chain data: snapshotting accounts for airdrops and calculating pool APRs.
+
+<DocCardList className="single-column-cards" />

--- a/docs/integrate/endpoints/grpc.md
+++ b/docs/integrate/endpoints/grpc.md
@@ -1,4 +1,5 @@
 ---
+description: Query Osmosis over gRPC.
 sidebar_position: 10
 ---
 

--- a/docs/integrate/endpoints/rest.md
+++ b/docs/integrate/endpoints/rest.md
@@ -1,4 +1,5 @@
 ---
+description: Query Osmosis over the REST (LCD) gateway.
 sidebar_position: 11
 ---
 

--- a/docs/integrate/endpoints/rpc.md
+++ b/docs/integrate/endpoints/rpc.md
@@ -1,4 +1,5 @@
 ---
+description: Sign, broadcast, and subscribe over the chain's RPC endpoints.
 sidebar_position: 12
 ---
 

--- a/docs/integrate/endpoints/sqs.md
+++ b/docs/integrate/endpoints/sqs.md
@@ -1,4 +1,5 @@
 ---
+description: The production routing and quote service that powers the frontend.
 sidebar_position: 13
 ---
 

--- a/docs/integrate/external_projects/README.md
+++ b/docs/integrate/external_projects/README.md
@@ -1,3 +1,7 @@
+---
+description: Ecosystem projects and libraries built around Osmosis.
+---
+
 # External Projects
 
 Osmosis integrates with a range of external projects and is supported by a wider ecosystem of open-source tooling. This page collects the integration guides maintained here alongside the external libraries most useful when building on Osmosis.

--- a/docs/integrate/external_projects/pyth.md
+++ b/docs/integrate/external_projects/pyth.md
@@ -1,3 +1,7 @@
+---
+description: Integrate Pyth price feeds with Osmosis.
+---
+
 # Pyth
 
 ## Introduction

--- a/docs/integrate/external_projects/subquery.md
+++ b/docs/integrate/external_projects/subquery.md
@@ -1,3 +1,7 @@
+---
+description: Index Osmosis data with SubQuery.
+---
+
 # SubQuery
 
 ## Intro

--- a/docs/integrate/features/_category_.json
+++ b/docs/integrate/features/_category_.json
@@ -1,1 +1,1 @@
-{ "label": "Feature Integrations", "position": 6, "collapsible": true, "collapsed": true, "link": { "type": "generated-index", "slug": "/integrate/features", "description": "Integrate against specific Osmosis features: concentrated liquidity, alloyed assets, and smart accounts." } }
+{"label": "Feature Integrations", "position": 6, "collapsible": true, "collapsed": true, "link": {"type": "doc", "id": "integrate/features/index"}}

--- a/docs/integrate/features/concentrated-liquidity-integration.md
+++ b/docs/integrate/features/concentrated-liquidity-integration.md
@@ -1,4 +1,5 @@
 ---
+description: Integrate against concentrated liquidity pools and positions.
 title: Concentrated Liquidity Integration
 sidebar_position: 5
 ---

--- a/docs/integrate/features/index.mdx
+++ b/docs/integrate/features/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Feature Integrations
+description: Integrate against specific Osmosis features, from concentrated liquidity to alloyed assets and smart accounts.
+---
+
+import DocCardList from '@theme/DocCardList';
+
+# Feature Integrations
+
+Integrate against specific Osmosis features. These pages cover the technical surface for concentrated liquidity, alloyed assets, and smart accounts.
+
+<DocCardList className="single-column-cards" />

--- a/docs/integrate/features/smart-accounts.md
+++ b/docs/integrate/features/smart-accounts.md
@@ -1,4 +1,5 @@
 ---
+description: The integrator surface for smart accounts and authenticators.
 sidebar_position: 17
 ---
 

--- a/docs/integrate/features/transmuter.md
+++ b/docs/integrate/features/transmuter.md
@@ -1,4 +1,5 @@
 ---
+description: The contract surface for alloyed assets and the transmuter.
 sidebar_position: 15
 ---
 

--- a/docs/integrate/list-asset/frontend.md
+++ b/docs/integrate/list-asset/frontend.md
@@ -1,4 +1,5 @@
 ---
+description: Ensure your asset is visible and correctly displayed on the frontend.
 sidebar_position: 8
 ---
 

--- a/docs/integrate/list-asset/incentives.md
+++ b/docs/integrate/list-asset/incentives.md
@@ -1,4 +1,5 @@
 ---
+description: Add liquidity incentives to your pool to bootstrap depth.
 sidebar_position: 7
 ---
 # Liquidity Incentives

--- a/docs/integrate/list-asset/liquidity.md
+++ b/docs/integrate/list-asset/liquidity.md
@@ -1,4 +1,5 @@
 ---
+description: Source the initial liquidity needed to list and trade your asset.
 sidebar_position: 6
 ---
 

--- a/docs/integrate/list-asset/pool-setup.mdx
+++ b/docs/integrate/list-asset/pool-setup.mdx
@@ -1,4 +1,5 @@
 ---
+description: Create a pool for your asset, from weighted to stableswap.
 sidebar_position: 5
 ---
 

--- a/docs/integrate/list-asset/registration.md
+++ b/docs/integrate/list-asset/registration.md
@@ -1,4 +1,5 @@
 ---
+description: Register your asset so Osmosis recognizes its metadata.
 sidebar_position: 4
 ---
 # Register your Asset

--- a/docs/integrate/list-asset/transfer.md
+++ b/docs/integrate/list-asset/transfer.md
@@ -1,4 +1,5 @@
 ---
+description: Connect your asset to Osmosis over an IBC transfer channel.
 sidebar_position: 3
 ---
 

--- a/docs/integrate/transaction-structure/README.md
+++ b/docs/integrate/transaction-structure/README.md
@@ -1,3 +1,7 @@
+---
+description: How messages and events are laid out in Osmosis transactions.
+---
+
 # Transaction Structure
 
 Each block on a blockchain, including Cosmos-based ones like Osmosis, are constructed of a series

--- a/docs/integrate/transaction-structure/arb.md
+++ b/docs/integrate/transaction-structure/arb.md
@@ -1,3 +1,7 @@
+---
+description: Anatomy of an arbitrage transaction on Osmosis.
+---
+
 # Arbitrage
 
 The transaction at index 1 of block 2836990 is an arbitrage transaction, swapping an exact amount in and (hopefully) getting a larger

--- a/docs/learn/features/alloyed-assets.md
+++ b/docs/learn/features/alloyed-assets.md
@@ -1,4 +1,5 @@
 ---
+description: One canonical denom that unifies several bridged versions of an asset.
 sidebar_position: 9
 ---
 

--- a/docs/learn/features/concentrated-liquidity.md
+++ b/docs/learn/features/concentrated-liquidity.md
@@ -1,4 +1,5 @@
 ---
+description: Provide liquidity in a chosen price range for far higher capital efficiency.
 sidebar_position: 2
 ---
 

--- a/docs/learn/features/eip-1559.md
+++ b/docs/learn/features/eip-1559.md
@@ -1,4 +1,5 @@
 ---
+description: The dynamic fee market that adjusts the base fee with network congestion.
 sidebar_position: 3
 ---
 

--- a/docs/learn/features/fee-abstraction.md
+++ b/docs/learn/features/fee-abstraction.md
@@ -1,4 +1,5 @@
 ---
+description: Pay transaction fees in many tokens, not only OSMO.
 sidebar_position: 4
 ---
 

--- a/docs/learn/features/ibc-hooks.md
+++ b/docs/learn/features/ibc-hooks.md
@@ -1,4 +1,5 @@
 ---
+description: Trigger a smart contract call from an IBC transfer, enabling cross-chain swaps.
 sidebar_position: 5
 ---
 

--- a/docs/learn/features/ibc-rate-limit.md
+++ b/docs/learn/features/ibc-rate-limit.md
@@ -1,4 +1,5 @@
 ---
+description: A configurable safety cap on how much of an asset can move over IBC.
 sidebar_position: 6
 ---
 

--- a/docs/learn/features/index.mdx
+++ b/docs/learn/features/index.mdx
@@ -6,14 +6,7 @@ import DocCardList from '@theme/DocCardList';
 # Features
 
 
-This page serves as an informative gateway to explore the innovative and distinctive features that Osmosis brings to the decentralized finance (DeFi) landscape. Leveraging its pioneering App Chain architecture, Osmosis offers a unique DeFi experience that sets it apart from traditional platforms. 
+The features that make Osmosis distinct. Each page explains what a feature is and why it matters; several link to a deeper technical specification under Build or an integration guide under Integrate.
 
-## Table of Contents
-  - [Concentrated Liquidity](/learn/features/concentrated-liquidity)
-  - [EIP-1559](/learn/features/eip-1559)
-  - [Fee Abstraction](/learn/features/fee-abstraction)
-  - [IBC Hooks](/learn/features/ibc-hooks)
-  - [IBC Rate Limit](/learn/features/ibc-rate-limit)
-  - [Token Factory](/learn/features/tokenfactory)
-  - [Protorev](/learn/features/protorev)
+<DocCardList />
 

--- a/docs/learn/features/protorev.md
+++ b/docs/learn/features/protorev.md
@@ -1,4 +1,5 @@
 ---
+description: In-protocol MEV capture that returns arbitrage value to the ecosystem.
 sidebar_position: 8
 ---
 

--- a/docs/learn/features/smart-accounts.md
+++ b/docs/learn/features/smart-accounts.md
@@ -1,4 +1,5 @@
 ---
+description: "Custom transaction authentication: session keys, spend limits, and more."
 sidebar_position: 10
 ---
 

--- a/docs/learn/features/tokenfactory.md
+++ b/docs/learn/features/tokenfactory.md
@@ -1,4 +1,5 @@
 ---
+description: Permissionlessly create native tokens namespaced to your address.
 sidebar_position: 7
 ---
 

--- a/docs/learn/get-started.md
+++ b/docs/learn/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: Connect a wallet and make your first trade on Osmosis.
 sidebar_position: 3
 ---
 # Getting Started

--- a/docs/learn/ibc.md
+++ b/docs/learn/ibc.md
@@ -1,4 +1,5 @@
 ---
+description: How Osmosis uses IBC to move assets across the interchain.
 title: IBC Protocol
 sidebar_position: 7
 ---

--- a/docs/learn/osmo.mdx
+++ b/docs/learn/osmo.mdx
@@ -1,4 +1,5 @@
 ---
+description: Tokenomics, staking, governance, and fees of the OSMO token.
 sidebar_position: 2
 ---
 # The OSMO Token

--- a/docs/learn/osmosis.md
+++ b/docs/learn/osmosis.md
@@ -1,4 +1,5 @@
 ---
+description: The cross-chain DEX and liquidity hub.
 sidebar_position: 1
 ---
 # What is Osmosis?

--- a/docs/learn/terminology.md
+++ b/docs/learn/terminology.md
@@ -1,4 +1,5 @@
 ---
+description: Definitions for the DeFi and Cosmos terms used throughout the docs.
 sidebar_position: 90
 ---
 

--- a/docs/validate/install-osmosisd.md
+++ b/docs/validate/install-osmosisd.md
@@ -1,4 +1,5 @@
 ---
+description: Install the osmosisd binary (specs and setup live under Build).
 title: Install osmosisd
 sidebar_position: 1
 ---

--- a/docs/validate/joining-mainnet.md
+++ b/docs/validate/joining-mainnet.md
@@ -1,4 +1,5 @@
 ---
+description: Sync and run a full Osmosis node on mainnet.
 sidebar_position: 3
 ---
 

--- a/docs/validate/joining-testnet.md
+++ b/docs/validate/joining-testnet.md
@@ -1,4 +1,5 @@
 ---
+description: Sync and run a full Osmosis node on testnet.
 sidebar_position: 2
 ---
 

--- a/docs/validate/performance.md
+++ b/docs/validate/performance.md
@@ -1,4 +1,5 @@
 ---
+description: Profile and diagnose the performance of a running node.
 title: Performance and Profiling
 sidebar_position: 5
 ---

--- a/docs/validate/relayer-guide.md
+++ b/docs/validate/relayer-guide.md
@@ -1,4 +1,5 @@
 ---
+description: Run IBC relaying infrastructure (Hermes) between chains.
 title: Relayer Guide
 sidebar_position: 8
 ---

--- a/docs/validate/tmkms.md
+++ b/docs/validate/tmkms.md
@@ -1,4 +1,5 @@
 ---
+description: Production validator key security with the Tendermint KMS.
 sidebar_position: 4
 ---
 

--- a/docs/validate/validating-mainnet.md
+++ b/docs/validate/validating-mainnet.md
@@ -1,4 +1,5 @@
 ---
+description: Create a validator and go live on mainnet.
 sidebar_position: 7
 ---
 

--- a/docs/validate/validating-testnet.md
+++ b/docs/validate/validating-testnet.md
@@ -1,4 +1,5 @@
 ---
+description: Create a validator and go live on testnet.
 sidebar_position: 6
 ---
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -286,6 +286,11 @@ const config = {
         'sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV',
       crossorigin: 'anonymous',
     },
+    // Poppins for headings (Inter remains for body, Fira Code for mono).
+    {
+      href: 'https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&display=swap',
+      type: 'text/css',
+    },
   ],
 };
 

--- a/src/components/HomepageComponents.jsx
+++ b/src/components/HomepageComponents.jsx
@@ -27,9 +27,20 @@ export function HomepageSection({
   );
 }
 
-export function HomepageCard({ id, icon, svgFile, title, description, to }) {
+export function HomepageCard({
+  id,
+  icon,
+  svgFile,
+  title,
+  description,
+  to,
+  featured = false,
+}) {
   return (
-    <Link to={to} className="homepage-card">
+    <Link
+      to={to}
+      className={clsx('homepage-card', featured && 'homepage-card--featured')}
+    >
       {svgFile
         ?  <div className="icon"><img src={svgFile}/></div>
         :  icon && <div className="icon">{icon}</div>

--- a/src/components/SidebarMenu/styles.module.css
+++ b/src/components/SidebarMenu/styles.module.css
@@ -1,11 +1,12 @@
 :root {
-  --docs-sections-menu-background-color: #efefef;
-  --docs-sections-menu-active-background-color: #2549aa;
+  --docs-sections-menu-background-color: var(--docs-color-background-100);
+  --docs-sections-menu-active-background-color: var(--docs-color-primary);
   --docs-sections-menu-active-color: #fff;
 }
 
 html[data-theme='dark'] {
-  --docs-sections-menu-background-color: #3f3f3f;
+  --docs-sections-menu-background-color: var(--docs-color-background-200);
+  --docs-sections-menu-active-color: var(--docs-color-background);
 }
 
 .container {

--- a/src/css/api-reference.css
+++ b/src/css/api-reference.css
@@ -34,7 +34,7 @@
 
 html[data-theme='dark'] .elements-container {
   --color-canvas-200: var(--docs-color-background-200) !important;
-  --ifm-pre-background: #1e1e1e;
+  --ifm-pre-background: var(--docs-color-code-background);
 }
 
 html[data-theme='dark'] .TryItPanel {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,43 +36,88 @@ body {
   --dyte-colors-video-bg: 50 50 50;
 }
 
-/* Dyte Docs Tokens */
+/* Docs tokens, remapped to the Osmosis frontend palette
+   (wosmongton purple + bullish teal). Legacy --docs-color-* names kept. */
 :root {
-  --docs-color-primary: #322DC2;
-  --docs-color-secondary: #db5224;
-  --docs-color-primary-100: #4540D8;
-  --docs-color-primary-tint: rgba(33, 96, 253, 0.16);
-  --docs-color-primary-tint-light: rgba(33 96 253/0.24);
+  --docs-color-primary: #462adf; /* wosmongton-700 */
+  --docs-color-secondary: #29d0b2; /* bullish-500 */
+  --docs-color-primary-100: #361fb2; /* wosmongton-800 */
+  --docs-color-primary-tint: rgba(70, 42, 223, 0.12);
+  --docs-color-primary-tint-light: rgba(70, 42, 223, 0.2);
 
-  --docs-color-border: #dadde1;
+  --docs-color-border: #e4e1fb; /* osmoverse-100 */
 
-  --docs-color-text: #000000;
-  --docs-color-text-100: #646464;
+  --docs-color-text: #140f34; /* osmoverse-900, purple-tinted near-black */
+  --docs-color-text-100: #565081; /* osmoverse-600 */
 
   --docs-color-background: #ffffff;
-  --docs-color-background-100: #f8f8f8;
-  --docs-color-background-200: #efefef;
-  --docs-color-background-300: #dcdcdc;
+  --docs-color-background-100: #f8f8fa;
+  --docs-color-background-200: #e4e1fb; /* osmoverse-100 */
+  --docs-color-background-300: #cec8f3; /* osmoverse-200 */
 
   /* Color from prism themes */
-  --docs-color-code-background: #f6f8fa;
+  --docs-color-code-background: #f6f5ff;
 
   --docs-color-android: #44db85;
   --docs-color-apple: var(--docs-color-text) !important;
+
+  /* Card surfaces (light) */
+  --docs-color-card-background: #ffffff;
+  --docs-color-card-background-hover: #f8f8fa;
+  --docs-color-card-border: #e4e1fb; /* osmoverse-100 */
+  --docs-color-card-border-hover: #462adf; /* wosmongton-700 */
+
+  /* shadow-md from the app, tinted to osmoverse-1000. */
+  --docs-card-shadow: 0px 6px 8px rgba(9, 5, 36, 0.2);
+  /* gradient-neutral from the app (featured/hero surfaces). */
+  --docs-gradient-neutral: linear-gradient(96.42deg, #462adf -0.59%, #8a86ff 100%);
+
+  /* Primary CTA fill is theme-fixed in the app (wosmongton-700 -> 400 on
+     hover), so it does NOT follow --ifm-color-primary, which flips light
+     in dark mode. */
+  --docs-cta-background: #462adf; /* wosmongton-700 */
+  --docs-cta-background-hover: #6a67ea; /* wosmongton-400 */
+
+  /* Scrollbar thumb (light): osmoverse-200 / -300 on hover. */
+  --docs-scrollbar-thumb: #cec8f3; /* osmoverse-200 */
+  --docs-scrollbar-thumb-hover: #b0aadc; /* osmoverse-300 */
+
+  /* Route the Infima `.thin-scrollbar` (sidebar/TOC) webkit vars through
+     the themed thumb token. */
+  --ifm-scrollbar-track-background-color: transparent;
+  --ifm-scrollbar-thumb-background-color: var(--docs-scrollbar-thumb);
+  --ifm-scrollbar-thumb-hover-background-color: var(--docs-scrollbar-thumb-hover);
 }
 
 [data-theme='dark'] {
-  --docs-color-border: #2e2e2e;
+  --docs-color-border: #282750; /* osmoverse-800, purple-tinted */
 
   --docs-color-text: #ffffff;
-  --docs-color-text-100: #b4b4b4;
+  --docs-color-text-100: #b0aadc; /* osmoverse-300 */
 
-  --docs-color-background: #161616;
-  --docs-color-background-100: #1c1c1c;
-  --docs-color-background-200: #2a2a2a;
-  --docs-color-background-300: #2e2e2e;
+  --docs-color-background: #090524; /* osmoverse-1000, the app body background */
+  --docs-color-background-100: #140f34; /* osmoverse-900, raised surface */
+  --docs-color-background-200: #201b43; /* osmoverse-850 */
+  --docs-color-background-300: #282750; /* osmoverse-800 */
 
-  --docs-color-code-background: #1e1e1e;
+  /* Code sits one step above the canvas so it reads as a distinct surface. */
+  --docs-color-code-background: #140f34;
+
+  --docs-color-primary: #8c8af9; /* wosmongton-300, accent/link */
+  --docs-color-primary-100: #6a67ea; /* wosmongton-400 */
+  --docs-color-primary-tint: rgba(140, 138, 249, 0.16);
+  --docs-color-primary-tint-light: rgba(140, 138, 249, 0.24);
+
+  /* Card surfaces, matching the Osmosis app (filled osmoverse panels with
+     an osmoverse-700 border that brightens to wosmongton-200 on hover). */
+  --docs-color-card-background: #282750; /* osmoverse-800 */
+  --docs-color-card-background-hover: #3c356d; /* osmoverse-700 */
+  --docs-color-card-border: #3c356d; /* osmoverse-700 */
+  --docs-color-card-border-hover: #b3b1fd; /* wosmongton-200 */
+
+  /* Scrollbar thumb (dark): osmoverse-600 / -500 on hover. */
+  --docs-scrollbar-thumb: #565081; /* osmoverse-600 */
+  --docs-scrollbar-thumb-hover: #736ca3; /* osmoverse-500 */
 }
 
 /* Docusaurus Theming */
@@ -87,44 +132,78 @@ body {
     'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol';
 
+  --ifm-heading-font-family: 'Poppins', 'Inter var', system-ui, -apple-system,
+    Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
+  --ifm-heading-font-weight: 600; /* matches the app's Poppins headings */
+
   --ifm-font-family-monospace: 'Fira Code VF', SFMono-Regular, Menlo, Monaco,
     Consolas, 'Liberation Mono', 'Courier New', monospace;
 
-  /* Theme colors */
-  --ifm-color-primary: #110D8B;
-  --ifm-color-primary-dark: #0A0674;
-  --ifm-color-primary-darker: #080559;
-  --ifm-color-primary-darkest: #02003F;
-  --ifm-color-primary-light: #1D18A8;
-  --ifm-color-primary-lighter: #2722BB;
-  --ifm-color-primary-lightest: #322DC2;
+  /* Theme colors, wosmongton ramp */
+  --ifm-color-primary: #462adf;
+  --ifm-color-primary-dark: #361fb2;
+  --ifm-color-primary-darker: #2d1b8f;
+  --ifm-color-primary-darkest: #1f1366;
+  --ifm-color-primary-light: #5b57fa;
+  --ifm-color-primary-lighter: #6a67ea;
+  --ifm-color-primary-lightest: #8c8af9;
+
+  --ifm-link-color: var(--docs-color-primary);
 
   --ifm-navbar-shadow: none;
-  --ifm-toc-border-color: #dedede;
+  --ifm-toc-border-color: var(--docs-color-border);
 
   --ifm-table-border-color: var(--docs-color-border);
   --code-border-color: var(--docs-color-border);
 
+  /* Larger, frontend-matching radii */
+  --ifm-button-border-radius: 0.75rem;
+  --ifm-card-border-radius: 1rem;
+
   --ifm-code-font-size: 92%;
-  --docusaurus-highlighted-code-line-bg: rgba(147, 178, 244, 0.38);
+  --docusaurus-highlighted-code-line-bg: rgba(140, 138, 249, 0.25);
 }
 
-/* For readability concerns, you should choose a lighter palette in dark mode. */
+/* Headings: Poppins with tighter tracking */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--ifm-heading-font-family);
+  letter-spacing: -0.02em;
+}
+
+/* Dark mode uses a lighter wosmongton accent for contrast. */
 html[data-theme='dark'] {
-  --ifm-link-color: #1a90ff;
-  --ifm-tabs-color-active-border: #1a90ff;
-  --ifm-tabs-color-active: #1a90ff;
+  --ifm-link-color: #8c8af9; /* wosmongton-300 */
+  --ifm-tabs-color-active-border: #8c8af9;
+  --ifm-tabs-color-active: #8c8af9;
 
-  --ifm-color-primary: #1a90ff;
+  --ifm-color-primary: #8c8af9;
+  --ifm-color-primary-dark: #6a67ea;
+  --ifm-color-primary-darker: #5b57fa;
+  --ifm-color-primary-darkest: #462adf;
+  --ifm-color-primary-light: #a3a1fb;
+  --ifm-color-primary-lighter: #b4b2fc;
+  --ifm-color-primary-lightest: #cdccfd;
 
-  --ifm-footer-background-color: #1c1c1c;
-  --ifm-background-surface-color: #161616;
-  --ifm-background-color: #161616;
-  --ifm-toc-border-color: #2e2e2e;
+  --ifm-footer-background-color: #140f34;
+  --ifm-background-surface-color: #090524;
+  --ifm-background-color: #090524;
+  --ifm-toc-border-color: var(--docs-color-border);
 
   --ifm-color-content: #e7e7e7;
 
-  --docusaurus-highlighted-code-line-bg: rgba(105, 105, 105, 0.3);
+  --docusaurus-highlighted-code-line-bg: rgba(140, 138, 249, 0.2);
+
+  /* Sidebar + other `.thin-scrollbar` containers style their webkit
+     scrollbar through these Infima vars; route them through the themed
+     thumb token. */
+  --ifm-scrollbar-track-background-color: transparent;
+  --ifm-scrollbar-thumb-background-color: var(--docs-scrollbar-thumb);
+  --ifm-scrollbar-thumb-hover-background-color: var(--docs-scrollbar-thumb-hover);
 }
 
 nav.navbar {
@@ -201,14 +280,15 @@ nav.menu {
   margin-top: 0.25rem;
   display: inline-block;
   padding: 0.25rem 1.5rem;
-  border-radius: 4px;
-  background-color: var(--docs-color-primary);
+  border-radius: 0.75rem;
+  background-color: var(--docs-cta-background); /* wosmongton-700 */
   color: #ffffff;
   text-decoration: none;
+  transition: background-color 0.15s;
 }
 
 .footer__cta a:hover {
-  background-color: var(--ifm-color-primary-darker);
+  background-color: var(--docs-cta-background-hover); /* wosmongton-400 */
 }
 
 .footer__data {
@@ -314,18 +394,26 @@ html[data-theme='dark'] .discord-icon::before {
   content: 'Discord';
 }
 
+/* Primary CTA, matching the app's <Button mode="primary">: 2px
+   wosmongton-700 fill that BRIGHTENS to wosmongton-400 on hover. */
 .dev-portal-link {
-  background-color: var(--docs-color-primary);
-  border-radius: 4px;
+  background-color: var(--docs-cta-background); /* wosmongton-700 */
+  border: 2px solid var(--docs-cta-background);
+  border-radius: 0.75rem; /* rounded-xl */
   margin-right: 12px;
-  transition-property: all;
+  transition-property: background-color, border-color;
+  transition-duration: 0.15s;
 }
 
 .dev-postman-link {
-  background-color: var(--docs-color-secondary);
-  border-radius: 4px;
+  /* bullish-600, dark enough for white label text to pass AA (bullish-500
+     fails). */
+  background-color: #00a399;
+  border: 2px solid #00a399;
+  border-radius: 0.75rem;
   margin-right: 12px;
-  transition-property: all;
+  transition-property: background-color, border-color;
+  transition-duration: 0.15s;
 }
 
 .dev-portal-link svg {
@@ -341,7 +429,8 @@ html[data-theme='dark'] .discord-icon::before {
 }
 
 .dev-portal-signup:hover {
-  background-color: var(--ifm-color-primary-darker);
+  background-color: var(--docs-cta-background-hover); /* wosmongton-400 */
+  border-color: var(--docs-cta-background-hover);
 }
 
 .dev-portal-login {
@@ -764,14 +853,50 @@ img[src$='#terminal'] {
   --ifm-link-hover-color: inherit;
   cursor: pointer;
 
-  transition-property: background-color, color;
+  transition-property: background-color, border-color, color;
+  transition-duration: 0.15s;
 
-  border: 1px solid var(--docs-color-border);
-  border-radius: 8px;
+  background-color: var(--docs-color-card-background);
+  border: 1px solid var(--docs-color-card-border);
+  border-radius: 1rem; /* rounded-2xl, matches the app */
+  box-shadow: var(--docs-card-shadow);
 }
 
-.homepage-card:hover {
-  background-color: var(--docs-color-background-100);
+/* On hover (dark mode), every card reveals the app's signature
+   gradient-neutral surface with white text. */
+[data-theme='dark'] .homepage-card:hover {
+  background-color: transparent;
+  background-image: var(--docs-gradient-neutral);
+  border-color: var(--docs-color-card-border-hover);
+  color: #fff;
+}
+
+[data-theme='dark'] .homepage-card:hover .card-content .title {
+  color: #fff;
+}
+
+[data-theme='dark'] .homepage-card:hover .card-content .description {
+  color: rgba(255, 255, 255, 0.87); /* white-emphasis */
+}
+
+/* Light mode keeps a softer hover (surface fill + accent border, dark
+   text) since the saturated gradient on a white page is too strong. */
+[data-theme='light'] .homepage-card:hover {
+  background-color: var(--docs-color-card-background-hover);
+  border-color: var(--docs-color-card-border-hover);
+}
+
+/* Featured card: spans 2 of the 3 grid columns. Its only resting cue is
+   the wosmongton border (otherwise it's a normal card) plus the larger
+   title; the gradient hover is shared by all cards. One per section;
+   pair with 4 regular cards so the 3-col grid fills two clean rows. */
+.homepage-card--featured {
+  grid-column: span 2;
+  border-color: var(--docs-color-card-border-hover);
+}
+
+.homepage-card--featured .card-content .title {
+  font-size: 20px;
 }
 
 .icon svg {
@@ -852,29 +977,142 @@ img[src$='#terminal'] {
   .two-cols .section-content {
     grid-template-columns: repeat(1, minmax(0, 1fr));
   }
+  /* In the single-column grid a featured card cannot span 2. */
+  .homepage-card--featured {
+    grid-column: span 1;
+  }
 }
 
 
 /* OSMOSIS */
 
-/* Issue #210: render DocCardList items full-width on desktop. Infima
-   drives both flex-basis and max-width from --ifm-col-width on any
-   element matching .col[class*=col--], so override the variable
-   (scoped to <article class="col">, the DocCardList markup) to keep
-   the footer unaffected.
+/* DocCardList uses its default Infima grid (2-col `col col--6`).
+   Pages that opt into `single-column-cards` (via the category link
+   className or the DocCardList className prop) render one card per row. */
+.row.single-column-cards > article.col {
+  --ifm-col-width: 100%;
+}
 
-   Docusaurus's DocCategoryGeneratedIndexPage zeros margin-bottom on
-   the last two articles (`article:nth-last-child(-n + 2)`) on the
-   assumption of a 2-col grid where they share a row. Once we collapse
-   to a single column those two are stacked, so we need the gap back
-   between them — restore margin-bottom on every article except the
-   actual last one. */
-@media (min-width: 997px) {
-  article.col {
-    --ifm-col-width: 100%;
-  }
+/* Reading measure: cap flowing prose at ~72ch for readability. Code
+   blocks, tables, admonitions, card grids, and images opt back out to
+   full width so wide content is never clipped. Scoped to the doc
+   article body so the homepage and generated-index card grids are
+   unaffected. */
+.theme-doc-markdown.markdown > p,
+.theme-doc-markdown.markdown > ul,
+.theme-doc-markdown.markdown > ol,
+.theme-doc-markdown.markdown > h1,
+.theme-doc-markdown.markdown > h2,
+.theme-doc-markdown.markdown > h3,
+.theme-doc-markdown.markdown > h4,
+.theme-doc-markdown.markdown > h5,
+.theme-doc-markdown.markdown > h6,
+.theme-doc-markdown.markdown > blockquote {
+  max-width: 72ch;
+}
 
-  article.col.margin-bottom--lg:not(:last-child) {
-    margin-bottom: 2rem !important;
-  }
+/* Lede: the first paragraph (immediately after the page H1) renders one
+   size up, as documented in CONTRIBUTING.md "Docs page conventions". */
+.theme-doc-markdown.markdown > header + p,
+.theme-doc-markdown.markdown > h1 + p {
+  font-size: 1.125rem;
+  line-height: 1.6;
+  color: var(--docs-color-text);
+}
+
+/* Full-width opt-outs. */
+.theme-doc-markdown.markdown > pre,
+.theme-doc-markdown.markdown > .theme-code-block,
+.theme-doc-markdown.markdown > .table-wrapper,
+.theme-doc-markdown.markdown > table,
+.theme-doc-markdown.markdown > .theme-admonition,
+.theme-doc-markdown.markdown > .admonition,
+.theme-doc-markdown.markdown > details,
+.theme-doc-markdown.markdown > div[class*='cardList'],
+.theme-doc-markdown.markdown > .row,
+.theme-doc-markdown.markdown > p > img,
+.theme-doc-markdown.markdown > img {
+  max-width: 100%;
+}
+
+/* DocCardList: restyle the built-in card grid (used on the section index
+   pages: Learn, Integrate, Build, Validate, Community, List an Asset, etc.)
+   to match HomepageCard and the Osmosis app. The card is the <a> element
+   itself, which carries `.theme-doc-card-container`. */
+.theme-doc-card-container.card {
+  background-color: var(--docs-color-card-background);
+  border: 1px solid var(--docs-color-card-border);
+  border-radius: 1rem;
+  box-shadow: var(--docs-card-shadow);
+  transition-property: background-color, border-color, color;
+  transition-duration: 0.15s;
+}
+
+/* Dark mode: gradient hover with white text (matches the homepage cards). */
+[data-theme='dark'] .theme-doc-card-container.card:hover {
+  background-color: transparent;
+  background-image: var(--docs-gradient-neutral);
+  border-color: var(--docs-color-card-border-hover);
+  color: #fff;
+}
+
+[data-theme='dark'] .theme-doc-card-container.card:hover .theme-doc-card-title,
+[data-theme='dark'] .theme-doc-card-container.card:hover h2,
+[data-theme='dark'] .theme-doc-card-container.card:hover p {
+  color: #fff;
+}
+
+/* Light mode: softer surface-fill hover, dark text. */
+[data-theme='light'] .theme-doc-card-container.card:hover {
+  background-color: var(--docs-color-card-background-hover);
+  border-color: var(--docs-color-card-border-hover);
+}
+
+/* Hide the generic doc/folder glyph: DocCardList has no per-card custom
+   icons, so the cards read as text-only (title + summary). */
+.theme-doc-card-container .theme-doc-card-icon {
+  display: none;
+}
+
+/* Docusaurus applies `text--truncate` (single-line ellipsis) to the card
+   description, which clips multi-sentence summaries. Let it wrap instead,
+   clamped to two lines so cards stay roughly even. With proper concise
+   frontmatter descriptions, two lines should be enough. */
+.theme-doc-card-container .theme-doc-card-description {
+  white-space: normal;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+}
+
+/* Scrollbar, matching the app. The thumb token is themed (osmoverse-600
+   in dark, osmoverse-200 in light) so both modes get a styled scrollbar. */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--docs-scrollbar-thumb);
+  border-radius: 18px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--docs-scrollbar-thumb-hover);
+}
+
+/* Docusaurus's `.thin-scrollbar` (sidebar menu + right-hand TOC) sets
+   `scrollbar-width: thin` but no `scrollbar-color`, so Firefox falls back
+   to the browser-default grey thumb. Set the Firefox property explicitly,
+   and route the Infima webkit vars through the same token. */
+.thin-scrollbar {
+  scrollbar-color: var(--docs-scrollbar-thumb) transparent;
+}
+
+/* Text selection picks up the wosmongton accent. */
+::selection {
+  background: var(--docs-color-primary-tint-light);
 }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -17,6 +17,8 @@ import {
   Transaction,
   OsmosisCore,
   Contribute,
+  Network,
+  RelayerIcon,
 } from '../icons';
 
 export default function Homepage() {
@@ -30,9 +32,9 @@ export default function Homepage() {
       <div className="pad">
         <div className="center homepage-content">
           <div className='margin-bottom--lg'>
-            <h2>Osmosis Docs</h2>
+            <h2>Osmosis Documentation</h2>
             <p>
-              The Osmosis blockchain is a decentralized network of validators and full nodes, with many front-ends and development teams on it. Explore our docs and examples to quickly learn, develop & integrate with the Osmosis blockchain.
+              Osmosis is the cross-chain DEX and liquidity hub. Whether you want to understand how the protocol works, connect your app or assets, build on the chain, or run a node, these docs cover it. Use the sections below to find your path, or jump straight in.
             </p>
             <button
               type="button"
@@ -45,17 +47,25 @@ export default function Homepage() {
 
           <Section title="Learn">
             <Card
+              featured
               title="What is Osmosis?"
-              description="Osmosis is the premier cross-chain DEX and DeFi hub for the Cosmos ecosystem and beyond."
+              description="Osmosis is the premier cross-chain DEX and DeFi hub for the Cosmos ecosystem and beyond. Start here for the concepts behind the protocol."
               to="/learn/osmosis"
               icon={<OsmosisCore />}
             />
             <Card
               title="The OSMO Token"
-              description="Tokenomics, staking, and governance of the OSMO token."
+              description="Tokenomics, staking, governance, and fees of the OSMO token."
               to="/learn/osmo"
               icon={<OsmosisCore />}
               svgFile="/icons/osmo.svg"
+            />
+            <Card
+              title="Get Started"
+              description="Connect a wallet and make your first trade on Osmosis."
+              to="/learn/get-started"
+              icon={<AssetIcon />}
+              svgFile="/icons/store.svg"
             />
             <Card
               title="Features"
@@ -64,12 +74,20 @@ export default function Homepage() {
               icon={<ModulesIcon />}
               svgFile="/icons/modules.svg"
             />
+            <Card
+              title="Glossary"
+              description="Definitions for the DeFi and Cosmos terms used throughout the docs."
+              to="/learn/terminology"
+              icon={<ModulesIcon />}
+              svgFile="/icons/registry.svg"
+            />
           </Section>
 
           <Section title="Integrate">
             <Card
+              featured
               title="List an Asset"
-              description="The end-to-end workflow for bringing a token to Osmosis."
+              description="The end-to-end workflow for bringing a token to Osmosis: connect over IBC, register, source liquidity, create a pool, and add incentives."
               to="/integrate/list-asset"
               icon={<AssetIcon />}
             />
@@ -84,16 +102,30 @@ export default function Homepage() {
               title="Feature Integrations"
               description="Integrate against concentrated liquidity, alloyed assets, and smart accounts."
               to="/integrate/features"
+              icon={<ModulesIcon />}
+              svgFile="/icons/modules.svg"
+            />
+            <Card
+              title="Transaction Structure"
+              description="How messages and events are laid out in Osmosis transactions."
+              to="/integrate/transaction-structure"
               icon={<Transaction />}
               svgFile="/icons/transaction.svg"
+            />
+            <Card
+              title="IBC Channels"
+              description="How assets reach Osmosis over IBC, and where to find the canonical channel and denom mappings."
+              to="/integrate/channels"
+              icon={<Network />}
             />
           </Section>
 
           <Section title="Build" id="build" hasSubSections>
             <Section id="build-main" HeadingTag="h4">
               <Card
+                featured
                 title="Install osmosisd"
-                description="Minimum specs, installation, building from source, and the osmosisd command reference."
+                description="Minimum specs, installation, building from source, and the osmosisd command reference. The starting point for chain development."
                 to="/build/developer-environment/osmosisd"
                 icon={<TerminalIcon />}
                 svgFile="/icons/cli.svg"
@@ -122,13 +154,6 @@ export default function Homepage() {
                 title="CosmWasm"
                 description="Write, deploy, and interact with CosmWasm smart contracts on Osmosis."
                 to="/build/cosmwasm"
-                icon={<TerminalIcon />}
-                svgFile="/icons/cw-orch.svg"
-              />
-              <Card
-                title="cw-orchestrator"
-                description="All-in-one Rust-based CosmWasm testing, scripting, and deployment tool."
-                to="/build/cosmwasm/cw-orch"
                 icon={<TerminalIcon />}
                 svgFile="/icons/cw-orch.svg"
               />
@@ -185,9 +210,17 @@ export default function Homepage() {
 
           <Section title="Validate">
             <Card
+              featured
               title="Running a Node on Mainnet"
-              description="Sync and run a full Osmosis node on mainnet."
+              description="Sync and run a full Osmosis node on mainnet, the foundation for validating and relaying."
               to="/validate/joining-mainnet"
+              icon={<TerminalIcon />}
+              svgFile="/icons/cli.svg"
+            />
+            <Card
+              title="Install osmosisd"
+              description="Minimum specs and installation for the osmosisd binary."
+              to="/validate/install-osmosisd"
               icon={<TerminalIcon />}
               svgFile="/icons/cli.svg"
             />
@@ -197,6 +230,12 @@ export default function Homepage() {
               to="/validate/validating-mainnet"
               icon={<TerminalIcon />}
               svgFile="/icons/cli.svg"
+            />
+            <Card
+              title="Using TMKMS"
+              description="Production key security for a validator with the Tendermint KMS."
+              to="/validate/tmkms"
+              icon={<KeysIcon />}
             />
             <Card
               title="Relayer Guide"
@@ -219,11 +258,15 @@ export default function Homepage() {
               title="Translations"
               description="Help translate the Osmosis interface into new languages."
               to="/community/translating"
+              icon={<Contribute />}
+              svgFile="/icons/registry.svg"
             />
             <Card
               title="IBC Relayer List"
               description="Directory of relaying operators connecting Osmosis to the Cosmos ecosystem."
               to="/community/ibc-relayers-list"
+              icon={<RelayerIcon />}
+              svgFile="/icons/relayer.svg"
             />
           </Section>
 


### PR DESCRIPTION
Modernizes the docs site styling to match the Osmosis frontend ([MTN-84](https://linear.app/osmosis/issue/MTN-84)). All token values were verified against `osmosis-frontend`'s `tailwind.config.js`, not approximated.

Supersedes the closed draft #313 (which predated the IA restructure). Build is clean; reviewed by the frontend-team reviewer and a content/style pass.

Review links point at this PR's Vercel preview build.

## Visual review (toggle light + dark mode for each)

- [x] [Homepage](https://docs-git-chore-mtn-84-design-modernization.vercel.dev-osmosis.zone/) — header "Osmosis Documentation", intro, featured cards (Learn/Integrate/Validate/Build), gradient hover (dark) / soft hover (light), Community plain
- [x] [A dense doc page](https://docs-git-chore-mtn-84-design-modernization.vercel.dev-osmosis.zone/build/chain/gamm) — Poppins headings, purple links, 72ch reading measure on prose, code/tables full width, lede paragraph one size up
- [x] [A section index](https://docs-git-chore-mtn-84-design-modernization.vercel.dev-osmosis.zone/learn) — cards match the homepage (no glyphs, 2-line descriptions, hover)
- [x] [Single-column index: Feature Integrations](https://docs-git-chore-mtn-84-design-modernization.vercel.dev-osmosis.zone/integrate/features) — one card per row
- [x] [Single-column index: Data Recipes](https://docs-git-chore-mtn-84-design-modernization.vercel.dev-osmosis.zone/integrate/data-recipes)
- [x] [Single-column index: Frontend & SDKs](https://docs-git-chore-mtn-84-design-modernization.vercel.dev-osmosis.zone/build/frontend)
- [x] [Single-column index: CosmWasm](https://docs-git-chore-mtn-84-design-modernization.vercel.dev-osmosis.zone/build/cosmwasm)
- [x] [Learn > Features](https://docs-git-chore-mtn-84-design-modernization.vercel.dev-osmosis.zone/learn/features) — now a card grid (was a manual TOC)
- [x] [API reference](https://docs-git-chore-mtn-84-design-modernization.vercel.dev-osmosis.zone/api/) — Stoplight still renders with the new tokens
- [x] Sidebar + right-hand TOC scrollbars are themed (osmoverse thumb), both modes
- [x] Navbar "Launch Dex" CTA: 2px wosmongton fill, brightens on hover (not washed-out in dark mode)

## What changed

- **Palette/typography:** `--docs-color-*` remapped to wosmongton purple + bullish teal; dark canvas osmoverse-1000 (`#090524`); Poppins headings (600), Inter body, Fira Code mono.
- **Cards:** filled osmoverse-800 surface, osmoverse-700 border, `shadow-md`, 1rem radius; gradient-neutral hover (dark) / soft hover (light); featured = wosmongton border + larger title, spans 2 cols.
- **Index pages:** match homepage cards; glyphs hidden; 2-line descriptions; single-column on four pages; two generated-index categories converted to doc-index pages.
- **CTAs:** match the app primary button, theme-fixed; Postman CTA bullish-600 for AA contrast.
- **Scrollbar, 72ch measure + lede, text selection, Stoplight tokens.**
- **Content:** concise `description:` frontmatter on 66 pages (drives the card summaries); homepage header/intro; CONTRIBUTING "Docs page conventions" section.

## Notes

- Admonitions intentionally keep Infima's semantic colors (info/success/warning/danger); exact ion/bullish/rust matching is deferred.
- The 4 new Learn pages on the MTN-113 branch will get their `description:` frontmatter when that branch merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Docusaurus/CSS-only changes with no runtime chain or auth logic; risk is limited to visual regressions on the docs site.
> 
> **Overview**
> **Modernizes the Osmosis docs site** to align with the app.osmosis.zone palette and typography: wosmongton/osmoverse tokens, **Poppins** headings, themed scrollbars and selection, **72ch** prose measure with a larger **lede** paragraph, and homepage/section **cards** (shadows, gradient hover in dark mode, optional **featured** two-column cards).
> 
> **Homepage** copy and card grid are expanded (featured cards on Learn/Integrate/Validate/Build; more Community links). **Section indexes** get real landing pages for Data Recipes and Feature Integrations (replacing generated indexes), **Learn > Features** switches from a manual TOC to `<DocCardList />`, and several hubs use **`single-column-cards`**. **~66 pages** gain `description:` frontmatter for card summaries; **CONTRIBUTING** documents docs page conventions.
> 
> **CTAs** (navbar/footer/dev links) use theme-fixed wosmongton fills; Stoplight/API and sidebar menu colors route through the new tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d753e01433f6cb0699706ec5f9fac67e594c919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->