### PR TITLE
docs(integrate): add affiliate fee-share integrator guide (MTN-172)

### DIFF
--- a/docs/integrate/affiliate-fee-share.md
+++ b/docs/integrate/affiliate-fee-share.md
@@ -6,35 +6,72 @@ sidebar_position: 8
 
 # Affiliate Fee Share
 
-If you send swap volume to Osmosis from your own app, aggregator, or frontend, you can take an affiliate fee on each swap. You build the swap surface; Osmosis provides the onchain pieces that let you take a cut.
+If you send swap volume to Osmosis from your own app, aggregator, or frontend, you can take an affiliate fee on each swap. There is no Osmosis-native embeddable widget, but there are three supported paths, in increasing order of integration effort:
 
-There is no hosted embeddable widget to drop in. You construct and submit the swap yourself (from your UI, bot, or backend), and one of two onchain mechanisms carries the fee:
+- The **Skip Go Widget**, a drop-in React or Web Component with built-in affiliate fee configuration. The fastest path if you want a ready-made swap surface.
+- The **`affiliate-swap` contract**, the self-contained path if you build your own surface and swap directly against Osmosis pools: send it a token, it takes your fee and swaps the rest.
+- The **Skip `swap_and_action` affiliates array**, if you build your own surface on Skip API routing.
 
-- The **`affiliate-swap` contract**, the self-contained path: send it a token, it takes your fee and swaps the rest through Osmosis pools. This is the one to use if you are building your own swap surface against Osmosis directly.
-- The **Skip `swap_and_action` affiliates array**, if you already route swaps through the Skip entry point.
-
-A note on why a contract is involved: the native poolmanager swap message (`MsgSwapExactAmountIn` / `MsgSwapExactAmountOut`) has **no** affiliate or fee field. You cannot attach a cut to a plain Osmosis swap. The `affiliate-swap` contract exists precisely to wrap a swap with a fee deduction, which is why it, rather than a raw swap message, is the integrator path.
+A note on why a contract is always involved: the native poolmanager swap message (`MsgSwapExactAmountIn` / `MsgSwapExactAmountOut`) has **no** affiliate or fee field. You cannot attach a cut to a plain Osmosis swap, so every affiliate path wraps the swap in a contract that performs the fee deduction.
 
 ## Which path applies
 
 | You are... | Use | Fee is taken... |
 | -- | -- | -- |
-| Building your own swap surface against Osmosis pools (app, bot, backend) | `affiliate-swap` contract | From the input token, before the swap |
-| Already routing swaps through the Skip entry point | Skip `affiliates` array | By Skip, per the entry point contract |
+| Embedding a ready-made swap UI in your app | Skip Go Widget | Per its `chainIdsToAffiliates` config |
+| Building your own surface, swapping Osmosis pools directly | `affiliate-swap` contract | From the input token, before the swap |
+| Building your own surface on Skip API routing | Skip `affiliates` array | From `min_asset`, in the output token |
+
+## Drop-in: the Skip Go Widget
+
+The [Skip Go Widget](https://docs.skip.build/go/widget/getting-started) (`@skip-go/widget`) is an embeddable swap component, available as a React component or a Web Component, with affiliate fees as a first-class config option:
+
+```tsx
+import { Widget } from "@skip-go/widget";
+
+<Widget
+  chainIdsToAffiliates={{
+    "osmosis-1": {
+      affiliates: [
+        { basisPointsFee: "50", address: "osmo1youraffiliateaddress..." },
+      ],
+    },
+  }}
+/>;
+```
+
+- `basisPointsFee`: your fee in basis points (`50` is 0.5%).
+- `address`: the fee recipient, which must be valid for that chain.
+- The total `basisPointsFee` must be consistent across every chain you configure.
+
+The widget handles quoting, fee inclusion, and message construction for you. See the [widget configuration reference](https://docs.skip.build/go/widget/configuration) for theming and the full option set. The rest of this page covers the two lower-level paths for integrators building their own surface.
 
 ## The `affiliate-swap` contract
 
-Osmosis has a deployed `affiliate-swap` CosmWasm contract (code id `149`). You send it one token, it takes your fee, and it swaps the remainder on your behalf through the poolmanager. The fee goes to any address you name.
+Osmosis has a deployed `affiliate-swap` CosmWasm contract. You send it one token, it takes your fee, and it swaps the remainder on your behalf through the poolmanager. The fee goes to any address you name.
+
+Use this instance:
+
+```
+osmo19n4w08zgxhc669cnjt47h5v8tyd6nel2jhy6pkgz7hthy3mu4umsrc298t
+```
+
+The code (id `149`) has several instances on mainnet, instantiated with different fee caps (`0`, `1.5`, and `10` percent are all live). An instance capped at `0` pays you nothing, so pin the address above and verify its cap (below) rather than picking any instance of the code id.
+
+The contract wraps `MsgSwapExactAmountIn` only: **exact-in swaps**. There is no exact-out variant.
 
 ### Execute message
 
-The contract exposes a single `swap` execute message:
+The contract exposes a single `swap` execute message. This example swaps ATOM to OSMO through pool 1 (an ATOM/OSMO pool):
 
 ```json
 {
   "swap": {
     "routes": [
-      { "pool_id": "1", "token_out_denom": "uosmo" }
+      {
+        "pool_id": "1",
+        "token_out_denom": "uosmo"
+      }
     ],
     "token_out_min_amount": { "denom": "uosmo", "amount": "950000" },
     "fee_percentage": "1.0",
@@ -44,41 +81,52 @@ The contract exposes a single `swap` execute message:
 ```
 
 - `routes`: the poolmanager swap route (`SwapAmountInRoute`: `pool_id` + `token_out_denom`), same routing you would pass to `MsgSwapExactAmountIn`.
-- `token_out_min_amount`: your slippage-guarded minimum output. This is enforced on the swap of the post-fee amount.
-- `fee_percentage`: your affiliate fee, as a percent (so `1.0` is 1%). Optional; omitting it means no fee.
-- `fee_collector`: the address that receives the fee.
+- `token_out_min_amount`: your slippage-guarded minimum output, enforced on the swap of the post-fee amount. Only the `amount` is enforced; the `denom` field is ignored by the deployed contract. Set it to the route's output denom anyway for readability.
+- `fee_percentage`: your affiliate fee, as a percent (so `1.0` is 1%). Optional; omitting it means no fee. It must deserialize as an unsigned decimal: a negative value is rejected at parse time, not clamped to zero.
+- `fee_collector`: the address that receives the fee. Must be a valid Osmosis address; the contract validates it and rejects the call otherwise.
 
 Send the input token as funds on the execute call. The contract:
 
-1. Takes `fee_percentage` percent of the sent amount (clamped to at least `0` and at most the contract's configured maximum), and sends that fee to `fee_collector` in the **input denom**.
-2. Swaps the remaining amount through `routes`, enforcing `token_out_min_amount`.
+1. Takes `fee_percentage` percent of the sent amount and sends that fee to `fee_collector` in the **input denom**.
+2. Swaps the remaining amount through `routes`, enforcing `token_out_min_amount.amount`.
 3. Returns the swapped output to you.
 
 ### Fee cap
 
-The fee is capped. If you request more than the configured maximum, the contract silently uses the maximum instead of failing. Query the live cap before relying on a value:
+Each instance has its own maximum. If you request more than the instance's configured maximum, the contract silently uses the maximum instead of failing. Query the live cap on the instance you use:
 
 ```bash
 # max_fee_percentage is returned as a percent, e.g. "1.5" means 1.5%
-osmosisd query wasm contract-state smart <CONTRACT_ADDRESS> '{"get_max_fee_percentage":{}}'
+osmosisd query wasm contract-state smart osmo19n4w08zgxhc669cnjt47h5v8tyd6nel2jhy6pkgz7hthy3mu4umsrc298t '{"get_max_fee_percentage":{}}'
 ```
 
-The deployed maximum is `1.5` (1.5%) at the time of writing, with a hard ceiling of 10% built into the contract. Because the fee comes out of the input before the swap, a `1.0` fee on a `1000000` `uosmo` input sends `10000` `uosmo` to `fee_collector` and swaps `990000`.
+The instance above is capped at `1.5` (1.5%) at the time of writing; the contract code refuses to instantiate with a cap above 10%.
 
 ### Worked example
 
-You want to swap 1 OSMO to USDC through pool 1, taking a 1% referral fee to your own address:
+You want to swap 1 ATOM to OSMO through pool 1, taking a 1% referral fee to your own address. ATOM on Osmosis is `ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2` (6 decimals, so 1 ATOM = `1000000`):
 
 1. Build the execute message above with `fee_percentage: "1.0"` and `fee_collector` set to your address.
-2. Send `1000000uosmo` as funds on the execute.
-3. Onchain, `10000uosmo` (1%) transfers to your address, and `990000uosmo` swaps to USDC with your `token_out_min_amount` enforced.
-4. The USDC output returns to the sender.
+2. Execute against the instance above, attaching `1000000` of the ATOM denom as funds.
+3. Onchain, `10000` ATOM-denom (1%) transfers to your address, and the remaining `990000` swaps to OSMO with `token_out_min_amount.amount` enforced.
+4. The OSMO output returns to the sender.
+
+Because the fee comes out of the input before the swap, quote the swap on the post-fee amount (`input * (1 - fee)`), not the gross input, or your displayed output will be too high.
 
 ## The Skip `affiliates` array
 
-Swaps routed through the [Skip](https://skip.build/) entry point (code id `833`, the path Osmosis uses for inbound IBC swaps) carry affiliate fees in a `swap_and_action` message. The entry point deducts the fee as part of executing the action.
+Swaps built with the [Skip API](https://docs.skip.build/) execute through a Skip entry point contract and can carry affiliate fees. Two entry points exist on Osmosis:
 
-The affiliates field is an array; each entry is:
+- `osmo10a3k4hvk37cc4hnxctw4p95fhscd2z6h2rmx0aukc6rm8u9qqx9smfsh7u` (code id `1241`): the entry point Skip currently publishes for Osmosis. Messages generated by the Skip API or Widget target Skip's current contracts.
+- `osmo1vkdakqqg5htq5c3wy2kj2geq536q665xdexrtjuwqckpads2c2nsvhhcyv` (code id `833`): an older entry point, still live; the Osmosis frontend builds its inbound IBC-hook swap memos against it (currently with `affiliates: []`, no fee).
+
+If you use the Skip API, you do not pick the address yourself; the API generates messages against the right contract. The addresses matter only if you are hand-building or auditing messages. Skip's [contract address list](https://docs.skip.build/go/contracts/skip-go-contracts) is the authoritative source.
+
+### The fee must be in the quote, not just the message
+
+Populating `affiliates` on the message alone is not enough. Skip requires the fee at **quote time**: pass `cumulative_affiliate_fee_bps` (the total fee in bps across all your affiliates) in the route request, then supply the matching `affiliates` array (recipient addresses whose fees sum to that total) when generating messages. The entry point computes the fee from `min_asset`, in the **output** token, not from the input or the realized output. A message whose affiliates were not accounted for in the quote can misquote the user or fail an exact-in swap. See [Skip's affiliate fee documentation](https://docs.skip.build/go/general/affiliate-fees) for the API flow.
+
+Each affiliate entry is:
 
 ```json
 {
@@ -90,14 +138,25 @@ The affiliates field is an array; each entry is:
 - `basis_points_fee`: your fee in basis points (so `50` is 0.5%).
 - `address`: the address that receives the fee.
 
-This sits inside the `swap_and_action` message alongside `user_swap`, `min_asset`, and `post_swap_action`:
+In the executed `swap_and_action` message it sits alongside `user_swap`, `min_asset`, and `post_swap_action`. The `timeout_timestamp` is a Unix timestamp in **nanoseconds** and must be in the future; the entry point rejects anything at or before the current block time, so compute it at execution time (for example, now plus a few minutes). The value below is illustrative:
 
 ```json
 {
   "swap_and_action": {
-    "user_swap": { "swap_exact_asset_in": { "swap_venue_name": "osmosis-poolmanager", "operations": [ ... ] } },
+    "user_swap": {
+      "swap_exact_asset_in": {
+        "swap_venue_name": "osmosis-poolmanager",
+        "operations": [
+          {
+            "pool": "1",
+            "denom_in": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+            "denom_out": "uosmo"
+          }
+        ]
+      }
+    },
     "min_asset": { "native": { "denom": "uosmo", "amount": "950000" } },
-    "timeout_timestamp": 0,
+    "timeout_timestamp": 1798761600000000000,
     "post_swap_action": { "transfer": { "to_address": "osmo1recipient..." } },
     "affiliates": [
       { "basis_points_fee": "50", "address": "osmo1youraffiliateaddress..." }
@@ -106,15 +165,11 @@ This sits inside the `swap_and_action` message alongside `user_swap`, `min_asset
 }
 ```
 
-The Osmosis frontend builds exactly this message for IBC-hook swaps and currently passes `affiliates: []` (no fee). If you route your own swaps through the Skip entry point, populate the array with your address and bps.
-
-For the full Skip message shape, venue names, and the operations format, use the [Skip API documentation](https://docs.skip.build/). Osmosis only provides the deployed entry point; the message format is Skip's.
+For the full message shape and venue names, use the [Skip API documentation](https://docs.skip.build/). The message format is Skip's; Osmosis hosts the deployed entry points.
 
 ## Disclose the fee in your UI
 
-The `affiliate-swap` contract deducts your fee silently: it does not surface anything to the user, because the swap runs from your own surface. Disclosing the fee is your responsibility. Before the user signs, show the fee amount and that it goes to you, so the quoted output and the fee are both clear. Users should never discover a cut only by comparing the received amount against the market rate.
-
-For quoting, remember the fee is taken from the input before the swap, so quote the swap on the post-fee amount (`input * (1 - fee)`), not the gross input, or your displayed output will be too high.
+The `affiliate-swap` contract deducts your fee silently: it does not surface anything to the user, because the swap runs from your own surface. Disclosing the fee is your responsibility. Before the user signs, show the fee amount and that it goes to you, so the quoted output and the fee are both clear. Users should never discover a cut only by comparing the received amount against the market rate. The same applies to fees you configure on the Skip paths.
 
 ## Deep-linking the Osmosis app
 
@@ -124,7 +179,9 @@ If instead of building your own surface you just want to hand users off to the O
 https://app.osmosis.zone/?from=ATOM&to=OSMO
 ```
 
-- `from`: the sell asset symbol (defaults to ATOM).
-- `to`: the buy asset symbol (defaults to OSMO).
+- `from`: the sell asset (defaults to ATOM).
+- `to`: the buy asset (defaults to OSMO).
 
-This sets the default pair only. It swaps on the Osmosis app, not your surface, so no affiliate fee is taken. To earn a fee you build the swap yourself using one of the mechanisms above.
+Both accept an asset symbol or a minimal denom. Symbols are ambiguous where multiple bridged variants of an asset exist, so prefer minimal denoms (`uosmo`, or the full `ibc/HASH` for IBC assets) for links you generate programmatically; the symbol form is fine for hand-written links to majors like ATOM and OSMO.
+
+This sets the default pair only. It swaps on the Osmosis app, not your surface, so no affiliate fee is taken. To earn a fee you use one of the mechanisms above.

--- a/docs/integrate/affiliate-fee-share.md
+++ b/docs/integrate/affiliate-fee-share.md
@@ -128,9 +128,3 @@ https://app.osmosis.zone/?from=ATOM&to=OSMO
 - `to`: the buy asset symbol (defaults to OSMO).
 
 This sets the default pair only. It swaps on the Osmosis app, not your surface, so no affiliate fee is taken. To earn a fee you build the swap yourself using one of the mechanisms above.
-
-## Summary
-
-- The native poolmanager swap message carries no fee field. To take a cut you build the swap yourself and use one of the two onchain mechanisms below.
-- Building your own swap surface against Osmosis: call the `affiliate-swap` contract with a `fee_percentage` and `fee_collector`. The fee comes from the input token and is capped (currently 1.5%). Disclose it in your UI and quote on the post-fee amount.
-- Already routing through the Skip entry point: populate the `affiliates` array in `swap_and_action` with your address and `basis_points_fee`.

--- a/docs/integrate/affiliate-fee-share.md
+++ b/docs/integrate/affiliate-fee-share.md
@@ -1,0 +1,128 @@
+---
+title: Affiliate Fee Share
+description: Earn a fee share on swaps you route to Osmosis, as an integrator or referrer.
+sidebar_position: 8
+---
+
+# Affiliate Fee Share
+
+If you send swap volume to Osmosis from your own app, aggregator, or frontend, you can take an affiliate fee on each swap. There are two independent mechanisms, and which one you use depends on how the swap is routed:
+
+- The **`affiliate-swap` contract**, for swaps you build and submit directly against Osmosis pools.
+- The **Skip `swap_and_action` affiliates array**, for swaps routed through the Skip entry point (the path used for inbound IBC swaps).
+
+They are not alternatives to configure on the same message: each belongs to a different swap path. This page covers both, with a worked example for each.
+
+## Which path applies
+
+| You are... | Use | Fee is taken... |
+| -- | -- | -- |
+| Building a poolmanager swap yourself (CosmWasm or a bot) and want a cut | `affiliate-swap` contract | From the input token, before the swap |
+| Routing a swap through the Skip entry point (Skip API, inbound IBC) | Skip `affiliates` array | By Skip, per the entry point contract |
+
+## The `affiliate-swap` contract
+
+Osmosis has a deployed `affiliate-swap` CosmWasm contract (code id `149`). You send it one token, it takes your fee, and it swaps the remainder on your behalf through the poolmanager. The fee goes to any address you name.
+
+### Execute message
+
+The contract exposes a single `swap` execute message:
+
+```json
+{
+  "swap": {
+    "routes": [
+      { "pool_id": "1", "token_out_denom": "uosmo" }
+    ],
+    "token_out_min_amount": { "denom": "uosmo", "amount": "950000" },
+    "fee_percentage": "1.0",
+    "fee_collector": "osmo1youraffiliateaddress..."
+  }
+}
+```
+
+- `routes`: the poolmanager swap route (`SwapAmountInRoute`: `pool_id` + `token_out_denom`), same routing you would pass to `MsgSwapExactAmountIn`.
+- `token_out_min_amount`: your slippage-guarded minimum output. This is enforced on the swap of the post-fee amount.
+- `fee_percentage`: your affiliate fee, as a percent (so `1.0` is 1%). Optional; omitting it means no fee.
+- `fee_collector`: the address that receives the fee.
+
+Send the input token as funds on the execute call. The contract:
+
+1. Takes `fee_percentage` percent of the sent amount (clamped to at least `0` and at most the contract's configured maximum), and sends that fee to `fee_collector` in the **input denom**.
+2. Swaps the remaining amount through `routes`, enforcing `token_out_min_amount`.
+3. Returns the swapped output to you.
+
+### Fee cap
+
+The fee is capped. If you request more than the configured maximum, the contract silently uses the maximum instead of failing. Query the live cap before relying on a value:
+
+```bash
+# max_fee_percentage is returned as a percent, e.g. "1.5" means 1.5%
+osmosisd query wasm contract-state smart <CONTRACT_ADDRESS> '{"get_max_fee_percentage":{}}'
+```
+
+The deployed maximum is `1.5` (1.5%) at the time of writing, with a hard ceiling of 10% built into the contract. Because the fee comes out of the input before the swap, a `1.0` fee on a `1000000` `uosmo` input sends `10000` `uosmo` to `fee_collector` and swaps `990000`.
+
+### Worked example
+
+You want to swap 1 OSMO to USDC through pool 1, taking a 1% referral fee to your own address:
+
+1. Build the execute message above with `fee_percentage: "1.0"` and `fee_collector` set to your address.
+2. Send `1000000uosmo` as funds on the execute.
+3. Onchain, `10000uosmo` (1%) transfers to your address, and `990000uosmo` swaps to USDC with your `token_out_min_amount` enforced.
+4. The USDC output returns to the sender.
+
+## The Skip `affiliates` array
+
+Swaps routed through the [Skip](https://skip.build/) entry point (code id `833`, the path Osmosis uses for inbound IBC swaps) carry affiliate fees in a `swap_and_action` message. The entry point deducts the fee as part of executing the action.
+
+The affiliates field is an array; each entry is:
+
+```json
+{
+  "basis_points_fee": "50",
+  "address": "osmo1youraffiliateaddress..."
+}
+```
+
+- `basis_points_fee`: your fee in basis points (so `50` is 0.5%).
+- `address`: the address that receives the fee.
+
+This sits inside the `swap_and_action` message alongside `user_swap`, `min_asset`, and `post_swap_action`:
+
+```json
+{
+  "swap_and_action": {
+    "user_swap": { "swap_exact_asset_in": { "swap_venue_name": "osmosis-poolmanager", "operations": [ ... ] } },
+    "min_asset": { "native": { "denom": "uosmo", "amount": "950000" } },
+    "timeout_timestamp": 0,
+    "post_swap_action": { "transfer": { "to_address": "osmo1recipient..." } },
+    "affiliates": [
+      { "basis_points_fee": "50", "address": "osmo1youraffiliateaddress..." }
+    ]
+  }
+}
+```
+
+The Osmosis frontend builds exactly this message for IBC-hook swaps and currently passes `affiliates: []` (no fee). If you route your own swaps through the Skip entry point, populate the array with your address and bps.
+
+For the full Skip message shape, venue names, and the operations format, use the [Skip API documentation](https://docs.skip.build/). Osmosis only provides the deployed entry point; the message format is Skip's.
+
+## Embedding the swap tool
+
+There is no purpose-built embeddable swap widget with an affiliate parameter today. The swap tool on the Osmosis app does read the trading pair from URL query parameters, which lets you deep-link into a pre-filled swap:
+
+```
+https://app.osmosis.zone/?from=ATOM&to=OSMO
+```
+
+- `from`: the sell asset symbol (defaults to ATOM).
+- `to`: the buy asset symbol (defaults to OSMO).
+
+These set the default pair only. There is no query parameter to attach an affiliate address or fee to a deep link. To earn an affiliate fee you must build the swap yourself using one of the two mechanisms above.
+
+## Summary
+
+- To take a fee on a swap you build against Osmosis pools directly, call the `affiliate-swap` contract with a `fee_percentage` and `fee_collector`. The fee comes from the input token and is capped (currently 1.5%).
+- To take a fee on a swap routed through the Skip entry point, populate the `affiliates` array in `swap_and_action` with your address and `basis_points_fee`.
+- Deep links can pre-fill the swap pair but cannot carry an affiliate fee.

--- a/docs/integrate/affiliate-fee-share.md
+++ b/docs/integrate/affiliate-fee-share.md
@@ -48,7 +48,7 @@ The widget handles quoting, fee inclusion, and message construction for you. See
 
 ## The `affiliate-swap` contract
 
-Osmosis has a deployed `affiliate-swap` CosmWasm contract. You send it one token, it takes your fee, and it swaps the remainder on your behalf through the poolmanager. The fee goes to any address you name.
+Osmosis has a deployed `affiliate-swap` CosmWasm contract. You send it one token, it takes your fee, and it swaps the remainder on your behalf through the poolmanager. The fee goes to any valid Osmosis address you name.
 
 Use this instance:
 
@@ -111,7 +111,13 @@ You want to swap 1 ATOM to OSMO through pool 1, taking a 1% referral fee to your
 3. Onchain, `10000` ATOM-denom (1%) transfers to your address, and the remaining `990000` swaps to OSMO with `token_out_min_amount.amount` enforced.
 4. The OSMO output returns to the sender.
 
-Because the fee comes out of the input before the swap, quote the swap on the post-fee amount (`input * (1 - fee)`), not the gross input, or your displayed output will be too high.
+Because the fee comes out of the input before the swap, quote the swap on the post-fee amount, not the gross input, or your displayed output will be too high. Mirror the contract's integer math exactly (it caps the requested percentage, floors the fee amount, then subtracts), since an `input * (1 - fee)` approximation can differ by one minimal unit and ignores the cap:
+
+```
+effective_fee = min(requested_fee_percentage, instance_max_fee_percentage)
+fee_amount    = floor(input_amount * effective_fee / 100)
+swap_amount   = input_amount - fee_amount
+```
 
 ## The Skip `affiliates` array
 

--- a/docs/integrate/affiliate-fee-share.md
+++ b/docs/integrate/affiliate-fee-share.md
@@ -6,19 +6,21 @@ sidebar_position: 8
 
 # Affiliate Fee Share
 
-If you send swap volume to Osmosis from your own app, aggregator, or frontend, you can take an affiliate fee on each swap. There are two independent mechanisms, and which one you use depends on how the swap is routed:
+If you send swap volume to Osmosis from your own app, aggregator, or frontend, you can take an affiliate fee on each swap. You build the swap surface; Osmosis provides the onchain pieces that let you take a cut.
 
-- The **`affiliate-swap` contract**, for swaps you build and submit directly against Osmosis pools.
-- The **Skip `swap_and_action` affiliates array**, for swaps routed through the Skip entry point (the path used for inbound IBC swaps).
+There is no hosted embeddable widget to drop in. You construct and submit the swap yourself (from your UI, bot, or backend), and one of two onchain mechanisms carries the fee:
 
-They are not alternatives to configure on the same message: each belongs to a different swap path. This page covers both, with a worked example for each.
+- The **`affiliate-swap` contract**, the self-contained path: send it a token, it takes your fee and swaps the rest through Osmosis pools. This is the one to use if you are building your own swap surface against Osmosis directly.
+- The **Skip `swap_and_action` affiliates array**, if you already route swaps through the Skip entry point.
+
+A note on why a contract is involved: the native poolmanager swap message (`MsgSwapExactAmountIn` / `MsgSwapExactAmountOut`) has **no** affiliate or fee field. You cannot attach a cut to a plain Osmosis swap. The `affiliate-swap` contract exists precisely to wrap a swap with a fee deduction, which is why it, rather than a raw swap message, is the integrator path.
 
 ## Which path applies
 
 | You are... | Use | Fee is taken... |
 | -- | -- | -- |
-| Building a poolmanager swap yourself (CosmWasm or a bot) and want a cut | `affiliate-swap` contract | From the input token, before the swap |
-| Routing a swap through the Skip entry point (Skip API, inbound IBC) | Skip `affiliates` array | By Skip, per the entry point contract |
+| Building your own swap surface against Osmosis pools (app, bot, backend) | `affiliate-swap` contract | From the input token, before the swap |
+| Already routing swaps through the Skip entry point | Skip `affiliates` array | By Skip, per the entry point contract |
 
 ## The `affiliate-swap` contract
 
@@ -108,9 +110,15 @@ The Osmosis frontend builds exactly this message for IBC-hook swaps and currentl
 
 For the full Skip message shape, venue names, and the operations format, use the [Skip API documentation](https://docs.skip.build/). Osmosis only provides the deployed entry point; the message format is Skip's.
 
-## Embedding the swap tool
+## Disclose the fee in your UI
 
-There is no purpose-built embeddable swap widget with an affiliate parameter today. The swap tool on the Osmosis app does read the trading pair from URL query parameters, which lets you deep-link into a pre-filled swap:
+The `affiliate-swap` contract deducts your fee silently: it does not surface anything to the user, because the swap runs from your own surface. Disclosing the fee is your responsibility. Before the user signs, show the fee amount and that it goes to you, so the quoted output and the fee are both clear. Users should never discover a cut only by comparing the received amount against the market rate.
+
+For quoting, remember the fee is taken from the input before the swap, so quote the swap on the post-fee amount (`input * (1 - fee)`), not the gross input, or your displayed output will be too high.
+
+## Deep-linking the Osmosis app
+
+If instead of building your own surface you just want to hand users off to the Osmosis app with a pair pre-filled, the app reads the trading pair from URL query parameters:
 
 ```
 https://app.osmosis.zone/?from=ATOM&to=OSMO
@@ -119,10 +127,10 @@ https://app.osmosis.zone/?from=ATOM&to=OSMO
 - `from`: the sell asset symbol (defaults to ATOM).
 - `to`: the buy asset symbol (defaults to OSMO).
 
-These set the default pair only. There is no query parameter to attach an affiliate address or fee to a deep link. To earn an affiliate fee you must build the swap yourself using one of the two mechanisms above.
+This sets the default pair only. It swaps on the Osmosis app, not your surface, so no affiliate fee is taken. To earn a fee you build the swap yourself using one of the mechanisms above.
 
 ## Summary
 
-- To take a fee on a swap you build against Osmosis pools directly, call the `affiliate-swap` contract with a `fee_percentage` and `fee_collector`. The fee comes from the input token and is capped (currently 1.5%).
-- To take a fee on a swap routed through the Skip entry point, populate the `affiliates` array in `swap_and_action` with your address and `basis_points_fee`.
-- Deep links can pre-fill the swap pair but cannot carry an affiliate fee.
+- The native poolmanager swap message carries no fee field. To take a cut you build the swap yourself and use one of the two onchain mechanisms below.
+- Building your own swap surface against Osmosis: call the `affiliate-swap` contract with a `fee_percentage` and `fee_collector`. The fee comes from the input token and is capped (currently 1.5%). Disclose it in your UI and quote on the post-fee amount.
+- Already routing through the Skip entry point: populate the `affiliates` array in `swap_and_action` with your address and `basis_points_fee`.

--- a/docs/integrate/affiliate-fee-share.md
+++ b/docs/integrate/affiliate-fee-share.md
@@ -6,10 +6,10 @@ sidebar_position: 8
 
 # Affiliate Fee Share
 
-If you send swap volume to Osmosis from your own app, aggregator, or frontend, you can take an affiliate fee on each swap. There is no Osmosis-native embeddable widget, but there are three supported paths, in increasing order of integration effort:
+If you send swap volume to Osmosis from your own app, aggregator, or frontend, you can take an affiliate fee on each swap. There is no Osmosis-native embeddable widget, but there are three supported paths:
 
-- The **Skip Go Widget**, a drop-in React or Web Component with built-in affiliate fee configuration. The fastest path if you want a ready-made swap surface.
 - The **`affiliate-swap` contract**, the self-contained path if you build your own surface and swap directly against Osmosis pools: send it a token, it takes your fee and swaps the rest.
+- The **Skip Go Widget**, a drop-in React or Web Component with built-in affiliate fee configuration. The fastest path if you want a ready-made swap surface.
 - The **Skip `swap_and_action` affiliates array**, if you build your own surface on Skip API routing.
 
 A note on why a contract is always involved: the native poolmanager swap message (`MsgSwapExactAmountIn` / `MsgSwapExactAmountOut`) has **no** affiliate or fee field. You cannot attach a cut to a plain Osmosis swap, so every affiliate path wraps the swap in a contract that performs the fee deduction.
@@ -18,33 +18,9 @@ A note on why a contract is always involved: the native poolmanager swap message
 
 | You are... | Use | Fee is taken... |
 | -- | -- | -- |
-| Embedding a ready-made swap UI in your app | Skip Go Widget | Per its `chainIdsToAffiliates` config |
 | Building your own surface, swapping Osmosis pools directly | `affiliate-swap` contract | From the input token, before the swap |
+| Embedding a ready-made swap UI in your app | Skip Go Widget | Per its `chainIdsToAffiliates` config |
 | Building your own surface on Skip API routing | Skip `affiliates` array | From `min_asset`, in the output token |
-
-## Drop-in: the Skip Go Widget
-
-The [Skip Go Widget](https://docs.skip.build/go/widget/getting-started) (`@skip-go/widget`) is an embeddable swap component, available as a React component or a Web Component, with affiliate fees as a first-class config option:
-
-```tsx
-import { Widget } from "@skip-go/widget";
-
-<Widget
-  chainIdsToAffiliates={{
-    "osmosis-1": {
-      affiliates: [
-        { basisPointsFee: "50", address: "osmo1youraffiliateaddress..." },
-      ],
-    },
-  }}
-/>;
-```
-
-- `basisPointsFee`: your fee in basis points (`50` is 0.5%).
-- `address`: the fee recipient, which must be valid for that chain.
-- The total `basisPointsFee` must be consistent across every chain you configure.
-
-The widget handles quoting, fee inclusion, and message construction for you. See the [widget configuration reference](https://docs.skip.build/go/widget/configuration) for theming and the full option set. The rest of this page covers the two lower-level paths for integrators building their own surface.
 
 ## The `affiliate-swap` contract
 
@@ -119,6 +95,52 @@ fee_amount    = floor(input_amount * effective_fee / 100)
 swap_amount   = input_amount - fee_amount
 ```
 
+### Disclose the fee in your UI
+
+The `affiliate-swap` contract deducts your fee silently: it does not surface anything to the user, because the swap runs from your own surface. Disclosing the fee is your responsibility. Before the user signs, show the fee amount and that it goes to you, so the quoted output and the fee are both clear. Users should never discover a cut only by comparing the received amount against the market rate. The same applies to fees you configure on the Skip paths.
+
+
+## Deep-linking the Osmosis app
+
+If instead of building your own surface you just want to hand users off to the Osmosis app with a pair pre-filled, the app reads the trading pair from URL query parameters:
+
+```
+https://app.osmosis.zone/?from=ATOM&to=OSMO
+```
+
+- `from`: the sell asset (defaults to ATOM).
+- `to`: the buy asset (defaults to OSMO).
+
+Both accept an asset symbol or a minimal denom. Symbols are ambiguous where multiple bridged variants of an asset exist, so prefer minimal denoms (`uosmo`, or the full `ibc/HASH` for IBC assets) for links you generate programmatically; the symbol form is fine for hand-written links to majors like ATOM and OSMO.
+
+This sets the default pair only. It swaps on the Osmosis app, not your surface, so no affiliate fee is taken. To earn a fee you use one of the mechanisms on this page.
+
+
+## Drop-in: the Skip Go Widget
+
+The [Skip Go Widget](https://docs.skip.build/go/widget/getting-started) (`@skip-go/widget`) is an embeddable swap component, available as a React component or a Web Component, with affiliate fees as a first-class config option:
+
+```tsx
+import { Widget } from "@skip-go/widget";
+
+<Widget
+  chainIdsToAffiliates={{
+    "osmosis-1": {
+      affiliates: [
+        { basisPointsFee: "50", address: "osmo1youraffiliateaddress..." },
+      ],
+    },
+  }}
+/>;
+```
+
+- `basisPointsFee`: your fee in basis points (`50` is 0.5%).
+- `address`: the fee recipient, which must be valid for that chain.
+- The total `basisPointsFee` must be consistent across every chain you configure.
+
+The widget handles quoting, fee inclusion, and message construction for you. See the [widget configuration reference](https://docs.skip.build/go/widget/configuration) for theming and the full option set. If you build your own surface instead, use the `affiliate-swap` contract above or the Skip `affiliates` array below.
+
+
 ## The Skip `affiliates` array
 
 Swaps built with the [Skip API](https://docs.skip.build/) execute through a Skip entry point contract and can carry affiliate fees. Two entry points exist on Osmosis:
@@ -144,7 +166,7 @@ Each affiliate entry is:
 - `basis_points_fee`: your fee in basis points (so `50` is 0.5%).
 - `address`: the address that receives the fee.
 
-In the executed `swap_and_action` message it sits alongside `user_swap`, `min_asset`, and `post_swap_action`. The `timeout_timestamp` is a Unix timestamp in **nanoseconds** and must be in the future; the entry point rejects anything at or before the current block time, so compute it at execution time (for example, now plus a few minutes). The value below is illustrative:
+In the executed `swap_and_action` message it sits alongside `user_swap`, `min_asset`, and `post_swap_action`. The `timeout_timestamp` is a Unix timestamp in **nanoseconds** and must not be earlier than the current block time: the entry point rejects it only once the block time has passed it, so a timestamp equal to the block time is accepted. In practice, compute it at execution time with a buffer (for example, now plus a few minutes). The value below is illustrative:
 
 ```json
 {
@@ -172,22 +194,3 @@ In the executed `swap_and_action` message it sits alongside `user_swap`, `min_as
 ```
 
 For the full message shape and venue names, use the [Skip API documentation](https://docs.skip.build/). The message format is Skip's; Osmosis hosts the deployed entry points.
-
-## Disclose the fee in your UI
-
-The `affiliate-swap` contract deducts your fee silently: it does not surface anything to the user, because the swap runs from your own surface. Disclosing the fee is your responsibility. Before the user signs, show the fee amount and that it goes to you, so the quoted output and the fee are both clear. Users should never discover a cut only by comparing the received amount against the market rate. The same applies to fees you configure on the Skip paths.
-
-## Deep-linking the Osmosis app
-
-If instead of building your own surface you just want to hand users off to the Osmosis app with a pair pre-filled, the app reads the trading pair from URL query parameters:
-
-```
-https://app.osmosis.zone/?from=ATOM&to=OSMO
-```
-
-- `from`: the sell asset (defaults to ATOM).
-- `to`: the buy asset (defaults to OSMO).
-
-Both accept an asset symbol or a minimal denom. Symbols are ambiguous where multiple bridged variants of an asset exist, so prefer minimal denoms (`uosmo`, or the full `ibc/HASH` for IBC assets) for links you generate programmatically; the symbol form is fine for hand-written links to majors like ATOM and OSMO.
-
-This sets the default pair only. It swaps on the Osmosis app, not your surface, so no affiliate fee is taken. To earn a fee you use one of the mechanisms above.


### PR DESCRIPTION
**Preview:** [/integrate/affiliate-fee-share](https://docs-git-johnnywyles-mtn-172-affiliate-fee-share.vercel.dev-osmosis.zone/integrate/affiliate-fee-share)

## What

Adds an integrator guide for taking an affiliate/referral fee on swaps routed to Osmosis ([MTN-172](https://linear.app/osmosis/issue/MTN-172)), at `docs/integrate/affiliate-fee-share.md`.

Three supported paths, in increasing integration effort:

1. **Skip Go Widget** (`@skip-go/widget`, React/Web Component) with `chainIdsToAffiliates` — the drop-in embed. There is no Osmosis-native widget; Skip's is the supported one.
2. **`affiliate-swap` contract** — the self-contained path for integrators building their own surface against Osmosis pools directly.
3. **Skip `affiliates` array** — for integrators building on Skip API routing.

## Verified against deployed code / live chain

- **`affiliate-swap`**: pinned to the intended instance `osmo19n4w08z...c298t` (cap `1.5%`, queried live). Code id 149 alone is ambiguous — instances are live with 0%, 1.5%, and 10% caps (verified across four instances), and a 0%-cap instance pays nothing. Deployed v0.1.0 semantics documented precisely: exact-in only; only `token_out_min_amount.amount` enforced (denom ignored); `fee_collector` validated; negative `fee_percentage` rejected at deserialization, not clamped; above-max requests silently use the instance max.
- **Skip entry points**: the currently published one is `osmo10a3k4...smfsh7u` (code **1241**, verified on-chain); the older code-**833** contract is still live and is what the frontend's IBC-hook memo targets (`affiliates: []`). The guide distinguishes them and notes Skip API users don't pick addresses.
- **Skip fee flow**: the fee must be in the **quote** (`cumulative_affiliate_fee_bps` in the route request, matching affiliates at message generation); the entry point computes it from `min_asset` in the **output** token. Populating the array alone can misquote or fail exact-in swaps.
- **Native swap has no fee field**: `MsgSwapExactAmountIn`/`Out` carry no affiliate field (v31.0.2 proto), which is why every path wraps the swap in a contract.
- **Worked examples are executable**: ATOM → OSMO via pool 1 (pool contents verified live), full ibc denom given; Skip example has a complete operation object and a future nanosecond `timeout_timestamp` (zero is always rejected by the deployed entry point).

## Review history

An initial draft was reviewed and 7 findings (5 P1, 2 P2) were fixed in `4e435a42b`: the false "no embeddable widget" claim, the missing Skip quote step, an impossible pool-1 example, an always-expired timeout, unpinned contract addresses, imprecise deployed-contract semantics, and symbol-vs-denom deep-link guidance.

## Notes

- Builds clean; house style (no em-dashes, "onchain", frontmatter/sidebar conventions). `sidebar_position: 8`, after Fees and Gas.
- UI fee-disclosure guidance included: integrators must show the fee before signing; quote on the post-fee amount for the contract path.

Resolves MTN-172.
