### PR TITLE
fix(integrate): remove duplicate transaction example in transaction-structure

### DIFF
--- a/docs/integrate/transaction-structure/README.md
+++ b/docs/integrate/transaction-structure/README.md
@@ -127,7 +127,6 @@ The main outline is as follows:
 <p/>
 </details>
 
-
 As the purpose of this document is to describe the transaction structure, rather than the block structure, we
 will not spend too much time on the block structure.
 
@@ -457,101 +456,7 @@ Below is part of the transaction at index 1 of the above block.
 
 </details>
 
-Each transaction has an identical structure. The differences are in the details inside each structure:
-
-<details>
-<summary>transaction 2</summary>
-
-```json
-{
-  "height": "2836990",
-  "txhash": "5BBC27779EA33FC99C319D74CFE730DC2A3102277D75410E75F2F9F5ED259BFE",
-  "codespace": "",
-  "code": 0,
-  "data": "0A2C0A2A2F6F736D6F7369732E67616D6D2E763162657461312E4D7367537761704578616374416D6F756E74496E",
-  "raw_log": "<raw data>",
-  "logs": [
-    {
-      "msg_index": 0,
-      "log": "",
-      "events": [
-        { ... },
-        { ... },
-        ...
-      ]
-    }
-  ],
-  "info": "",
-  "gas_wanted": "2000000",
-  "gas_used": "183726",
-  "tx": {
-    "@type": "/cosmos.tx.v1beta1.Tx",
-    "body": {
-      "messages": [
-        {
-          "@type": "/osmosis.gamm.v1beta1.MsgSwapExactAmountIn",
-          "sender": "osmo1l4u56l7cvx8n0n6c7w650k02vz67qudjlcut89",
-          "routes": [
-            {
-              "poolId": "604",
-              "tokenOutDenom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
-            },
-            {
-              "poolId": "611",
-              "tokenOutDenom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
-            },
-            {
-              "poolId": "1",
-              "tokenOutDenom": "uosmo"
-            }
-          ],
-          "tokenIn": {
-            "denom": "uosmo",
-            "amount": "15000000"
-          },
-          "tokenOutMinAmount": "15000000"
-        }
-      ],
-      "memo": "",
-      "timeout_height": "0",
-      "extension_options": [],
-      "non_critical_extension_options": []
-    },
-    "auth_info": {
-      "signer_infos": [
-        {
-          "public_key": {
-            "@type": "/cosmos.crypto.secp256k1.PubKey",
-            "key": "ArVxHYy0VZ22LI7+o5HJwli+G4SoXVb2GjCejYUU//XX"
-          },
-          "mode_info": {
-            "single": {
-              "mode": "SIGN_MODE_DIRECT"
-            }
-          },
-          "sequence": "63948"
-        }
-      ],
-      "fee": {
-        "amount": [
-          {
-            "denom": "uosmo",
-            "amount": "0"
-          }
-        ],
-        "gas_limit": "2000000",
-        "payer": "",
-        "granter": ""
-      }
-    },
-    "signatures": []
-  },
-  "timestamp": "2022-01-17T17:14:01Z"
-}
-```
-
-</details>
-
+Every transaction in the block shares this same top-level structure; the differences are in the details inside each one.
 
 Each transaction is structured of the following key elements. The more complex ones will be described in detail below.
 


### PR DESCRIPTION
Found during the multi-agent accuracy sweep of the Integrate section (the Integrate content itself merged in #344; this fix lands separately since that PR is already merged).

## Problem

The Transaction Structure page presented two worked examples, "transaction 1" and "transaction 2", with the lead-in "Each transaction has an identical structure. The differences are in the details inside each structure." But the **"transaction 2" block was a byte-identical copy of "transaction 1"** — same `txhash` (`5BBC2777...259BFE`), same body, same logs. It demonstrated no difference, which defeated the point of showing a second example.

## Fix

The source block is from height **2836990** (Jan 2022), which is pruned on public RPC/archive endpoints I can reach, so a genuine second transaction's data cannot be sourced without fabricating onchain values (not acceptable). Rather than invent data, this:

- Removes the duplicate "transaction 2" `<details>` block (96 lines).
- Rewords the lead-in to describe the shared top-level structure using the single retained (transaction 1) example, which the following "Each transaction is structured of the following key elements" field list already references.

Net diff: 1 insertion, 96 deletions. Build passes.

## Follow-up (optional)

If a genuinely distinct second example is wanted, it would need a real transaction pulled from an archive node for that block (or a different, retrievable block), sourced rather than reconstructed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit to `docs/integrate/transaction-structure/README.md` with no code or configuration impact.
> 
> **Overview**
> Fixes misleading documentation on the **Transaction Structure** page: the second worked example was a duplicate of the first (same `txhash` and JSON), so it did not illustrate differing transaction details as the old copy claimed.
> 
> The duplicate **"transaction 2"** `<details>` block (~96 lines) is removed. The lead-in is replaced with a single sentence stating that every transaction in the block shares the same top-level structure and that variation is in the inner fields, aligned with the retained **transaction 1** example and the field list that follows.
> 
> A minor whitespace cleanup removes an extra blank line before the block-structure aside. No runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcec8cc6dd35370cfa013d484bc6f2b1ae815f01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->