### PR TITLE
Add Valopers explorer

### DIFF
--- a/docs/integrate/endpoints/index.mdx
+++ b/docs/integrate/endpoints/index.mdx
@@ -75,12 +75,14 @@ The following is a list of explorers available.
 - Bigdipper: [https://osmosis.bigdipper.live/](https://osmosis.bigdipper.live/)
 - Ping.pub: [https://ping.pub/osmosis](https://ping.pub/osmosis)
 - Celatone (Contract Explorer): [https://celatone.osmosis.zone/mainnet](https://celatone.osmosis.zone/mainnet)
+- Valopers: [https://osmosis.valopers.com](https://osmosis.valopers.com)
 
 #### Testnet
 
 - Mintscan: [https://testnet.mintscan.io/osmosis-testnet](https://testnet.mintscan.io/osmosis-testnet)
 - Ping.pub: [https://testnet.ping.pub/osmosis](https://testnet.ping.pub/osmosis)
 - Celatone (Contract Explorer): [https://celatone.osmosis.zone/osmo-test-5](https://celatone.osmosis.zone/osmo-test-5)
+- Valopers: [https://testnet.osmosis.valopers.com](https://testnet.osmosis.valopers.com)
 
 
 


### PR DESCRIPTION
Title: Add Valopers explorer

Adds Valopers to the Osmosis explorer lists.

Mainnet: https://osmosis.valopers.com
Testnet: https://testnet.osmosis.valopers.com

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Adds **Valopers** to the Osmosis explorer lists in `docs/integrate/endpoints/index.mdx`: mainnet (`osmosis.valopers.com`) and testnet (`testnet.osmosis.valopers.com`), matching the format of the existing Mintscan, Ping.pub, and Celatone entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6b66ee49b7c064c4b0110bb2e492e56d18af211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->