### PR TITLE
docs(build): re-lead CosmWasm on cw-orchestrator, add a Quickstart (MTN-115 2/4)

### DIFF
--- a/docs/build/cosmwasm/beaker/README.md
+++ b/docs/build/cosmwasm/beaker/README.md
@@ -4,19 +4,14 @@ description: Scaffold, deploy, and interact with contracts using Beaker.
 
 # Beaker
 
+:::warning Beaker is no longer actively maintained
+Beaker's last release was v0.1.8 (November 2023). For new contracts, use [cw-orchestrator](/build/cosmwasm/cw-orch) with the [Quickstart](/build/cosmwasm/quickstart). These pages remain as a reference for projects already built on Beaker.
+:::
+
 <p align="center">
-<a href="https://docs.osmosis.zone/cosmwasm/">
+<a href="/build/cosmwasm">
     <img src="/icons/beaker.svg" alt="Beaker logo" title="Beaker" width="150" align="center" height="150" />
 </a>
-</p>
-
-<p align="center" width="100%">
-    <img  height="20" src="https://github.com/osmosis-labs/beaker/actions/workflows/doctest.yml/badge.svg"/>
-    <img height="20" src="https://github.com/osmosis-labs/beaker/actions/workflows/lint.yml/badge.svg"/>
-    <a href="https://github.com/osmosis-labs/beaker/blob/main/LICENSE-APACHE"><img height="20" src="https://img.shields.io/badge/license-APACHE-blue.svg"/></a>
-    <a href="https://github.com/osmosis-labs/beaker/blob/main/LICENSE-MIT"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
-    <a href="https://deps.rs/repo/github/osmosis-labs/beaker"><img height="20" src="https://deps.rs/repo/github/osmosis-labs/beaker/status.svg"/></a>
-    <a href="https://crates.io/crates/beaker"><img height="20" src="https://img.shields.io/crates/v/beaker.svg"/></a>
 </p>
 
 [Beaker](https://github.com/osmosis-labs/beaker) makes it easy to scaffold a new cosmwasm app, with all of the dependencies for osmosis hooked up, interactive console, and a sample front-end at the ready.
@@ -161,7 +156,7 @@ template_repo = "https://github.com/osmosis-labs/cw-tpl-osmosis.git"
 
 ### Deploy contract on LocalOsmosis
 
-LocalOsmosis, as its name suggest, is Osmosis for local development. In the upcoming release, Beaker will have more complete integration with LocalOsmosis, it has to be installed and run separately.
+LocalOsmosis, as its name suggests, is Osmosis for local development. It has to be installed and run separately.
 
 You can install from source by following the instruction at [osmosis-labs/LocalOsmosis](https://github.com/osmosis-labs/LocalOsmosis), or use the official installer and select option 3:
 
@@ -229,10 +224,10 @@ To create the contract entrypoint for migration, first, define `MigrateMsg` in `
 pub struct MigrateMsg {}
 ```
 
-With MigrateMsg defined we need to update `contract.rs`. First update the import from `create::msg` to include `MigrateMsg`:
+With MigrateMsg defined we need to update `contract.rs`. First update the import from `crate::msg` to include `MigrateMsg`:
 
 ```rust
-use create::msg::{CountResponse, ExecuteMsg, InstantiateMsg, QueryMsg, MigrateMsg};
+use crate::msg::{CountResponse, ExecuteMsg, InstantiateMsg, QueryMsg, MigrateMsg};
 ```
 
 ```rust
@@ -346,8 +341,8 @@ await contract.counter.query({ get_count: {} });
 
 You can find available methods for the aforementioned instances here:
 
-- [Account](console/classes//Account.md#methods-1)
-- [Contract](./console/classes//Contract.md#methods-1)
+- [Account](./console/classes/Account.md#methods-1)
+- [Contract](./console/classes/Contract.md#methods-1)
 
 You can remove `contract` and/or `account` namespace by changing config.
 
@@ -366,7 +361,7 @@ await counter.query({ get_count: {} });
 
 
 
-With the Typescript SDK which was previously mentioned, it is used to extend the `Contract` instance with method generated ftom execute and query messages. For example:
+With the Typescript SDK which was previously mentioned, it is used to extend the `Contract` instance with methods generated from execute and query messages. For example:
 
 ```js
 await counter.getCount()
@@ -379,13 +374,13 @@ await sc.getCount()
 
 With this, it's more convenient than the previous interaction method since you can use tab completion for the methods as well.
 
-Beaker console is also allowed to deploy contract, so that you don't another terminal tab to do so.
+Beaker console is also allowed to deploy contracts, so that you don't need another terminal tab to do so.
 
 ```js
 .deploy counter -- --signer-account test1 --raw '{ "count": 999 }'
 ```
 
-`.build`, `.storeCode`, `.instantiate` commands are also available and has the same options as Beaker cli command, except that `--no-wasm-opt` are in by default since it is being intended to use in the development phase.
+`.build`, `.storeCode`, `.instantiate` commands are also available and have the same options as the Beaker CLI commands, except that `--no-wasm-opt` is on by default since it is intended for use in the development phase.
 
 `.help` to see all available commands.
 

--- a/docs/build/cosmwasm/beaker/commands/README.md
+++ b/docs/build/cosmwasm/beaker/commands/README.md
@@ -4,7 +4,7 @@
 
 CosmWasm development tooling
 
-Version: 0.0.6
+Version: 0.1.8 (last release, November 2023)
 
 Arguments:
 

--- a/docs/build/cosmwasm/beaker/commands/beaker_wasm.md
+++ b/docs/build/cosmwasm/beaker/commands/beaker_wasm.md
@@ -88,13 +88,13 @@ Arguments:
 
 * ` <contract-name>`Name of the contract to store
 
-* `--schema-gen-cmd <schema-gen-cmd>`: Sschema generation command, default: `cargo run -p {contract_name} --example schema`
+* `--schema-gen-cmd <schema-gen-cmd>`: Schema generation command, default: `cargo run -p {contract_name} --example schema`
 
 * `--schema-dir <schema-dir>`: Directory of input schema for ts generation
 
 * `--out-dir <out-dir>`: Code output directory, ignore remaining ts build process if custom out_dir is specified
 
-* `--node-package-manager <node-package-manager>`: Code output directory (default: `yarn`)
+* `--node-package-manager <node-package-manager>`: Node package manager to use (default: `yarn`)
 
 ---
 
@@ -166,7 +166,7 @@ Arguments:
 
 ### `beaker wasm instantiate`
 
-Instanitate .wasm stored on chain
+Instantiate .wasm stored on chain
 
 Arguments:
 
@@ -208,7 +208,7 @@ Arguments:
 
 ### `beaker wasm migrate`
 
-Migrated instanitate contract to use other code stored on chain
+Migrate an instantiated contract to use other code stored on chain
 
 Arguments:
 

--- a/docs/build/cosmwasm/cosmwasm-beaker.md
+++ b/docs/build/cosmwasm/cosmwasm-beaker.md
@@ -98,7 +98,7 @@ deposit: 500000000uosmo
 code:
     repo:   https://github.com/osmosis-labs/beaker/
     rust_flags: -C link-arg=-s
-    roptimizer: workspace-optimizer:0.12.6
+    optimizer: workspace-optimizer:0.12.6
 ```
 
 ```sh
@@ -166,12 +166,12 @@ Great! Your proposal should have passed now!
 
 ### Signers
 
-In the examples above we used the test1 account to sign transactions. However, Bekaer supports 3 options for signing transactions as shown on the official [README](https://github.com/osmosis-labs/beaker#Signers).
+In the examples above we used the test1 account to sign transactions. However, Beaker supports 3 options for signing transactions as shown on the official [README](https://github.com/osmosis-labs/beaker#Signers).
 
-- `--signer-account` input of this option refer to the accounts defined in the [config file](./beaker/config/global), which is not encrypted, so it should be used only for testing
+- `--signer-account` input of this option refer to the accounts defined in the [config file](./beaker/config/global.md), which is not encrypted, so it should be used only for testing
 - `--signer-mnemonic` input of this option is the raw mnemonic string to construct a signer
 - `--signer-private-key` input of this option is the same as `--signer-mnemonic` except it expects base64 encoded private key
-- `--signer-keyring` use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker/commands/beaker_key).
+- `--signer-keyring` use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker/commands/beaker_key.md).
 
 ### Using the OS keyring
 Let's dive a little deeper on how to use the OS keyring in order to sign a transaction with your OS keyring. 

--- a/docs/build/cosmwasm/cosmwasm-deployment.md
+++ b/docs/build/cosmwasm/cosmwasm-deployment.md
@@ -23,7 +23,7 @@ The following is a quick guide that shows the basics of deploying a contract to 
 - Contract explorer
 
 :::tip
-Please note this is a detailed guide on how to deploy via `osmosisd`, it also covers additional tooling and useful tips.  You can also deploy to testnet with [Beaker](./cosmwasm-beaker.md) with a couple of commands. 
+This is a detailed guide on how to deploy via `osmosisd`, covering additional tooling and useful tips. For the recommended scripted workflow, see [cw-orchestrator](/build/cosmwasm/cw-orch) and the [Quickstart](/build/cosmwasm/quickstart).
 :::
 
 
@@ -43,7 +43,7 @@ Then run the following commands:
 # 1. Set 'stable' as the default release channel:
 rustup default stable
 cargo version
-# If this is lower than 1.50.0+, update
+# Update to a recent stable toolchain (CosmWasm and the optimizer track current Rust)
 rustup update stable
 
 # 2. Add WASM as the compilation target:
@@ -64,7 +64,7 @@ Run the following and choose option #2 (Client Node) and #2 (Testnet) in order.
 ```bash
 curl -sL https://get.osmosis.zone/install > i.py && python3 i.py
 ```
-Now you have successfully completed setting up an Osmosis client node in Testnet. In order to use `osmosisd` from the cli, either reload your terminal or refresh your profile with : `‘source ~/.profile’`
+Now you have successfully completed setting up an Osmosis client node in Testnet. In order to use `osmosisd` from the cli, either reload your terminal or refresh your profile with `source ~/.profile`
 
 ### Setup the Client
 
@@ -147,7 +147,7 @@ cargo wasm
     wasm = "build --release --target wasm32-unknown-unknown"
     ```
     
-    So when we run the `cargo wasm` command, the `cargo build --release —-target wasm32-unknown-unknown` command is executed according to the option in the config file above.
+    So when we run the `cargo wasm` command, the `cargo build --release --target wasm32-unknown-unknown` command is executed according to the option in the config file above.
     
 
 After this compiles, it should produce a file in `target/wasm32-unknown-unknown/release/cw_tpl_osmosis.wasm`.  If you check the size of the file by using the `ls -lh` command, it shows around `1.8M`. This is a release build, but not stripped of all unneeded code. To produce a much smaller version, you can run this which tells the compiler to strip all unused code out:
@@ -194,7 +194,7 @@ RES=$(osmosisd query tx "$TXHASH" --output json)
 - `--gas-adjustment` : adjustment factor to be multiplied against the estimate returned by the tx simulation.
 - `-y` : to skip tx broadcasting prompt confirmation.
 - `--output` : output format.
-- `-b sync` : broadcast the transaction synchronously and return immediately with the txhash. The `block` mode used in older Cosmos SDK versions is no longer supported — query the tx by hash after the next block to fetch the result.
+- `-b sync` : broadcast the transaction synchronously and return immediately with the txhash. The `block` mode used in older Cosmos SDK versions is no longer supported, so query the tx by hash after the next block to fetch the result.
 
 ![](https://user-images.githubusercontent.com/70956926/172293654-7beba11b-ce5f-4979-94e2-19156c6e5b27.png)
 
@@ -216,7 +216,7 @@ Run the following command to set the `CODE_ID` as a variable:
 
 ```bash
 # get CODE_ID
-CODE_ID=$(echo $RES | jq -r '.logs[0].events[-1].attributes[0].value')
+CODE_ID=$(echo $RES | jq -r '.events[] | select(.type=="store_code") | .attributes[] | select(.key=="code_id") | .value')
 echo $CODE_ID
 ```
 

--- a/docs/build/cosmwasm/cosmwasm-verify-contract.md
+++ b/docs/build/cosmwasm/cosmwasm-verify-contract.md
@@ -9,7 +9,7 @@ The following are the steps needed to verify any contract from the chain. In thi
 
 
 ### Create new contract
-Follow [this guide](./cosmwasm-beaker) to create a new contract with Beaker.
+Follow the [Quickstart](/build/cosmwasm/quickstart) to scaffold and deploy a contract.
 
 Output:
 

--- a/docs/build/cosmwasm/cw-orch.md
+++ b/docs/build/cosmwasm/cw-orch.md
@@ -7,21 +7,21 @@ sidebar_position: 8
 
 ## Introduction
 
-cw-orchestrator is the most advanced scripting, testing, and deployment framework for CosmWasm smart-contracts. It makes it easy to write cross-environment compatible code for [cw-multi-test](https://github.com/CosmWasm/cw-multi-test), [Osmosis Test Tube](https://github.com/osmosis-labs/test-tube), [Starship](https://github.com/cosmology-tech/starship) (alpha), and **live networks**, significantly reducing code duplication and test-writing time. 
+cw-orchestrator is the most advanced scripting, testing, and deployment framework for CosmWasm smart-contracts. It makes it easy to write cross-environment compatible code for [cw-multi-test](https://github.com/CosmWasm/cw-multi-test), [Osmosis Test Tube](https://github.com/osmosis-labs/test-tube), [Starship](https://github.com/hyperweb-io/starship) (alpha), and **live networks**, significantly reducing code duplication and test-writing time. 
 
 
 Get ready to change the way you interact with contracts and simplify your smart-contracts journey. The following steps will allow you to integrate `cw-orch` and write clean code such as:
 
 ```rust
 counter.upload()?;
-counter.instantiate(&InstantiateMsg { count: 0 }, None, None)?;
+counter.instantiate(&InstantiateMsg { count: 0 }, None, &[])?;
 counter.increment()?;
 
 let count = counter.get_count()?;
 assert_eq!(count.count, 1);
 ```
 
-In this quick-start guide, we will review the necessary steps in order to integrate [`cw-orch`](https://github.com/AbstractSDK/cw-orchestrator) into a simple contract create. [We review integration of rust-workspaces (multiple contracts) at the end of this page](#integration-in-a-workspace).
+In this quick-start guide, we will review the necessary steps in order to integrate [`cw-orch`](https://github.com/AbstractSDK/cw-orchestrator) into a simple contract crate. [We review integration of rust-workspaces (multiple contracts) at the end of this page](#integration-in-a-workspace).
 
 > **NOTE**: *Quicker than the quick start*
 >
@@ -41,7 +41,7 @@ In this quick-start guide, we will review the necessary steps in order to integr
   - [Using the integration](#using-the-integration)
 - [Integration in a workspace](#integration-in-a-workspace)
   - [Handling dependencies and features](#handling-dependencies-and-features)
-  - [Creating an interface create](#creating-an-interface-create)
+  - [Creating an interface crate](#creating-an-interface-crate)
   - [Integrating single contracts](#integrating-single-contracts)
 - [More examples and scripts](#more-examples-and-scripts)
 
@@ -94,7 +94,7 @@ Then, inside that `interface.rs` file, you can define the interface for your con
 ```rust
 use cw_orch::{interface, prelude::*};
 
-use create::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 
 pub const CONTRACT_ID: &str = "counter_contract";
 
@@ -112,11 +112,11 @@ impl<Chain: CwEnv> Uploadable for CounterContract<Chain> {
     fn wrapper(&self) -> Box<dyn MockContract<Empty>> {
         Box::new(
             ContractWrapper::new_with_empty(
-                create::contract::execute,
-                create::contract::instantiate,
-                create::contract::query,
+                crate::contract::execute,
+                crate::contract::instantiate,
+                crate::contract::query,
             )
-            .with_migrate(create::contract::migrate),
+            .with_migrate(crate::contract::migrate),
         )
     }
 }
@@ -129,7 +129,7 @@ Learn more about the content of the interface creation specifics in the [`cw-orc
 >
 >    ```rust
 >    #[cfg(feature = "interface")]
->    pub use create::interface::CounterContract;
+>    pub use crate::interface::CounterContract;
 >    ```
 
 ### Interaction helpers
@@ -177,14 +177,14 @@ Find out more about the interaction helpers in the [`cw-orch` documentation](htt
 >
 >    ```rust
 >    #[cfg(feature = "interface")]
->    pub use create::msg::{ExecuteMsgFns as CounterExecuteMsgFns, QueryMsgFns as CounterQueryMsgFns};
+>    pub use crate::msg::{ExecuteMsgFns as CounterExecuteMsgFns, QueryMsgFns as CounterQueryMsgFns};
 >    ```
 
 ### Using the integration
 
 Now that all the setup is done, you can use your contract in tests, integration-tests or scripts.
 
-Start by importing your create, with the `interface` feature enabled. Depending on your use-case this will be in `[dependencies]` or `[dev-dependencies]`:
+Start by importing your crate, with the `interface` feature enabled. Depending on your use-case this will be in `[dependencies]` or `[dev-dependencies]`:
 
 ```toml
 counter-contract = { path = "../counter-contract", features = ["interface"] }
@@ -206,7 +206,7 @@ pub fn main() -> anyhow::Result<()> {
     pretty_env_logger::init(); // Used to log contract and chain interactions
 
     let rt = Runtime::new()?;
-    let network = networks::LOCAL_JUNO;
+    let network = networks::LOCAL_OSMO;
     let chain = DaemonBuilder::default()
         .handle(rt.handle())
         .chain(network)
@@ -216,7 +216,7 @@ pub fn main() -> anyhow::Result<()> {
     let counter = CounterContract::new(chain);
 
     counter.upload()?;
-    counter.instantiate(&InstantiateMsg { count: 0 }, None, None)?;
+    counter.instantiate(&InstantiateMsg { count: 0 }, None, &[])?;
 
     counter.increment()?;
 
@@ -245,9 +245,9 @@ Refer above to [Adding `cw-orch` to your `Cargo.toml` file](#adding-cw-orch-to-y
 
 For instance, for the `cw20_base` contract, you need to execute those 2 steps on the `cw20-base` contract (where the `QueryMsg` are defined) as well as on the `cw20` package (where the `ExecuteMsg` are defined).
 
-### Creating an interface create
+### Creating an interface crate
 
-When using a workspace, we advise you to create a new create inside your workspace for defining your contract's interfaces. In order to do that, use:
+When using a workspace, we advise you to create a new crate inside your workspace for defining your contract's interfaces. In order to do that, use:
 
 ```shell
 cargo new interface --lib
@@ -261,7 +261,7 @@ Add the interface package to your workspace `Cargo.toml` file
 members = ["packages/*", "contracts/*", "interface"]
 ```
 
-Inside this `interface` create, we advise to integrate all your contracts 1 by 1 in separate files. Here is the structure of the `cw-plus` integration for reference:
+Inside this `interface` crate, we advise to integrate all your contracts 1 by 1 in separate files. Here is the structure of the `cw-plus` integration for reference:
 
 ```path
 interface (interface collection)

--- a/docs/build/cosmwasm/index.mdx
+++ b/docs/build/cosmwasm/index.mdx
@@ -9,7 +9,7 @@ import DocCardList from '@theme/DocCardList';
 
 CosmWasm lets you write smart contracts in Rust and run them on Osmosis. This section covers the full contract lifecycle: scaffolding a project, building and testing, deploying to a local or test network, verifying a deployed contract, and calling contracts from your application.
 
-**Beaker** is the recommended starting point, a scaffolding tool that wires up contract dependencies, an interactive console, and a sample frontend. From there, **CosmWasm & LocalOsmosis** covers developing against a local chain, and the **testnet deployment** and **CosmWasm & Beaker** guides walk through deploying to a public testnet, with **Submit a CosmWasm Governance Proposal** for the gov-gated store step. **Verifying Smart Contracts** covers reproducible builds, **cw-orchestrator** handles scripting and testing across environments, and the **JavaScript** guide shows how to call deployed contracts from a JavaScript runtime.
+The **Quickstart** is the recommended starting point: it scaffolds a contract with the official CosmWasm template and uses **cw-orchestrator** to build, deploy, and test across environments. From there, **CosmWasm & LocalOsmosis** covers developing against a local chain, and the **testnet deployment** guide walks through deploying to a public testnet, with **Submit a CosmWasm Governance Proposal** for the gov-gated store step. **Verifying Smart Contracts** covers reproducible builds, and the **JavaScript** guide shows how to call deployed contracts from a JavaScript runtime. The **CosmWasm & Beaker** pages remain for projects already using Beaker, which is no longer actively maintained.
 
 If you are building UIs or SDK integrations rather than contracts, see Frontend.
 

--- a/docs/build/cosmwasm/javascript.md
+++ b/docs/build/cosmwasm/javascript.md
@@ -27,14 +27,12 @@ npm i cosmwasm
 
 Open the package.json file in a code editor and add
 
-```json=
-"type": "module",.
-
-  {
-        // ...
-        "type": "module",
-        // ...
-    }
+```json
+{
+  // ...
+  "type": "module"
+  // ...
+}
 ```
 
 Create a new index.ts file
@@ -45,7 +43,7 @@ touch index.ts
 
 The class CosmWasmClient is exported from the CosmJS package @cosmjs/cosmwasm-stargate. Learn more in the [official docs](https://cosmwasm.github.io/CosmWasmJS/clients/reading/CosmWasmClient.html).
 
-```javascript=
+```javascript
 import { CosmWasmClient } from "cosmwasm";
 
 // This is your rpc endpoint
@@ -59,14 +57,14 @@ async function main() {
 main();
 ```
 
-:: tip
-You can also connect to the mainnet by replacing rpcEndpoint to https://rpc.osmosis.zone/
-::
+:::tip
+You can also connect to the mainnet by replacing rpcEndpoint with https://rpc.osmosis.zone/
+:::
 
 ## Run it
 
 ```
-npm index.js
+node index.js
 ```
 
 You should see something like:
@@ -76,7 +74,7 @@ You should see something like:
 
 As documented on the [official docs](https://cosmwasm.github.io/CosmWasmJS/clients/reading/CosmWasmClient.html#available-methods).
 
-```javascript=
+```javascript
 async function moreExamples() {
   const client = await CosmWasmClient.connect(rpcEndpoint);
   const chainId = await client.getChainId()
@@ -173,7 +171,7 @@ node index.js
 ```
 
 The output should look like this:
-![](contract_details.png)
+![](./contract_details.png)
 
 ## Get the count from the contract
 

--- a/docs/build/cosmwasm/localosmosis.md
+++ b/docs/build/cosmwasm/localosmosis.md
@@ -6,11 +6,11 @@ sidebar_position: 3
 
 # CosmWasm & LocalOsmosis 
 
-:::tip  
-You can now deploy contracts to LocalOsmosis with [Beaker](https://github.com/osmosis-labs/beaker). The official tooling to deploy Osmosis Smartcontracts.
+:::tip
+For new contracts, the recommended workflow is [cw-orchestrator](/build/cosmwasm/cw-orch) with the [Quickstart](/build/cosmwasm/quickstart). This page shows the underlying manual steps, which use Beaker (no longer actively maintained) and `osmosisd` directly.
 :::
 
-The following is detailed guide that shows the basics of manually deploying a contract to a Osmosis local environment. It covers: 
+The following is a detailed guide that shows the basics of manually deploying a contract to an Osmosis local environment. It covers: 
 
 - Initial Setup
     - Rust
@@ -75,7 +75,7 @@ Install the following packages to generate the contract:
 
 ```bash
 cargo install cargo-generate --features vendored-openssl
-cargo install cargo-run-scrip
+cargo install cargo-run-script
 ```
 
 #### Beaker
@@ -148,7 +148,7 @@ This produces a file about 149kB. We will do further optimisation below.
 
 ### Optimized Compilation
 
-To reduce gas costs, the binary size should be as small as possible. This will result in a less costly deployment, and lower fees on every interaction. Luckily, there is tooling to help with this. You can optimize production code using rust-optimizer. rust-optimizer produces reproducible builds of CosmWasm smart contracts. This means third parties can verify the contract is actually the claimed code.
+To reduce gas costs, the binary size should be as small as possible. This will result in a less costly deployment, and lower fees on every interaction. Luckily, there is tooling to help with this. You can optimize production code using the CosmWasm optimizer (`cosmwasm/optimizer`), which produces reproducible builds of CosmWasm smart contracts. This means third parties can verify the contract is actually the claimed code.
 
 
 ```
@@ -159,7 +159,7 @@ sudo docker run --rm -v "$(pwd)":/code \
  
 ```
 
-Binary will be at artifacts/osmosis_cw_tpl.wasm folder and its size will be 138k
+Binary will be at artifacts/cw_tpl_osmosis.wasm and its size will be 138k
 
 ### Created a local key 
 Create a key using one of the seeds provided in localOsmosis. 
@@ -179,7 +179,7 @@ You can deploy the contract to localOsmosis or a testnet.  In this example we wi
 
 ```
 cd artifacts
-osmosisd tx wasm store cw_tpl_osmosis.wasm  --from <unsafe-test-key-name> --chain-id=<chain-id> --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b block -y
+osmosisd tx wasm store cw_tpl_osmosis.wasm  --from <unsafe-test-key-name> --chain-id=<chain-id> --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b sync -y
 ```
 
 `<unsafe-test-key-name>` = Name of your local key.
@@ -193,8 +193,8 @@ Save the CODE_ID from the output of the command above as a local variable `CODE_
 Instead of looking for the code_id the command above, you can also run the following command to set the CODE_ID as a variable.
     
 ```
-TX=$(osmosisd tx wasm store cw_tpl_osmosis.wasm  --from <unsafe-test-key-name> --chain-id=<chain-id> --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b block --output json -y | jq -r '.txhash')
-CODE_ID=$(osmosisd query tx $TX --output json | jq -r '.logs[0].events[-1].attributes[0].value')
+TX=$(osmosisd tx wasm store cw_tpl_osmosis.wasm  --from <unsafe-test-key-name> --chain-id=<chain-id> --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b sync --output json -y | jq -r '.txhash')
+CODE_ID=$(osmosisd query tx $TX --output json | jq -r '.events[] | select(.type=="store_code") | .attributes[] | select(.key=="code_id") | .value')
 echo "Your contract code_id is $CODE_ID"
 ```
 
@@ -205,13 +205,13 @@ If this is a brand new localOsmosis instance it should be `1`
  
 ```
 INITIAL_STATE='{"count":100}'
-osmosisd tx wasm instantiate $CODE_ID $INITIAL_STATE --amount 50000uosmo  --label "Counter Contract" --from <unsafe-test-key-name> --chain-id <chain-id> --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b block -y --no-admin
+osmosisd tx wasm instantiate $CODE_ID $INITIAL_STATE --amount 50000uosmo  --label "Counter Contract" --from <unsafe-test-key-name> --chain-id <chain-id> --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b sync -y --no-admin
 ```
 
 Example
 ```
 INITIAL_STATE='{"count":100}'
-osmosisd tx wasm instantiate $CODE_ID $INITIAL_STATE --amount 50000uosmo  --label "Counter Contract" --from c1 --chain-id localosmosis --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b block -y --no-admin
+osmosisd tx wasm instantiate $CODE_ID $INITIAL_STATE --amount 50000uosmo  --label "Counter Contract" --from c1 --chain-id localosmosis --gas-prices 0.05uosmo --gas auto --gas-adjustment 1.3 -b sync -y --no-admin
 ```
 
 ### Get contract address

--- a/docs/build/cosmwasm/quickstart.md
+++ b/docs/build/cosmwasm/quickstart.md
@@ -1,0 +1,60 @@
+---
+title: Quickstart
+description: Scaffold, build, and deploy your first CosmWasm contract on Osmosis.
+sidebar_position: 1
+---
+
+# CosmWasm Quickstart
+
+The fastest path from nothing to a deployed contract on Osmosis. Each step links to the page with the full detail; this page is the ordered happy path.
+
+## 1. Scaffold a contract
+
+Use `cargo generate` with the official CosmWasm template to create a working contract and build system:
+
+```bash
+cargo install cargo-generate --features vendored-openssl
+cargo generate --git https://github.com/CosmWasm/cw-template.git --name my-contract
+cd my-contract
+```
+
+This gives you a cargo project with a sample contract (the standard `counter`), an entry-point layout, and a build setup you can customize.
+
+## 2. Add cw-orchestrator
+
+[cw-orchestrator](/build/cosmwasm/cw-orch) is the actively maintained tool for building, deploying, and testing CosmWasm contracts, and the recommended path on Osmosis. Add it to the contract crate as an optional dependency:
+
+```bash
+cargo add --optional cw-orch
+```
+
+Adding it as optional and enabling it behind an `interface` feature flag keeps `cw-orch` out of the compiled wasm artifact. You then define a typed interface for the contract and use it to write deploy and test scripts that run unchanged against a local chain, a testnet, or mainnet. See [Scripts and Tests with cw-orchestrator](/build/cosmwasm/cw-orch) for the feature setup, the interface macro, and the full workflow.
+
+## 3. Build and test locally
+
+Develop against a local chain. Spin up [LocalOsmosis](/build/cosmwasm/localosmosis):
+
+```bash
+make localnet-start    # from a checkout of the osmosis repo
+```
+
+Then build, upload, and instantiate the contract against it from a cw-orch script:
+
+```rust
+let counter = CounterContract::new(chain);
+counter.upload()?;
+counter.instantiate(&InstantiateMsg { count: 0 }, None, &[])?;
+```
+
+cw-orchestrator also runs the same scripts against [cw-multi-test](https://github.com/CosmWasm/cw-multi-test) and [Osmosis Test Tube](https://github.com/osmosis-labs/test-tube) for fast unit and integration tests with no node running. See [CosmWasm & LocalOsmosis](/build/cosmwasm/localosmosis) for the local accounts and full workflow.
+
+## 4. Deploy to testnet
+
+When the contract works locally, point the same cw-orch script at a public testnet, or upload with `osmosisd` directly (see [testnet deployment](/build/cosmwasm/cosmwasm-deployment)). Storing code on a network where governance gates it goes through a [governance proposal](/build/cosmwasm/submit-wasm-proposal).
+
+> Beaker was a popular all-in-one scaffolding and deployment tool, but it is no longer actively maintained (last release 2023). The [Beaker pages](/build/cosmwasm/beaker) remain for existing projects; new contracts should use the workflow above.
+
+## Next steps
+
+- **Verify** your deployed contract reproducibly: [Verifying Smart Contracts](/build/cosmwasm/cosmwasm-verify-contract).
+- **Call the contract from an app:** the [JavaScript guide](/build/cosmwasm/javascript), or build a full frontend with [Frontend & SDKs](/build/frontend).

--- a/docs/build/cosmwasm/submit-wasm-proposal.md
+++ b/docs/build/cosmwasm/submit-wasm-proposal.md
@@ -20,23 +20,22 @@ curl -sL https://get.osmosis.zone/install > i.py && python3 i.py
 
 ### Start localOsmosis
 
-Inside a separate bash window start your localOsmosis which was installed in ~/localosmosis
+Inside a separate bash window, start LocalOsmosis from a checkout of the Osmosis repo:
 
 ```
-cd ~/localosmosis
-docker-compose up
-
+cd ~/osmosis
+make localnet-start
 ```
 You will start seeing LocalOsmosis block activity in your terminal. Keep LocalOsmosis running while you perform the next steps in a new terminal window.
 
 :::tip
-If you had previously installed localOsmosis, it's a good idea to start fresh and delete ~/localosmosis `rm -rf ~/localosmosis` before installing it again.
+See [CosmWasm & LocalOsmosis](/build/cosmwasm/localosmosis) for the full local setup, including the automatic installer option.
 ::: 
 
 ## Download sample contract
 
 ``` 
-curl -s -L -O https://github.com/CosmWasm/cw-plus/releases/download/v0.12.1/cw20_base.wasm
+curl -s -L -O https://github.com/CosmWasm/cw-plus/releases/download/v1.1.2/cw20_base.wasm
 ```
 
 ## Define variables 
@@ -62,10 +61,13 @@ VAL=$(osmosisd keys show -a validator --keyring-backend test)
 
 ## Submit proposal
 
+Storing code on a permissioned network goes through `x/wasm`'s own governance proposal command, `tx wasm submit-proposal wasm-store` (the older `tx gov submit-proposal wasm-store` form, and the `--description` flag, were removed in newer SDK/wasmd versions; metadata is now `--title` plus `--summary`, and the stored message's `--authority` is the gov module address):
+
 ```
-osmosisd tx gov submit-proposal wasm-store $CONTRACT.wasm --title "Add $CONTRACT" \
-  --description "Let's upload this contract" --run-as $VAL \
-  --from validator --keyring-backend test --chain-id $CHAIN_ID -y -b block \
+osmosisd tx wasm submit-proposal wasm-store $CONTRACT.wasm \
+  --title "Add $CONTRACT" --summary "Let's upload this contract" \
+  --authority osmo10d07y265gmmuvt4z0w9aw880jnsr700jjeq4qp \
+  --from validator --keyring-backend test --chain-id $CHAIN_ID -y -b sync \
   --gas 9000000 --gas-prices 0.05uosmo
 ```
 
@@ -77,13 +79,13 @@ osmosisd query gov proposal $PROPOSAL
 ## Deposit on proposal
 ```
 osmosisd tx gov deposit $PROPOSAL 10000000uosmo --from validator --keyring-backend test \
-    --chain-id $CHAIN_ID -y -b block --gas 6000000 --gas-prices 0.05uosmo
+    --chain-id $CHAIN_ID -y -b sync --gas 6000000 --gas-prices 0.05uosmo
 ```
 
 ## Vote
 ```
 osmosisd tx gov vote $PROPOSAL yes --from validator --keyring-backend test \
-    --chain-id $CHAIN_ID -y -b block --gas 600000 --gas-prices 0.05uosmo
+    --chain-id $CHAIN_ID -y -b sync --gas 600000 --gas-prices 0.05uosmo
 ```
 
 ## Check the results


### PR DESCRIPTION
Part **2 of 4** splitting the Build section accuracy pass ([MTN-115](https://linear.app/osmosis/issue/MTN-115)) for review. Previously one 48-file PR (#339); split by section so each is reviewable on its own. Independent of the other three.

## New page

**CosmWasm Quickstart**: the ordered happy path (scaffold with the official cw-template, add cw-orchestrator, build and test against LocalOsmosis, deploy to testnet), linking the detailed pages in sequence. Distinct from the CosmWasm index overview, which is a survey rather than a path.

## Re-lead on cw-orchestrator

Beaker is unmaintained (last release 2023), so it is demoted to a referenced legacy path with a deprecation banner rather than the recommended tool. The Quickstart, index, localosmosis, deployment, and verify-contract pages now lead with cw-orch plus the official cw-template.

## Fixes

- **cw-orch**: `networks::LOCAL_OSMO`, not `LOCAL_OSMOSIS`. The latter does not exist in the crate, so the example failed to compile.
- **Removed CLI**: `-b block` and `--broadcast-mode=block` (both gone in SDK v0.47+) replaced with `sync`; legacy `tx gov submit-proposal wasm-store` replaced with `tx wasm submit-proposal store-wasm`; the `CODE_ID` jq parse fixed for the v0.47+ response shape.
- **Compile-breaking Rust**: `create::` corrected to `crate::` across code blocks, and the instantiate signature fixed.
- **cosmwasm index**: prose aligned with the card list.

Build passes.
