### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -110,6 +110,7 @@ const config = {
     docsPlugin,
     redirectsPlugin,
     webpackPlugin,
+    'docusaurus-plugin-copy-page-button',
   ],
 
   themeConfig:

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-select": "^0.1.1",
     "@stoplight/elements": "^9.0.21",
     "clsx": "^2.0.0",
+    "docusaurus-plugin-copy-page-button": "^0.8.1",
     "katex": "0.16",
     "param-case": "^3.0.4",
     "prism-react-renderer": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7262,6 +7262,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+docusaurus-plugin-copy-page-button@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.8.1.tgz#81bd0cca01551a3995169e3baa5c4bd17a2258b3"
+  integrity sha512-TGzSETve01PRdPm79GVckA8lqiFo3kHHVxemzLbSZE7/lqO0MquZHgJtEnq9m3yZGcYdUUTXRlcLgr8d+Qg7Ow==
+
 docusaurus-plugin-typedoc@^0.17.5:
   version "0.17.5"
   resolved "https://registry.yarnpkg.com/docusaurus-plugin-typedoc/-/docusaurus-plugin-typedoc-0.17.5.tgz#d326a1e3d728c75adbb59d7d376e72ddfad0b78a"


### PR DESCRIPTION
This PR
- adds docusaurus-plugin-copy-page-button to package.json
- adds the plugin string to plugins in docusaurus.config.ts
- puts a "Copy page" button in the docs sidebar — exports current page as clean markdown
- adds one-click "Open in Claude / ChatGPT / Gemini" actions that prefill the markdown

why useful for Osmosis specifically:
the integrate/ and validate/ sections carry a lot of per-page nuance — pools, IBC transfers, CosmWasm, running and upgrading nodes. the typical flow for someone building against Osmosis or standing up a validator is reading a docs page → wanting to drop just that page into an LLM to scaffold the integration or debug a setup. this saves the selection-and-cleanup step.

zero config, auto-injects into the TOC sidebar, theme-aware. (noticed you swizzle DocSidebar — the button injects near the TOC on the right, so it won't touch your left-nav customizations.)

shipping on React Native, Redux Toolkit, Puppeteer, pnpm, PlayCanvas, Arbitrum, Cardano, Sui, Nillion, Flare, Kaia, and ~20 other docs sites. listed on the Docusaurus community plugins page.

happy to close/rebase if not a fit
- repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button
