### PR TITLE
docs(endpoints): link OpenChainBench public RPC latency benchmark

### DIFF
--- a/docs/integrate/endpoints/index.mdx
+++ b/docs/integrate/endpoints/index.mdx
@@ -95,3 +95,6 @@ The following is a list of explorers available.
     - advance key and team features
     - PAYG flat-fee CU pricing
 
+## Public RPC Benchmarks
+
+If you're picking between the public endpoints listed above, [OpenChainBench](https://openchainbench.com/benchmarks/osmosis-rpc) publishes an open, multi-region latency benchmark for Osmosis Tendermint RPC. It probes `status` from Paris, Virginia, and Singapore against `rpc.osmosis.zone`, Polkachu, PublicNode, Imperator, and LavenderFive, and tracks p50/p95 latency, availability, and block-height staleness. Methodology and raw data are open-source ([source](https://github.com/ChainBench/openchainbench)).


### PR DESCRIPTION
## Summary

Adds a short subsection under `docs/integrate/endpoints/index.mdx` pointing developers to a public multi-region latency benchmark for Osmosis Tendermint RPC endpoints.

The goal is to give integrators an independent signal when choosing between `rpc.osmosis.zone` and the third-party providers already listed on this page (Polkachu, PublicNode, Imperator, LavenderFive, etc.).

## What it links to

[OpenChainBench / osmosis-rpc](https://openchainbench.com/benchmarks/osmosis-rpc) — an open-source ([ChainBench/openchainbench](https://github.com/ChainBench/openchainbench)) latency probe run from Paris (eu-west), Virginia (us-east), and Singapore (ap-southeast). It:

- Calls Tendermint `status` on each provider from all 3 regions.
- Publishes p50 / p95 request latency, availability (%), and block-height staleness vs the fastest peer.
- Rolls up 24 h / 7 d / 30 d views, methodology, and raw JSON.

No API keys, no signup, no paywall.

## Why here

Anyone landing on `integrate/endpoints` to pick an RPC currently has no observability signal to compare providers — only marketing blurbs. A single line linking to a neutral, open benchmark helps them make an informed call.

## Notes

- Osmosis is the first Cosmos SDK chain we added to the RPC benchmark cluster; the probe uses `status` (not `block`/`abci_query`), matching the Tendermint entrypoint every integrator hits first.
- I don't work at any of the providers listed on the benchmark; happy to reword if the phrasing reads as promotional.