### PR TITLE
docs(build): dev-environment fixes, nav entry, tracker-ID cleanup (MTN-115 4/4)

### DIFF
--- a/docs/build/developer-environment/cli.md
+++ b/docs/build/developer-environment/cli.md
@@ -102,7 +102,7 @@ MYACCOUNT=$(osmosisd keys show testaccount -a --keyring-backend test)
 ```
 
 The command above creates a local key-pair that is not yet registered on the chain. An account is created the first time it receives tokens from another account.
- You can now send some tokens to this enw account. If you are connected to the testnet, you can get tokens from [https://faucet.osmosis.zone](https://faucet.osmosis.zone)
+ You can now send some tokens to this new account. If you are connected to the testnet, you can get tokens from [https://faucet.osmosis.zone](https://faucet.osmosis.zone)
 
 ```bash
 # Check that the testaccount account did receive the tokens.

--- a/docs/build/developer-environment/ide-guide.md
+++ b/docs/build/developer-environment/ide-guide.md
@@ -42,7 +42,7 @@ These are the VSCode extensions that are in daily use by the teams working on Os
 
 ## Vscode configuration
 
-To make your environment run tests automatically every time you save"
+To make your environment run tests automatically every time you save:
 
 Go to: `VSCode -> Preferences -> settings -> Extensions -> Go`
 

--- a/docs/build/developer-environment/index.mdx
+++ b/docs/build/developer-environment/index.mdx
@@ -10,7 +10,7 @@ import DocCardList from '@theme/DocCardList';
 
 Set up the local toolchain you need before building on or against Osmosis. These pages are shared groundwork for chain development, CosmWasm work, and running a node.
 
-**Install osmosisd** covers the binary's minimum specs and installation, and **Interact with the CLI** shows how to query and submit transactions with it. **Build and Test** compiles Osmosis from source, **IDE Setup** configures a Go development environment, and **Local Testing** spins up a containerized LocalOsmosis chain to develop against. **Key Management** covers creating, importing, and using keys, including multisig.
+**Install osmosisd** covers the binary's minimum specs, installation, and building from source, and **Interact with the CLI** shows how to query and submit transactions with it. **IDE Setup** configures a Go development environment, and **Local Testing** spins up a containerized LocalOsmosis chain to develop against. **Key Management** covers creating, importing, and using keys, including multisig.
 
 The same `osmosisd` binary serves both developers and node operators, so node operators in the Validate section are pointed here for installation rather than duplicating it.
 

--- a/docs/build/developer-environment/keys/keys-cli.md
+++ b/docs/build/developer-environment/keys/keys-cli.md
@@ -123,8 +123,8 @@ $ osmosisd keys show Default --bech acc
 $ osmosisd keys show Default --bech val
 - name: Default
   type: local
-  address: osmocncl1zdlttjrqh9jsgk2l8tgn6f0kxlfy98s3prz35z
-  pubkey: osmocnclpub1addwnpepq0ua07k8p3vrv5dap4pl77n4gjyyqsqrndzu0tdrr60ddhfg6ah0ck5ad5l
+  address: osmovaloper1zdlttjrqh9jsgk2l8tgn6f0kxlfy98s3prz35z
+  pubkey: osmovaloperpub1addwnpepq0ua07k8p3vrv5dap4pl77n4gjyyqsqrndzu0tdrr60ddhfg6ah0ck5ad5l
   mnemonic: ""
   threshold: 0
   pubkeys: []
@@ -139,8 +139,8 @@ $ osmosisd keys show Default --bech val
 $ osmosisd keys show Default --bech cons
 - name: Default
   type: local
-  address: osmocnclcons1zdlttjrqh9jsgk2l8tgn6f0kxlfy98s34pfmlc
-  pubkey: osmocnclconspub1addwnpepq0ua07k8p3vrv5dap4pl77n4gjyyqsqrndzu0tdrr60ddhfg6ah0ch6kdrc
+  address: osmovalcons1zdlttjrqh9jsgk2l8tgn6f0kxlfy98s34pfmlc
+  pubkey: osmovalconspub1addwnpepq0ua07k8p3vrv5dap4pl77n4gjyyqsqrndzu0tdrr60ddhfg6ah0ch6kdrc
   mnemonic: ""
   threshold: 0
   pubkeys: []

--- a/docs/build/developer-environment/keys/multisig.md
+++ b/docs/build/developer-environment/keys/multisig.md
@@ -75,16 +75,16 @@ osmosisd tx bank send \
     --chain-id=osmosis-1 \
     --gas=auto \
     --fees=1000000uosmo \
-    --broadcast-mode=block
+    --broadcast-mode=sync
 ```
 
 ### Step 2: Create the multisig transaction
 
-We want to send 5 OSMO from our multisig account to `osmo1rgjxswhuxhcrhmyxlval0qa70vxwvqn2e0srft`.
+We want to send 5 OSMO from our multisig account `osmo1e0fx0q9meawrcq7fmma9x60gk35lpr4xk3884m` to `osmo157g6rn6t6k5rl0dl57zha2wx72t633axqyvvwq`.
 
 ```bash
 osmosisd tx bank send \
-    osmo1rgjxswhuxhcrhmyxlval0qa70vxwvqn2e0srft \
+    osmo1e0fx0q9meawrcq7fmma9x60gk35lpr4xk3884m \
     osmo157g6rn6t6k5rl0dl57zha2wx72t633axqyvvwq \
     5000000uosmo \
     --gas=200000 \
@@ -101,12 +101,12 @@ The file `unsignedTx.json` contains the unsigned transaction encoded in JSON.
     "messages": [
       {
         "@type": "/cosmos.bank.v1beta1.MsgSend",
-        "from_address": "osmo1rgjxswhuxhcrhmyxlval0qa70vxwvqn2e0srft",
+        "from_address": "osmo1e0fx0q9meawrcq7fmma9x60gk35lpr4xk3884m",
         "to_address": "osmo157g6rn6t6k5rl0dl57zha2wx72t633axqyvvwq",
         "amount": [
           {
             "denom": "uosmo",
-            "amount": "5000000000000000000"
+            "amount": "5000000"
           }
         ]
       }
@@ -177,12 +177,12 @@ The TX is now signed:
     "messages": [
       {
         "@type": "/cosmos.bank.v1beta1.MsgSend",
-        "from_address": "osmo1rgjxswhuxhcrhmyxlval0qa70vxwvqn2e0srft",
+        "from_address": "osmo1e0fx0q9meawrcq7fmma9x60gk35lpr4xk3884m",
         "to_address": "osmo157g6rn6t6k5rl0dl57zha2wx72t633axqyvvwq",
         "amount": [
           {
             "denom": "uosmo",
-            "amount": "5000000000000000000"
+            "amount": "5000000"
           }
         ]
       }
@@ -259,5 +259,5 @@ The TX is now signed:
 ```sh
 osmosisd tx broadcast signedTx.json \
     --chain-id=osmosis-1 \
-    --broadcast-mode=block
+    --broadcast-mode=sync
 ```

--- a/docs/build/developer-environment/osmosisd.md
+++ b/docs/build/developer-environment/osmosisd.md
@@ -68,7 +68,7 @@ After installed, open new terminal to properly load go
 
 ## Install Osmosis Binary
 
-Clone the osmosis repo and check out the current mainnet release tag (replace `v31.0.0` below with the latest tag from the [Osmosis releases](https://github.com/osmosis-labs/osmosis/releases) page):
+Clone the osmosis repo and check out the current mainnet release tag (replace `v31.0.3` below with the latest tag from the [Osmosis releases](https://github.com/osmosis-labs/osmosis/releases) page):
 
 
 ```bash

--- a/docs/build/index.mdx
+++ b/docs/build/index.mdx
@@ -7,11 +7,12 @@ import DocCardList from '@theme/DocCardList';
 
 # Build on Osmosis
 
-This section is for developers building on or extending Osmosis. It splits three ways by what you are building:
+This section is for developers building on or extending Osmosis. It splits four ways by what you are building:
 
-- **Chain Development** : the Osmosis chain itself. Set up a dev environment, build from source, run a local testnet, and read the specifications for every `x/` module (GAMM, concentrated liquidity, pool manager, gov, mint, superfluid, TWAP, and more).
-- **CosmWasm** : smart contracts on Osmosis. Scaffolding with Beaker, deployment and verification, local and testnet workflows, and interacting with contracts from JavaScript.
-- **Frontend** : the TypeScript and JavaScript SDKs for composing and broadcasting Osmosis transactions, including OsmoJS, Telescope, and CosmosKit.
+- **Developer Environment** : the toolchain. Install `osmosisd`, build from source, manage keys, and spin up a local testnet to develop against. Start here.
+- **Chain Development** : the Osmosis chain itself. Read the specifications for every `x/` module (GAMM, concentrated liquidity, pool manager, gov, mint, superfluid, TWAP, and more).
+- **CosmWasm** : smart contracts on Osmosis. Scaffolding with cw-orchestrator, deployment and verification, local and testnet workflows, and interacting with contracts from JavaScript.
+- **Frontend & SDKs** : the TypeScript and JavaScript SDKs for composing and broadcasting Osmosis transactions, including OsmoJS, Telescope, and CosmosKit.
 
 Pick the path that matches what you are building. If you are integrating an existing application against Osmosis rather than extending the protocol, see Integrate instead.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -69,7 +69,7 @@ const mathRemark = [remarkMath, { singleDollarTextMath: false }];
 // Single docs instance rooted at `docs/`, served at the site root so existing
 // URLs are preserved (docs/osmosis-core/... -> /osmosis-core/...). One sidebar
 // follows the reader across all sections (the fix for the former per-section
-// isolated sidebars). MTN-88 Phase 1: collapse only; the folder->taxonomy
+// isolated sidebars). This is the collapse-only step; the folder->taxonomy
 // reorganization and redirects come in a later phase.
 const docsPlugin = [
   '@docusaurus/plugin-content-docs',
@@ -86,7 +86,7 @@ const docsPlugin = [
   }),
 ];
 
-// In-repo backstop for the URL changes from the IA restructure (MTN-88).
+// In-repo backstop for the URL changes from the IA restructure.
 // Vercel serves the canonical 301s (vercel.json `redirects`), but this client
 // redirect keeps old paths resolving on local/preview builds where Vercel rules
 // do not apply. The full old->new map is generated from the page move plan.
@@ -193,6 +193,7 @@ const config = {
             label: 'Build',
             position: 'left',
             items: [
+              { label: 'Developer Environment', to: 'build/developer-environment' },
               { label: 'Chain Development', to: 'build/chain' },
               { label: 'CosmWasm', to: 'build/cosmwasm' },
               { label: 'Frontend & SDKs', to: 'build/frontend' },
@@ -309,7 +310,7 @@ const config = {
         appId: 'F26GLV8TNU',
         apiKey: ALGOLIA_SEARCH_KEY,
         indexName: 'Docs',
-        // Kept off through the MTN-88 single-instance migration: the new index
+        // Kept off through the single-instance migration: the new index
         // has faceting configured, but page `docusaurus_tag` values will flip
         // from per-section to `docs-default-current` on that merge and lag the
         // index by one crawl. Re-enable once the structure has settled.

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -938,7 +938,7 @@ img[src$='#terminal'] {
 }
 
 /* Force the mobile-style hamburger navbar earlier than Docusaurus's
-   default 996px breakpoint. After the IA restructure (MTN-88) the navbar
+   default 996px breakpoint. After the IA restructure the navbar
    has only 5 short left items (Learn, Integrate, Build, Validate,
    Community) plus the right-side icons, search, and Launch Dex, so it
    fits much further down than the old 8-item bar did. The early-hamburger


### PR DESCRIPTION
Part **4 of 4** splitting the Build section accuracy pass ([MTN-115](https://linear.app/osmosis/issue/MTN-115)) for review. Previously one 48-file PR (#339); split by section so each is reviewable on its own.

The other three: chain module specs, CosmWasm, Frontend & SDKs. They are independent and can land in any order, but this one is the smallest and touches the nav, so it is a sensible first.

## Changes

- **keys**: `osmovaloper` / `osmovalcons` prefixes corrected; multisig example amount fixed from 18 to 6 decimals, and its sender corrected.
- **dev-environment index**: removed a phantom "Build and Test" card so the prose matches the card list.
- **osmosisd / cli / ide-guide**: minor accuracy fixes.
- **docusaurus.config.js**: adds Developer Environment to the Build navbar dropdown, and drops tracker IDs from comments per house convention.
- **build/index.mdx**: describes the section four ways rather than three, now that Developer Environment is surfaced. Also updates the CosmWasm blurb to cw-orchestrator and renames Frontend to Frontend & SDKs, matching the other two PRs in this set.
- **custom.css**: single-column card tweak.

Build passes.
