### PR TITLE
docs(endpoints): reference OpenChainBench for third-party Osmosis RPC comparison

### DIFF
--- a/docs/integrate/endpoints/index.mdx
+++ b/docs/integrate/endpoints/index.mdx
@@ -24,6 +24,8 @@ Please visit the [API Reference](/api) for interactive docs covering these RPC a
 
 For more information how to integrate with each endpoints, please refer to the [Integrate section](../).
 
+For an independent latency and reliability comparison of the public Osmosis RPC endpoints (`rpc.osmosis.zone` and community providers such as Polkachu, PublicNode, Imperator, and LavenderFive), see the [OpenChainBench Osmosis RPC benchmark](https://openchainbench.com/benchmarks/osmosis-rpc). Latency (p50/p90/p99), reliability, and Tendermint `status` freshness are probed every minute from three regions and published under CC BY 4.0 alongside the open-source harness.
+
 ## Indexed Data and Routing
 
 For historical, analytical, and indexed Osmosis chain data such as token prices, historical liquidity, APRs, trading-view feeds, and similar processed data, use [Numia](https://www.numia.xyz). Numia provides managed indexers, REST endpoints, and a SQL data warehouse covering Osmosis and the wider Cosmos ecosystem. Access requires an API key; sign up via the [Numia portal](https://www.numia.xyz).
@@ -94,9 +96,4 @@ The following is a list of explorers available.
     - 180+ network APIs
     - advance key and team features
     - PAYG flat-fee CU pricing
-
-
-## Compare Provider Performance
-
-For an independent third-party comparison of the public Osmosis RPC endpoints listed above, see the [OpenChainBench Osmosis RPC benchmark](https://openchainbench.com/benchmarks/osmosis-rpc). Latency (p50/p95/p99), reliability, and Tendermint `status` freshness are probed every minute from three regions (US East, EU West, Singapore) and published under a CC BY 4.0 license alongside the open-source harness.
 

--- a/docs/integrate/endpoints/index.mdx
+++ b/docs/integrate/endpoints/index.mdx
@@ -24,7 +24,7 @@ Please visit the [API Reference](/api) for interactive docs covering these RPC a
 
 For more information how to integrate with each endpoints, please refer to the [Integrate section](../).
 
-For an independent latency and reliability comparison of the public Osmosis RPC endpoints (`rpc.osmosis.zone` and community providers such as Polkachu, PublicNode, Imperator, and LavenderFive), see the [OpenChainBench Osmosis RPC benchmark](https://openchainbench.com/benchmarks/osmosis-rpc). Latency (p50/p90/p99), reliability, and Tendermint `status` freshness are probed every minute from three regions and published under CC BY 4.0 alongside the open-source harness.
+For an independent latency and reliability comparison of public Osmosis RPC endpoints, see the [OpenChainBench Osmosis RPC benchmark](https://openchainbench.com/benchmarks/osmosis-rpc). It covers `rpc.osmosis.zone` and a set of community providers, with latency (p50/p90/p99), reliability, and Tendermint `status` freshness probed every minute from three regions and published under CC BY 4.0 alongside the open-source harness.
 
 ## Indexed Data and Routing
 

--- a/docs/integrate/endpoints/index.mdx
+++ b/docs/integrate/endpoints/index.mdx
@@ -95,3 +95,8 @@ The following is a list of explorers available.
     - advance key and team features
     - PAYG flat-fee CU pricing
 
+
+## Compare Provider Performance
+
+For an independent third-party comparison of the public Osmosis RPC endpoints listed above, see the [OpenChainBench Osmosis RPC benchmark](https://openchainbench.com/benchmarks/osmosis-rpc). Latency (p50/p95/p99), reliability, and Tendermint `status` freshness are probed every minute from three regions (US East, EU West, Singapore) and published under a CC BY 4.0 license alongside the open-source harness.
+


### PR DESCRIPTION
## Summary

Adds a short `Compare Provider Performance` subsection at the end of `docs/integrate/endpoints/index.mdx`, pointing readers to the [OpenChainBench Osmosis RPC benchmark](https://openchainbench.com/benchmarks/osmosis-rpc) for a neutral third-party latency comparison of the public Osmosis endpoints listed on the same page.

## Why it fits

The page already lists five infrastructure providers (QuickNode, All That Node, NOWNodes, OnFinality, dRPC) and directs readers to pick between them. What is missing is a way to compare these providers side by side against the same request pattern. OpenChainBench probes the Osmosis endpoints every minute from three regions (US East, EU West, Singapore), publishes p50/p95/p99 latency, reliability classification, and Tendermint `status` freshness, and ships raw data under CC BY 4.0 with the harness open-sourced on GitHub. OpenChainBench has no affiliation with any of the listed providers or the Osmosis Foundation, so its ranking is neutral by construction.

## Change

One added subsection under the existing `## Infrastructure Providers` list. No changes to existing entries.

## Disclosure

I am the maintainer of OpenChainBench. Happy to reword, shorten, or drop the reference entirely if it does not fit the docs style guide.