### PR TITLE
chore(search): read the Algolia search key from an env var (MTN-241)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
+# Algolia DocSearch search-only key (public by design; read-only ACL).
+# Required for the docs search box. Set the real value in Vercel and locally.
+ALGOLIA_SEARCH_KEY=
+
+# docsearch-scraper credentials (write access; used only by the scraper Action,
+# not the site build). Kept as GitHub Action secrets in CI.
 APPLICATION_ID=
 API_KEY=

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,6 +14,44 @@ const npm2yarn = esmDefault(require('@docusaurus/remark-plugin-npm2yarn'));
 const remarkMath = esmDefault(require('remark-math'));
 const rehypeKatex = esmDefault(require('rehype-katex'));
 
+// Minimal .env loader (Docusaurus does not read .env, and we avoid adding a
+// dotenv dependency just for one var). Only fills vars not already set, so the
+// real process environment (Vercel, CI) always wins over the file.
+(() => {
+  try {
+    const fs = require('fs');
+    const path = require('path');
+    const envPath = path.join(__dirname, '.env');
+    if (!fs.existsSync(envPath)) return;
+    for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+      const m = line.match(/^\s*([\w.-]+)\s*=\s*(.*)\s*$/);
+      if (!m || line.trimStart().startsWith('#')) continue;
+      const key = m[1];
+      let val = m[2].replace(/^["']|["']$/g, '');
+      if (process.env[key] === undefined) process.env[key] = val;
+    }
+  } catch {
+    /* best-effort; real env vars still apply */
+  }
+})();
+
+// Algolia DocSearch search-only API key. This key is public by design (it must
+// ship to the browser for the search box to work) and is read-only
+// (search/listIndexes/settings/browse; no write/admin ACL). It is read from an
+// env var rather than committed inline so org secret scanners stop flagging it
+// as an exposed credential; env-injecting it changes nothing about security.
+// Set ALGOLIA_SEARCH_KEY in Vercel (all environments) and in a local `.env`.
+// The scraper's write credentials (APPLICATION_ID / API_KEY) are separate
+// GitHub Action secrets and are correctly not in this repo.
+const ALGOLIA_SEARCH_KEY = process.env.ALGOLIA_SEARCH_KEY;
+if (!ALGOLIA_SEARCH_KEY) {
+  throw new Error(
+    'ALGOLIA_SEARCH_KEY is not set. Set it (Vercel env vars, or a local .env) ' +
+      'so the docs search box works. It is the public search-only DocSearch key, ' +
+      'not a secret; see docusaurus.config.js for details.'
+  );
+}
+
 /** @type {import('@docusaurus/preset-classic').Options} */ defaultSettings = {
   remarkPlugins: [[npm2yarn, { sync: true }]],
 };
@@ -266,9 +304,10 @@ const config = {
       algolia: {
         // Org-owned Algolia account. The docsearch-scraper GitHub Action
         // (APPLICATION_ID / API_KEY secrets) populates the `Docs` index.
-        // This key is search-only (search/listIndexes/settings/browse).
+        // apiKey is the public search-only key, read from ALGOLIA_SEARCH_KEY
+        // (see the const near the top of this file).
         appId: 'F26GLV8TNU',
-        apiKey: '0c5c06782dec165349c88655f2de36b6',
+        apiKey: ALGOLIA_SEARCH_KEY,
         indexName: 'Docs',
         // Kept off through the MTN-88 single-instance migration: the new index
         // has faceting configured, but page `docusaurus_tag` values will flip


### PR DESCRIPTION
## ⚠️ Action required before merge

This change reads the Algolia search key from `ALGOLIA_SEARCH_KEY` with **no literal fallback**. **Set `ALGOLIA_SEARCH_KEY` in the Vercel project env vars (all environments) before merging**, or the build fails by design (the guard halts the build rather than shipping a broken search box). The value is the same public search-only key currently in the config.

## What

The Algolia DocSearch key is **public by design** (it must ship to the browser for the search box to work) and **read-only** (verified ACL: `search`, `listIndexes`, `settings`, `browse`; no write/admin). But org secret scanners keep flagging the committed literal in `docusaurus.config.js` as an exposed credential, and we keep re-triaging the same false positive.

This reads the key from an env var so there is no literal string in source to match. It changes **nothing** about security: the key still reaches the client bundle (confirmed), because it has to for search to work. This only stops the scanner reports.

## Changes

- **`docusaurus.config.js`**: `apiKey` now comes from `process.env.ALGOLIA_SEARCH_KEY`. Adds:
  - A build-time guard that throws a clear error if the var is unset, so a misconfigured deploy fails loudly instead of shipping a broken search box.
  - A minimal, zero-dependency `.env` loader (only fills vars not already set, so the real environment always wins), so local dev works without adding `dotenv`.
- **`.env.example`**: documents `ALGOLIA_SEARCH_KEY`.

## Verified

- The key literal is gone from all tracked files (`git grep` finds zero); it lives only in a gitignored local `.env`.
- Real env vars override `.env`; `.env` is gitignored so it is never committed.
- `yarn build` passes, and the search key still reaches the client bundle (`build/assets/js/main.*.js`), so search continues to work.
- The `docsearch-scraper` write credentials (`APPLICATION_ID` / `API_KEY`) are separate GitHub Action secrets and are untouched.

## Note on scope

The recurring reports come from an external/org-level scanner (this repo runs no secret scanner in CI). Removing the committed literal is what actually silences them, so a `.gitleaks.toml` allowlist was intentionally not added (there is no literal left to match, and no in-repo gitleaks runs).

Resolves MTN-241.
