### PR TITLE
fix(docs): operator and tooling accuracy sweep (validate, developer environment, Beaker v0.1.8)

### DIFF
--- a/docs/build/cosmwasm/beaker/README.md
+++ b/docs/build/cosmwasm/beaker/README.md
@@ -54,7 +54,7 @@ This section is intended to give you an introduction to `Beaker`, for more detai
 
 - [Rust](https://www.rust-lang.org/tools/install) for building cosmwasm contract
     - [Rustup](https://rustup.rs/) for dealing with wasm target
-- [Docker](https://docs.docker.com/get-docker/) for running wasm `rust-optimizer` and spinning up [LocalOsmosis](https://github.com/osmosis-labs/localosmosis)
+- [Docker](https://docs.docker.com/get-docker/) for running wasm `rust-optimizer` and spinning up [LocalOsmosis](https://github.com/osmosis-labs/osmosis/tree/main/tests/localosmosis)
 - [Node](https://nodejs.org/en/) for frontend related stuffs and `beaker-console`
   - [Yarn](https://yarnpkg.com/) over NPM, since it will not have package resolving issue and causes weird errors down the road
 
@@ -158,7 +158,7 @@ template_repo = "https://github.com/osmosis-labs/cw-tpl-osmosis.git"
 
 LocalOsmosis, as its name suggests, is Osmosis for local development. It has to be installed and run separately.
 
-You can install from source by following the instruction at [osmosis-labs/LocalOsmosis](https://github.com/osmosis-labs/LocalOsmosis), or use the official installer and select option 3:
+LocalOsmosis lives in the main Osmosis repo under [tests/localosmosis](https://github.com/osmosis-labs/osmosis/tree/main/tests/localosmosis); see the [Local Testing](/build/developer-environment/localtesting) guide for the full setup. Alternatively, use the official installer and select option 3:
 
 ```sh
 curl -sL https://get.osmosis.zone/install > i.py && python3 i.py
@@ -180,7 +180,7 @@ beaker wasm build --no-wasm-opt
 
 # read .wasm in `target/wasm32-unknown-unknown/release/<CONTRACT_NAME>.wasm` due to `--no-wasm-opt` flag
 # use `--signer-account test1` which is predefined.
-# The list of all predefined accounts are here: https://github.com/osmosis-labs/LocalOsmosis#accounts
+# The list of all predefined accounts are here: https://github.com/osmosis-labs/osmosis/tree/main/tests/localosmosis#localosmosis-accounts-and-keys
 # `code-id` is stored in the beaker state, local by default
 beaker wasm store-code counter --signer-account test1 --no-wasm-opt
 
@@ -330,7 +330,7 @@ Press `enter` to proceed for now, and we will discuss about it in detail in the 
 
 This will launch custom node repl, where `contract`, `account` are available.
 `contract` contains deployed contract.
-`account` contains [pre-defined accounts in localosmosis](https://github.com/osmosis-labs/LocalOsmosis#accounts).
+`account` contains [pre-defined accounts in LocalOsmosis](https://github.com/osmosis-labs/osmosis/tree/main/tests/localosmosis#localosmosis-accounts-and-keys).
 
 So you can interact with the recently deployed contract like this:
 
@@ -390,7 +390,7 @@ Apart from that, in the console, you can access Beaker's state, configuration an
 
 ### Typescript SDK Generation
 
-Beaker leverage [cosmwasm-typescript-gen](https://github.com/CosmWasm/cosmwasm-typescript-gen) to generate typescript client for cosmwasm contract. By default, Beaker's template prepare `ts/sdk` directory where typescript compiler and bundler are setup, so the generated client definition could be used by `beaker-console`, frontend or published as library for others to use.
+Beaker leverages [ts-codegen](https://github.com/hyperweb-io/ts-codegen) (formerly cosmwasm-typescript-gen) to generate a typescript client for a cosmwasm contract. By default, Beaker's template prepare `ts/sdk` directory where typescript compiler and bundler are setup, so the generated client definition could be used by `beaker-console`, frontend or published as library for others to use.
 
 To generate sdk for contract, run
 
@@ -485,11 +485,10 @@ await sc.getCount()
 Beaker project template also comes with frontend template. But in order to interact with it you need:
 
 - [Keplr installed](https://www.keplr.app/)
-- [Keplr chain setup for LocalOsmosis](https://github.com/osmosis-labs/LocalOsmosis/tree/main/localKeplr)
-- Add test account to Keplr
-  - [Add account via mnemonic in Keplr](https://help.keplr.app/articles/how-to-connect-additional-keplr-accounts).
+- [Keplr chain setup for LocalOsmosis](https://github.com/osmosis-labs/localosmosis-archive/tree/main/localKeplr) (from the archived standalone LocalOsmosis repo)
+- Add test account to Keplr via mnemonic (see the [Keplr Help Center](https://help.keplr.app) for wallet basics).
     The account `test1` can be added by copy-pasting `notice oak worry limit wrap speak medal online prefer cluster roof addict wrist behave treat actual wasp year salad speed social layer crew genius` to the Import account screen on Keplr. It contains 100,000 test OSMOs.
-  - [List of test accounts and its mnemonics in LocalOsmosis](https://github.com/osmosis-labs/LocalOsmosis#accounts)
+  - [List of test accounts and their mnemonics in LocalOsmosis](https://github.com/osmosis-labs/osmosis/tree/main/tests/localosmosis#localosmosis-accounts-and-keys)
 
 
 ```sh

--- a/docs/build/cosmwasm/beaker/commands/README.md
+++ b/docs/build/cosmwasm/beaker/commands/README.md
@@ -2,15 +2,9 @@
 
 ## `beaker`
 
-CosmWasm development tooling
+CosmWasm swiss-army knife configured for Osmosis by default, but trivial to make it work for other CosmWasm enabled chain.
 
 Version: 0.1.8 (last release, November 2023)
-
-Arguments:
-
-* `--help`: Print help information
-
-* `--version`: Print version information
 
 ## Subcommands
 
@@ -20,15 +14,11 @@ Create new workspace from boilerplate
 
 Arguments:
 
-* `--help`: Print help information
+* `<NAME>` Workspace name
 
-* `--version`: Print version information
+* `-t / --target-dir <TARGET_DIR>`: Path to store generated workspace
 
-* ` <name>`Workspace name
-
-* `-t/--target-dir <target-dir>`: Path to store generated workspace
-
-* `-b/--branch <branch>`: Template's branch, using main if not specified
+* `-b / --branch <BRANCH>`: Template's branch, using main if not specified
 
 ---
 
@@ -38,12 +28,6 @@ Manipulating and interacting with CosmWasm contract
 
 [\> `beaker wasm`'s subcommands](./beaker_wasm.md)
 
-Arguments:
-
-* `--help`: Print help information
-
-* `--version`: Print version information
-
 ---
 
 ### `beaker key`
@@ -51,12 +35,6 @@ Arguments:
 Managing key backed by system's secret store
 
 [\> `beaker key`'s subcommands](./beaker_key.md)
-
-Arguments:
-
-* `--help`: Print help information
-
-* `--version`: Print version information
 
 ---
 
@@ -66,8 +44,12 @@ Launch interactive console for interacting with the project
 
 Arguments:
 
-* `--help`: Print help information
+* `-n / --network <NETWORK>` (default: `local`)
 
-* `--version`: Print version information
+---
 
-* `-n/--network <network>` (default: `local`)
+### `beaker task`
+
+Managing tasks for the project
+
+[\> `beaker task`'s subcommands](./beaker_task.md)

--- a/docs/build/cosmwasm/beaker/commands/beaker_key.md
+++ b/docs/build/cosmwasm/beaker/commands/beaker_key.md
@@ -2,13 +2,9 @@
 
 Managing key backed by system's secret store
 
-Arguments:
-
-* `--help`: Print help information
-
-* `--version`: Print version information
-
 ## Subcommands
+
+---
 
 ### `beaker key set`
 
@@ -16,15 +12,11 @@ Create new key or update existing key
 
 Arguments:
 
-* `--help`: Print help information
+* `<NAME>` Name of the key to create or update
 
-* `--version`: Print version information
+* `<MNEMONIC>` Mnemonic string to store as an entry
 
-* ` <name>`Name of the key to create or update
-
-* ` <mnemonic>`Mnemonic string to store as an entry
-
-* `-y/--yes`: Agree to all prompts
+* `-y / --yes <YES>`: Agree to all prompts
 
 ---
 
@@ -34,13 +26,9 @@ Delete existing key
 
 Arguments:
 
-* `--help`: Print help information
+* `<NAME>` Name of the key to create or update
 
-* `--version`: Print version information
-
-* ` <name>`Name of the key to create or update
-
-* `-y/--yes`: Agree to all prompts
+* `-y / --yes <YES>`: Agree to all prompts
 
 ---
 
@@ -50,11 +38,7 @@ Get address from keyring's stored key
 
 Arguments:
 
-* `--help`: Print help information
-
-* `--version`: Print version information
-
-* ` <name>`Name of the key to create or update
+* `<NAME>` Name of the key to create or update
 
 ---
 
@@ -64,12 +48,8 @@ Generate new mnemonic
 
 Arguments:
 
-* `--help`: Print help information
+* `<NAME>` Name of the key to create or update
 
-* `--version`: Print version information
+* `--show <SHOW>`: Show mnemonic in the console if set, keep it secret otherwise
 
-* ` <name>`Name of the key to create or update
-
-* `--show`: Show mnemonic in the console if set, keep it secret otherwise
-
-* `-y/--yes`: Agree to all prompts
+* `-y / --yes <YES>`: Agree to all prompts

--- a/docs/build/cosmwasm/beaker/commands/beaker_task.md
+++ b/docs/build/cosmwasm/beaker/commands/beaker_task.md
@@ -1,0 +1,27 @@
+# `beaker task`
+
+Managing tasks for the project
+
+## Subcommands
+
+---
+
+### `beaker task new`
+
+Create a new task
+
+Arguments:
+
+* `<TASK>` Name of the task
+
+---
+
+### `beaker task run`
+
+Run a task
+
+Arguments:
+
+* `<SCRIPT>` Name of the task
+
+* `<ARGS>`

--- a/docs/build/cosmwasm/beaker/commands/beaker_wasm.md
+++ b/docs/build/cosmwasm/beaker/commands/beaker_wasm.md
@@ -2,13 +2,9 @@
 
 Manipulating and interacting with CosmWasm contract
 
-Arguments:
-
-* `--help`: Print help information
-
-* `--version`: Print version information
-
 ## Subcommands
+
+---
 
 ### `beaker wasm new`
 
@@ -16,15 +12,13 @@ Create new CosmWasm contract from boilerplate
 
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>` Contract name
 
-* `--version`: Print version information
+* `-t / --target-dir <TARGET_DIR>`: Path to store generated contract
 
-* ` <contract-name>`Contract name
+* `-v / --version <VERSION>`: Template's version, using main branch if not specified
 
-* `-t/--target-dir <target-dir>`: Path to store generated contract
-
-* `-v/--version <version>`: Template's version, using main branch if not specified
+* `--template <TEMPLATE>`: Template name, prompt for template if not specified
 
 ---
 
@@ -34,13 +28,9 @@ Build .wasm for storing contract code on the blockchain
 
 Arguments:
 
-* `--help`: Print help information
+* `--no-wasm-opt <NO_WASM_OPT>`: If set, the contract(s) will not be optimized by wasm-opt after build (only use in dev)
 
-* `--version`: Print version information
-
-* `--no-wasm-opt`: If set, the contract(s) will not be optimized by wasm-opt after build (only use in dev)
-
-* `-a/--aarch64`: Option for m1 user for wasm optimization, FOR TESTING ONLY, PRODUCTION BUILD SHOULD USE INTEL BUILD
+* `-a / --aarch64 <AARCH64>`: Option for m1 user for wasm optimization, FOR TESTING ONLY, PRODUCTION BUILD SHOULD USE INTEL BUILD
 
 ---
 
@@ -50,31 +40,29 @@ Store .wasm on chain for later initialization
 
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>` Name of the contract to store
 
-* `--version`: Print version information
+* `--no-wasm-opt <NO_WASM_OPT>`: If set, use non wasm-opt optimized wasm to store code (only use in dev)
 
-* ` <contract-name>`Name of the contract to store
+* `--permit-instantiate-only <PERMIT_INSTANTIATE_ONLY>`: Restricting the code to be able to instantiate only by given address, no restriction by default
 
-* `--no-wasm-opt`: If set, use non wasm-opt optimized wasm to store code (only use in dev)
+* `-n / --network <NETWORK>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
 
-* `--permit-instantiate-only <permit-instantiate-only>`: Restricting the code to be able to instantiate only by given address, no restriction by default
+* `--gas <GAS>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
 
-* `-n/--network <network>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
+* `--gas-limit <GAS_LIMIT>`: Limit to how much gas amount allowed to be consumed
 
-* `--gas <gas>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
+* `--signer-account <SIGNER_ACCOUNT>`: Specifies predefined account as a tx signer
 
-* `--gas-limit <gas-limit>`: Limit to how much gas amount allowed to be consumed
+* `--signer-keyring <SIGNER_KEYRING>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker_key.md)
 
-* `--signer-account <signer-account>`: Specifies predefined account as a tx signer
+* `--signer-mnemonic <SIGNER_MNEMONIC>`: Specifies mnemonic as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-private-key <SIGNER_PRIVATE_KEY>`: Specifies private_key as a tx signer (base64 encoded string)
 
-* `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
+* `-t / --timeout-height <TIMEOUT_HEIGHT>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
 
-* `--signer-private-key <signer-private-key>`: Specifies private_key as a tx signer (base64 encoded string)
-
-* `-t/--timeout-height <timeout-height>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
+* `-a / --account-sequence <ACCOUNT_SEQUENCE>`: Account sequence number to use for the transaction, if not provided, sequence will be fetched from the chain. This is useful if there is an account sequence mismatch
 
 ---
 
@@ -82,19 +70,13 @@ Arguments:
 
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>` Name of the contract to store
 
-* `--version`: Print version information
+* `--schema-gen-cmd <SCHEMA_GEN_CMD>`: Schema generation command, default: `cargo schema`
 
-* ` <contract-name>`Name of the contract to store
+* `--out-dir <OUT_DIR>`: Code output directory, ignore remaining ts build process if custom out_dir is specified
 
-* `--schema-gen-cmd <schema-gen-cmd>`: Schema generation command, default: `cargo run -p {contract_name} --example schema`
-
-* `--schema-dir <schema-dir>`: Directory of input schema for ts generation
-
-* `--out-dir <out-dir>`: Code output directory, ignore remaining ts build process if custom out_dir is specified
-
-* `--node-package-manager <node-package-manager>`: Node package manager to use (default: `yarn`)
+* `--node-package-manager <NODE_PACKAGE_MANAGER>`: Node package manager to use (default: `yarn`)
 
 ---
 
@@ -104,31 +86,29 @@ Update admin that can migrate contract
 
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>` Name of the contract to store
 
-* `--version`: Print version information
+* `-l / --label <LABEL>`: Label for the instantiated contract for later reference (default: `default`)
 
-* ` <contract-name>`Name of the contract to store
+* `--new-admin <NEW_ADMIN>`: Address of new admin
 
-* `-l/--label <label>`: Label for the instantiated contract for later reference (default: `default`)
+* `-n / --network <NETWORK>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
 
-* `--new-admin <new-admin>`: Address of new admin
+* `--gas <GAS>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
 
-* `-n/--network <network>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
+* `--gas-limit <GAS_LIMIT>`: Limit to how much gas amount allowed to be consumed
 
-* `--gas <gas>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
+* `--signer-account <SIGNER_ACCOUNT>`: Specifies predefined account as a tx signer
 
-* `--gas-limit <gas-limit>`: Limit to how much gas amount allowed to be consumed
+* `--signer-keyring <SIGNER_KEYRING>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker_key.md)
 
-* `--signer-account <signer-account>`: Specifies predefined account as a tx signer
+* `--signer-mnemonic <SIGNER_MNEMONIC>`: Specifies mnemonic as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-private-key <SIGNER_PRIVATE_KEY>`: Specifies private_key as a tx signer (base64 encoded string)
 
-* `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
+* `-t / --timeout-height <TIMEOUT_HEIGHT>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
 
-* `--signer-private-key <signer-private-key>`: Specifies private_key as a tx signer (base64 encoded string)
-
-* `-t/--timeout-height <timeout-height>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
+* `-a / --account-sequence <ACCOUNT_SEQUENCE>`: Account sequence number to use for the transaction, if not provided, sequence will be fetched from the chain. This is useful if there is an account sequence mismatch
 
 ---
 
@@ -138,29 +118,27 @@ Clear admin so no one can migrate contract
 
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>` Name of the contract to store
 
-* `--version`: Print version information
+* `-l / --label <LABEL>`: Label for the instantiated contract for later reference (default: `default`)
 
-* ` <contract-name>`Name of the contract to store
+* `-n / --network <NETWORK>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
 
-* `-l/--label <label>`: Label for the instantiated contract for later reference (default: `default`)
+* `--gas <GAS>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
 
-* `-n/--network <network>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
+* `--gas-limit <GAS_LIMIT>`: Limit to how much gas amount allowed to be consumed
 
-* `--gas <gas>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
+* `--signer-account <SIGNER_ACCOUNT>`: Specifies predefined account as a tx signer
 
-* `--gas-limit <gas-limit>`: Limit to how much gas amount allowed to be consumed
+* `--signer-keyring <SIGNER_KEYRING>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker_key.md)
 
-* `--signer-account <signer-account>`: Specifies predefined account as a tx signer
+* `--signer-mnemonic <SIGNER_MNEMONIC>`: Specifies mnemonic as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-private-key <SIGNER_PRIVATE_KEY>`: Specifies private_key as a tx signer (base64 encoded string)
 
-* `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
+* `-t / --timeout-height <TIMEOUT_HEIGHT>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
 
-* `--signer-private-key <signer-private-key>`: Specifies private_key as a tx signer (base64 encoded string)
-
-* `-t/--timeout-height <timeout-height>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
+* `-a / --account-sequence <ACCOUNT_SEQUENCE>`: Account sequence number to use for the transaction, if not provided, sequence will be fetched from the chain. This is useful if there is an account sequence mismatch
 
 ---
 
@@ -170,39 +148,37 @@ Instantiate .wasm stored on chain
 
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>` Name of the contract to instantiate
 
-* `--version`: Print version information
+* `-l / --label <LABEL>`: Label for the instantiated contract for later reference (default: `default`)
 
-* ` <contract-name>`Name of the contract to instantiate
+* `-r / --raw <RAW>`: Raw json string to use as instantiate msg
 
-* `-l/--label <label>`: Label for the instantiated contract for later reference (default: `default`)
+* `--admin <ADMIN>`: Specifying admin required for contract migration. Use "signer" for setting tx signer as admin. Use bech32 address (eg. "osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks") for custom admin
 
-* `-r/--raw <raw>`: Raw json string to use as instantiate msg
+* `-f / --funds <FUNDS>`: Funds to send to instantiated contract
 
-* `--admin <admin>`: Specifying admin required for contract migration. Use "signer" for setting tx signer as admin. Use bech32 address (eg. "osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks") for custom admin
+* `--no-proposal-sync <NO_PROPOSAL_SYNC>`: Skip the check for proposal's updated code_id
 
-* `-f/--funds <funds>`: Funds to send to instantiated contract
+* `-y / --yes <YES>`: Agree to all prompts
 
-* `--no-proposal-sync`: Skip the check for proposal's updated code_id
+* `-n / --network <NETWORK>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
 
-* `-y/--yes`: Agree to all prompts
+* `--gas <GAS>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
 
-* `-n/--network <network>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
+* `--gas-limit <GAS_LIMIT>`: Limit to how much gas amount allowed to be consumed
 
-* `--gas <gas>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
+* `--signer-account <SIGNER_ACCOUNT>`: Specifies predefined account as a tx signer
 
-* `--gas-limit <gas-limit>`: Limit to how much gas amount allowed to be consumed
+* `--signer-keyring <SIGNER_KEYRING>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker_key.md)
 
-* `--signer-account <signer-account>`: Specifies predefined account as a tx signer
+* `--signer-mnemonic <SIGNER_MNEMONIC>`: Specifies mnemonic as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-private-key <SIGNER_PRIVATE_KEY>`: Specifies private_key as a tx signer (base64 encoded string)
 
-* `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
+* `-t / --timeout-height <TIMEOUT_HEIGHT>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
 
-* `--signer-private-key <signer-private-key>`: Specifies private_key as a tx signer (base64 encoded string)
-
-* `-t/--timeout-height <timeout-height>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
+* `-a / --account-sequence <ACCOUNT_SEQUENCE>`: Account sequence number to use for the transaction, if not provided, sequence will be fetched from the chain. This is useful if there is an account sequence mismatch
 
 ---
 
@@ -212,35 +188,33 @@ Migrate an instantiated contract to use other code stored on chain
 
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>` Name of the contract to instantiate
 
-* `--version`: Print version information
+* `-l / --label <LABEL>`: Label for the instantiated contract for selecting migration target (default: `default`)
 
-* ` <contract-name>`Name of the contract to instantiate
+* `-r / --raw <RAW>`: Raw json string to use as instantiate msg
 
-* `-l/--label <label>`: Label for the instantiated contract for selecting migration target (default: `default`)
+* `--no-proposal-sync <NO_PROPOSAL_SYNC>`: Skip the check for proposal's updated code_id
 
-* `-r/--raw <raw>`: Raw json string to use as instantiate msg
+* `-y / --yes <YES>`: Agree to all prompts
 
-* `--no-proposal-sync`: Skip the check for proposal's updated code_id
+* `-n / --network <NETWORK>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
 
-* `-y/--yes`: Agree to all prompts
+* `--gas <GAS>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
 
-* `-n/--network <network>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
+* `--gas-limit <GAS_LIMIT>`: Limit to how much gas amount allowed to be consumed
 
-* `--gas <gas>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
+* `--signer-account <SIGNER_ACCOUNT>`: Specifies predefined account as a tx signer
 
-* `--gas-limit <gas-limit>`: Limit to how much gas amount allowed to be consumed
+* `--signer-keyring <SIGNER_KEYRING>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker_key.md)
 
-* `--signer-account <signer-account>`: Specifies predefined account as a tx signer
+* `--signer-mnemonic <SIGNER_MNEMONIC>`: Specifies mnemonic as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-private-key <SIGNER_PRIVATE_KEY>`: Specifies private_key as a tx signer (base64 encoded string)
 
-* `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
+* `-t / --timeout-height <TIMEOUT_HEIGHT>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
 
-* `--signer-private-key <signer-private-key>`: Specifies private_key as a tx signer (base64 encoded string)
-
-* `-t/--timeout-height <timeout-height>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
+* `-a / --account-sequence <ACCOUNT_SEQUENCE>`: Account sequence number to use for the transaction, if not provided, sequence will be fetched from the chain. This is useful if there is an account sequence mismatch
 
 ---
 
@@ -250,41 +224,39 @@ Build, Optimize, Store code, and instantiate contract
 
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>` Name of the contract to deploy
 
-* `--version`: Print version information
+* `-l / --label <LABEL>`: Label for the instantiated contract for later reference (default: `default`)
 
-* ` <contract-name>`Name of the contract to deploy
+* `-r / --raw <RAW>`: Raw json string to use as instantiate msg
 
-* `-l/--label <label>`: Label for the instantiated contract for later reference (default: `default`)
+* `--permit-instantiate-only <PERMIT_INSTANTIATE_ONLY>`: Restricting the code to be able to instantiate only by given address, no restriction by default
 
-* `-r/--raw <raw>`: Raw json string to use as instantiate msg
+* `--admin <ADMIN>`: Specifying admin required for contract migration. Use "signer" for setting tx signer as admin. Use bech32 address (eg. "osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks") for custom admin
 
-* `--permit-instantiate-only <permit-instantiate-only>`: Restricting the code to be able to instantiate only by given address, no restriction by default
+* `-f / --funds <FUNDS>`: Funds to send to instantiated contract
 
-* `--admin <admin>`: Specifying admin required for contract migration. Use "signer" for setting tx signer as admin. Use bech32 address (eg. "osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks") for custom admin
+* `--no-rebuild <NO_REBUILD>`: Use existing .wasm file to deploy if set to true
 
-* `-f/--funds <funds>`: Funds to send to instantiated contract
+* `--no-wasm-opt <NO_WASM_OPT>`: If set, skip wasm-opt and store the unoptimized code (only use in dev)
 
-* `--no-rebuild`: Use existing .wasm file to deploy if set to true
+* `-n / --network <NETWORK>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
 
-* `--no-wasm-opt`: If set, skip wasm-opt and store the unoptimized code (only use in dev)
+* `--gas <GAS>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
 
-* `-n/--network <network>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
+* `--gas-limit <GAS_LIMIT>`: Limit to how much gas amount allowed to be consumed
 
-* `--gas <gas>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
+* `--signer-account <SIGNER_ACCOUNT>`: Specifies predefined account as a tx signer
 
-* `--gas-limit <gas-limit>`: Limit to how much gas amount allowed to be consumed
+* `--signer-keyring <SIGNER_KEYRING>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker_key.md)
 
-* `--signer-account <signer-account>`: Specifies predefined account as a tx signer
+* `--signer-mnemonic <SIGNER_MNEMONIC>`: Specifies mnemonic as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-private-key <SIGNER_PRIVATE_KEY>`: Specifies private_key as a tx signer (base64 encoded string)
 
-* `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
+* `-t / --timeout-height <TIMEOUT_HEIGHT>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
 
-* `--signer-private-key <signer-private-key>`: Specifies private_key as a tx signer (base64 encoded string)
-
-* `-t/--timeout-height <timeout-height>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
+* `-a / --account-sequence <ACCOUNT_SEQUENCE>`: Account sequence number to use for the transaction, if not provided, sequence will be fetched from the chain. This is useful if there is an account sequence mismatch
 
 ---
 
@@ -294,37 +266,35 @@ Build, Optimize, Store code, and migrate contract
 
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>` Name of the contract to deploy
 
-* `--version`: Print version information
+* `-l / --label <LABEL>`: Label for the instantiated contract for later reference (default: `default`)
 
-* ` <contract-name>`Name of the contract to deploy
+* `-r / --raw <RAW>`: Raw json string to use as instantiate msg
 
-* `-l/--label <label>`: Label for the instantiated contract for later reference (default: `default`)
+* `--no-rebuild <NO_REBUILD>`: Use existing .wasm file to deploy if set to true
 
-* `-r/--raw <raw>`: Raw json string to use as instantiate msg
+* `--no-wasm-opt <NO_WASM_OPT>`: If set, skip wasm-opt and store the unoptimized code (only use in dev)
 
-* `--no-rebuild`: Use existing .wasm file to deploy if set to true
+* `--permit-instantiate-only <PERMIT_INSTANTIATE_ONLY>`: Restricting the code to be able to instantiate only by given address, no restriction by default
 
-* `--no-wasm-opt`: If set, skip wasm-opt and store the unoptimized code (only use in dev)
+* `-n / --network <NETWORK>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
 
-* `--permit-instantiate-only <permit-instantiate-only>`: Restricting the code to be able to instantiate only by given address, no restriction by default
+* `--gas <GAS>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
 
-* `-n/--network <network>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
+* `--gas-limit <GAS_LIMIT>`: Limit to how much gas amount allowed to be consumed
 
-* `--gas <gas>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
+* `--signer-account <SIGNER_ACCOUNT>`: Specifies predefined account as a tx signer
 
-* `--gas-limit <gas-limit>`: Limit to how much gas amount allowed to be consumed
+* `--signer-keyring <SIGNER_KEYRING>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker_key.md)
 
-* `--signer-account <signer-account>`: Specifies predefined account as a tx signer
+* `--signer-mnemonic <SIGNER_MNEMONIC>`: Specifies mnemonic as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-private-key <SIGNER_PRIVATE_KEY>`: Specifies private_key as a tx signer (base64 encoded string)
 
-* `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
+* `-t / --timeout-height <TIMEOUT_HEIGHT>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
 
-* `--signer-private-key <signer-private-key>`: Specifies private_key as a tx signer (base64 encoded string)
-
-* `-t/--timeout-height <timeout-height>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
+* `-a / --account-sequence <ACCOUNT_SEQUENCE>`: Account sequence number to use for the transaction, if not provided, sequence will be fetched from the chain. This is useful if there is an account sequence mismatch
 
 ---
 
@@ -332,8 +302,68 @@ Arguments:
 
 [\> `beaker wasm proposal`'s subcommands](./beaker_wasm_proposal.md)
 
+---
+
+### `beaker wasm execute`
+
+Execute contract messages
+
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>`
 
-* `--version`: Print version information
+* `-l / --label <LABEL>` (default: `default`)
+
+* `-r / --raw <RAW>`
+
+* `-f / --funds <FUNDS>`
+
+* `-n / --network <NETWORK>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
+
+* `--gas <GAS>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
+
+* `--gas-limit <GAS_LIMIT>`: Limit to how much gas amount allowed to be consumed
+
+* `--signer-account <SIGNER_ACCOUNT>`: Specifies predefined account as a tx signer
+
+* `--signer-keyring <SIGNER_KEYRING>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker_key.md)
+
+* `--signer-mnemonic <SIGNER_MNEMONIC>`: Specifies mnemonic as a tx signer
+
+* `--signer-private-key <SIGNER_PRIVATE_KEY>`: Specifies private_key as a tx signer (base64 encoded string)
+
+* `-t / --timeout-height <TIMEOUT_HEIGHT>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
+
+* `-a / --account-sequence <ACCOUNT_SEQUENCE>`: Account sequence number to use for the transaction, if not provided, sequence will be fetched from the chain. This is useful if there is an account sequence mismatch
+
+---
+
+### `beaker wasm query`
+
+Query contract state
+
+Arguments:
+
+* `<CONTRACT_NAME>`
+
+* `-l / --label <LABEL>` (default: `default`)
+
+* `-r / --raw <RAW>`
+
+* `-n / --network <NETWORK>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
+
+* `--gas <GAS>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
+
+* `--gas-limit <GAS_LIMIT>`: Limit to how much gas amount allowed to be consumed
+
+* `--signer-account <SIGNER_ACCOUNT>`: Specifies predefined account as a tx signer
+
+* `--signer-keyring <SIGNER_KEYRING>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker_key.md)
+
+* `--signer-mnemonic <SIGNER_MNEMONIC>`: Specifies mnemonic as a tx signer
+
+* `--signer-private-key <SIGNER_PRIVATE_KEY>`: Specifies private_key as a tx signer (base64 encoded string)
+
+* `-t / --timeout-height <TIMEOUT_HEIGHT>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
+
+* `-a / --account-sequence <ACCOUNT_SEQUENCE>`: Account sequence number to use for the transaction, if not provided, sequence will be fetched from the chain. This is useful if there is an account sequence mismatch

--- a/docs/build/cosmwasm/beaker/commands/beaker_wasm_proposal.md
+++ b/docs/build/cosmwasm/beaker/commands/beaker_wasm_proposal.md
@@ -1,12 +1,12 @@
 # `beaker wasm proposal`
 
-Arguments:
-
-* `--help`: Print help information
-
-* `--version`: Print version information
+:::danger These commands no longer work on Osmosis
+The `beaker wasm proposal` subcommands submit legacy (gov v1beta1) wasm proposals. Current Osmosis networks no longer route these legacy proposal messages, so proposals submitted this way are rejected and cannot succeed. To store contract code through governance, use the flow in [Submit a CosmWasm Governance Proposal](/build/cosmwasm/submit-wasm-proposal) instead.
+:::
 
 ## Subcommands
+
+---
 
 ### `beaker wasm proposal store-code`
 
@@ -14,43 +14,37 @@ Proposal for storing .wasm on chain for later initialization
 
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>` Name of the contract to store
 
-* `--version`: Print version information
+* `--permit-instantiate-only <PERMIT_INSTANTIATE_ONLY>`: Restricting the code to be able to instantiate/migrate only by given address, no restriction by default
 
-* ` <contract-name>`Name of the contract to store
+* `-p / --proposal <PROPOSAL>`: Path to proposal file, could be either yaml / toml format
 
-* `--permit-instantiate-only <permit-instantiate-only>`: Restricting the code to be able to instantiate/migrate only by given address, no restriction by default
+* `--title <TITLE>`: Proposal title (default: ``)
 
-* `-p/--proposal <proposal>`: Path to proposal file, could be either yaml / toml format
+* `--description <DESCRIPTION>`: Proposal description (default: ``)
 
-* `--title <title>`: Proposal title (default: ``)
+* `--deposit <DEPOSIT>`: Proposal deposit to activate voting
 
-* `--description <description>`: Proposal description (default: ``)
+* `--unpin-code <UNPIN_CODE>`: Unpin code on upload (default: `false`)
 
-* `--deposit <deposit>`: Proposal deposit to activate voting
+* `-n / --network <NETWORK>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
 
-* `--repo <repo>`: Public repository of the code (default: ``)
+* `--gas <GAS>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
 
-* `--rust-flags <rust-flags>`: RUST_FLAGS that passed while compiling to wasm If building with Beaker, it's usually "-C link-arg=-s"
+* `--gas-limit <GAS_LIMIT>`: Limit to how much gas amount allowed to be consumed
 
-* `--optimizer <optimizer>`: Type and version of the [optimizer](https://github.com/CosmWasm/rust-optimizer), either: `rust-optimizer:<version>` or `workspace-optimizer:<version>`. Beaker use workspace-optimizer, the version, if not manually configured, can be found in `wasm` config doc
+* `--signer-account <SIGNER_ACCOUNT>`: Specifies predefined account as a tx signer
 
-* `-n/--network <network>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
+* `--signer-keyring <SIGNER_KEYRING>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker_key.md)
 
-* `--gas <gas>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
+* `--signer-mnemonic <SIGNER_MNEMONIC>`: Specifies mnemonic as a tx signer
 
-* `--gas-limit <gas-limit>`: Limit to how much gas amount allowed to be consumed
+* `--signer-private-key <SIGNER_PRIVATE_KEY>`: Specifies private_key as a tx signer (base64 encoded string)
 
-* `--signer-account <signer-account>`: Specifies predefined account as a tx signer
+* `-t / --timeout-height <TIMEOUT_HEIGHT>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
-
-* `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
-
-* `--signer-private-key <signer-private-key>`: Specifies private_key as a tx signer (base64 encoded string)
-
-* `-t/--timeout-height <timeout-height>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
+* `-a / --account-sequence <ACCOUNT_SEQUENCE>`: Account sequence number to use for the transaction, if not provided, sequence will be fetched from the chain. This is useful if there is an account sequence mismatch
 
 ---
 
@@ -60,38 +54,30 @@ Vote for proposal
 
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>` Name of the contract to store
 
-* `--version`: Print version information
+* `-o / --option <OPTION>`: Vote option, one of: yes, no, no_with_veto, abstain
 
-* ` <contract-name>`Name of the contract to store
+* `-n / --network <NETWORK>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
 
-* `-o/--option <option>`: Vote option, one of: yes, no, no_with_veto, abstain
+* `--gas <GAS>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
 
-* `-n/--network <network>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
+* `--gas-limit <GAS_LIMIT>`: Limit to how much gas amount allowed to be consumed
 
-* `--gas <gas>`: Coin (amount and denom) you are willing to pay as gas eg. `1000uosmo`
+* `--signer-account <SIGNER_ACCOUNT>`: Specifies predefined account as a tx signer
 
-* `--gas-limit <gas-limit>`: Limit to how much gas amount allowed to be consumed
+* `--signer-keyring <SIGNER_KEYRING>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](./beaker_key.md)
 
-* `--signer-account <signer-account>`: Specifies predefined account as a tx signer
+* `--signer-mnemonic <SIGNER_MNEMONIC>`: Specifies mnemonic as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-private-key <SIGNER_PRIVATE_KEY>`: Specifies private_key as a tx signer (base64 encoded string)
 
-* `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
+* `-t / --timeout-height <TIMEOUT_HEIGHT>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
 
-* `--signer-private-key <signer-private-key>`: Specifies private_key as a tx signer (base64 encoded string)
-
-* `-t/--timeout-height <timeout-height>`: Specifies a block timeout height to prevent the tx from being committed past a certain height (default: `0`)
+* `-a / --account-sequence <ACCOUNT_SEQUENCE>`: Account sequence number to use for the transaction, if not provided, sequence will be fetched from the chain. This is useful if there is an account sequence mismatch
 
 ---
 
 ### `beaker wasm proposal query`
 
-[\> `beaker wasm proposal query`'s subcommands](beaker_wasm_proposal_query.md)
-
-Arguments:
-
-* `--help`: Print help information
-
-* `--version`: Print version information
+[\> `beaker wasm proposal query`'s subcommands](./beaker_wasm_proposal_query.md)

--- a/docs/build/cosmwasm/beaker/commands/beaker_wasm_proposal_query.md
+++ b/docs/build/cosmwasm/beaker/commands/beaker_wasm_proposal_query.md
@@ -1,12 +1,12 @@
 # `beaker wasm proposal query`
 
-Arguments:
-
-* `--help`: Print help information
-
-* `--version`: Print version information
+:::danger These commands no longer work on Osmosis
+The `beaker wasm proposal` subcommands rely on legacy (gov v1beta1) wasm proposals, which current Osmosis networks no longer route, so there are no such proposals to query. To store contract code through governance, use the flow in [Submit a CosmWasm Governance Proposal](/build/cosmwasm/submit-wasm-proposal) instead.
+:::
 
 ## Subcommands
+
+---
 
 ### `beaker wasm proposal query store-code`
 
@@ -14,10 +14,6 @@ Proposal for storing .wasm on chain for later initialization
 
 Arguments:
 
-* `--help`: Print help information
+* `<CONTRACT_NAME>` Name of the contract to store
 
-* `--version`: Print version information
-
-* ` <contract-name>`Name of the contract to store
-
-* `-n/--network <network>` (default: `local`)
+* `-n / --network <NETWORK>` (default: `local`)

--- a/docs/build/cosmwasm/beaker/config/README.md
+++ b/docs/build/cosmwasm/beaker/config/README.md
@@ -8,9 +8,14 @@ The following list is the configuration references for beaker which can be used 
 ---
 
 # Default Config
+
+:::note
+The testnet endpoints bundled with Beaker v0.1.8 use the legacy `osmotest5.osmosis.zone` hostnames; edit them in your `Beaker.toml` to the current osmo-test-5 hosts, `https://rpc.testnet.osmosis.zone` (RPC) and `https://lcd.testnet.osmosis.zone` (LCD).
+:::
+
 ```toml
 name = ''
-gas_price = '0.05uosmo'
+gas_price = '0.025uosmo'
 gas_adjustment = 1.3
 account_prefix = 'osmo'
 derivation_path = '''m/44'/118'/0'/0/0'''
@@ -23,16 +28,16 @@ rpc_endpoint = 'http://localhost:26657'
 [networks.testnet]
 chain_id = 'osmo-test-5'
 network_variant = 'Shared'
-grpc_endpoint = 'https://grpc-test.osmosis.zone:9090'
-rpc_endpoint = 'https://rpc.testnet.osmosis.zone'
+grpc_endpoint = 'https://grpc.osmotest5.osmosis.zone'
+rpc_endpoint = 'https://rpc.osmotest5.osmosis.zone'
 
 [networks.mainnet]
 chain_id = 'osmosis-1'
 network_variant = 'Shared'
 grpc_endpoint = 'https://grpc.osmosis.zone:9090'
-rpc_endpoint = 'https://rpc.osmosis.zone'
+rpc_endpoint = 'https://rpc.osmosis.zone:443'
 [accounts.validator]
-mnemonic = 'satisfy adjust timber high purchase tuition stool faith fine install that you unaware feed domain license impose boss human eager hat rent enjoy dawn'
+mnemonic = 'bottom loan skill merry east cradle onion journey palm apology verb edit desert impose absurd oil bubble sweet glove shallow size build burst effort'
 
 [accounts.test1]
 mnemonic = 'notice oak worry limit wrap speak medal online prefer cluster roof addict wrist behave treat actual wasp year salad speed social layer crew genius'
@@ -79,8 +84,11 @@ target_dir = '.'
 
 [wasm]
 contract_dir = 'contracts'
-template_repo = 'https://github.com/InterWasm/cw-template.git'
-optimizer_version = '0.12.6'
+optimizer_version = '0.14.0'
+
+[wasm.template_repos]
+classic = 'https://github.com/osmosis-labs/cw-minimal-template'
+sylvia = 'https://github.com/osmosis-labs/cw-sylvia-template'
 
 
 # console

--- a/docs/build/cosmwasm/beaker/config/global.md
+++ b/docs/build/cosmwasm/beaker/config/global.md
@@ -134,9 +134,13 @@
 
 ## Default Config
 
+:::note
+The testnet endpoints bundled with Beaker v0.1.8 use the legacy `osmotest5.osmosis.zone` hostnames; edit them in your `Beaker.toml` to the current osmo-test-5 hosts, `https://rpc.testnet.osmosis.zone` (RPC) and `https://lcd.testnet.osmosis.zone` (LCD).
+:::
+
 ```toml
 name = ''
-gas_price = '0.05uosmo'
+gas_price = '0.025uosmo'
 gas_adjustment = 1.3
 account_prefix = 'osmo'
 derivation_path = '''m/44'/118'/0'/0/0'''
@@ -149,16 +153,16 @@ rpc_endpoint = 'http://localhost:26657'
 [networks.testnet]
 chain_id = 'osmo-test-5'
 network_variant = 'Shared'
-grpc_endpoint = 'https://grpc-test.osmosis.zone:443'
-rpc_endpoint = 'https://rpc.testnet.osmosis.zone'
+grpc_endpoint = 'https://grpc.osmotest5.osmosis.zone'
+rpc_endpoint = 'https://rpc.osmotest5.osmosis.zone'
 
 [networks.mainnet]
 chain_id = 'osmosis-1'
 network_variant = 'Shared'
 grpc_endpoint = 'https://grpc.osmosis.zone:9090'
-rpc_endpoint = 'https://rpc.osmosis.zone'
+rpc_endpoint = 'https://rpc.osmosis.zone:443'
 [accounts.validator]
-mnemonic = 'satisfy adjust timber high purchase tuition stool faith fine install that you unaware feed domain license impose boss human eager hat rent enjoy dawn'
+mnemonic = 'bottom loan skill merry east cradle onion journey palm apology verb edit desert impose absurd oil bubble sweet glove shallow size build burst effort'
 
 [accounts.test1]
 mnemonic = 'notice oak worry limit wrap speak medal online prefer cluster roof addict wrist behave treat actual wasp year salad speed social layer crew genius'

--- a/docs/build/cosmwasm/cosmwasm-beaker.md
+++ b/docs/build/cosmwasm/cosmwasm-beaker.md
@@ -6,11 +6,11 @@ sidebar_position: 5
 # Cosmwasm & Beaker
 ## Deploying Cosmwasm Contracts to the testnet with Beaker
 
-The following guide will show you how to create and deploy a Cosmwasm smart contract to the Osmosis testnet. The testnet is permissionless by default to allow developers to test their contracts on a live environment. The Osmosis mainnet is permissioned meaning that you will need to submit a governance proposal in order to deploy to it. 
-
-:::note
-For an alternative CosmWasm scripting, testing, and deployment framework, see [cw-orchestrator](./cw-orch.md).
+:::warning Beaker is no longer actively maintained
+Beaker's last release was v0.1.8 (November 2023). For new contracts, use [cw-orchestrator](./cw-orch.md) with the [Quickstart](./quickstart.md). This page remains as a reference for projects already built on Beaker.
 :::
+
+The following guide will show you how to create and deploy a Cosmwasm smart contract to the Osmosis testnet. The testnet is permissionless by default to allow developers to test their contracts on a live environment. The Osmosis mainnet is permissioned meaning that you will need to submit a governance proposal in order to deploy to it. 
 
 ### Requirements
 - [Rust](https://www.rust-lang.org/tools/install)
@@ -33,7 +33,7 @@ In the directory you want your project to reside, run:
 beaker new counter-dapp
 ```
 
-For detailed information about Beaker [click here](https://github.com/osmosis-labs/beaker/blob/main/README.md).
+For detailed information about Beaker, see the [Beaker reference](./beaker/README.md).
 
 ### Your first CosmWasm contract with Beaker
 
@@ -54,10 +54,10 @@ beaker wasm deploy counter --signer-account test1 --network testnet --no-wasm-op
 Note how we added `--network testnet` to tell beaker to deploy to the testnet Osmosis chain. 
 
 ### Deploy with an admin
-In this example we are using `osmo1nyphwl8p5yx6fxzevjwqunsfqpcxukmtk8t60m` which is the address from the beaker test1 account as seen in the [config.rs](https://github.com/osmosis-labs/beaker/blob/main/packages/cli/src/framework/config.rs) file. 
+In this example we are using `osmo1nyphwl8p5yx6fxzevjwqunsfqpcxukmtk8t60m` which is the address from the beaker test1 account as seen in the [config.rs](https://github.com/osmosis-labs/beaker/blob/v0.1.8/packages/cli/src/framework/config.rs) file. 
 
 :::warning
-Please note that account test1 is publicly available as documented [here](https://github.com/osmosis-labs/beaker/blob/main/docs/config/global.md) and only used for development purposes. Beaker also supports signing from the OS keyring (see [Using the OS keyring](#using-the-os-keyring) below).
+Please note that account test1 is publicly available as documented in the [global config reference](./beaker/config/global.md) and only used for development purposes. Beaker also supports signing from the OS keyring (see [Using the OS keyring](#using-the-os-keyring) below).
 :::
 
 ```
@@ -67,101 +67,14 @@ beaker wasm deploy counter --signer-account test1 --admin osmo1nyphwl8p5yx6fxzev
 
 
 ### Deploy contract via governance
-We can also deploy the contract via governance on the testnet before going to mainnet. There are a couple of steps as described in the manual process via CLI [here](./submit-wasm-proposal.md), more details also available on the [official CosmWasm Docs](https://github.com/CosmWasm/wasmd/blob/main/x/wasm/Governance.md). 
 
+Beaker's `beaker wasm proposal store-code` flow submits a legacy (gov v1beta1) wasm proposal, which current Osmosis networks no longer route, so it cannot succeed. To store contract code through governance, follow [Submit a CosmWasm Governance Proposal](./submit-wasm-proposal.md), which walks through building the contract, submitting the store-code proposal with `osmosisd`, and voting on it. Background on wasm governance is available in the [official CosmWasm docs](https://github.com/CosmWasm/wasmd/blob/main/x/wasm/Governance.md).
 
-### Build contract
-This is required to create the compiled.wasm file that will be uploaded to the block chain.
-
-```
-beaker wasm build
-```
-
-
-### Submit proposal
-
-The proposal can be submitted with all the meta data in a yml file or toml file. Example file:
+You can track a proposal on the [Mintscan testnet explorer](https://www.mintscan.io/osmosis-testnet) or query it directly from the testnet LCD, for example:
 
 ```
-touch prop.yml
-nano prop.yml
+https://lcd.testnet.osmosis.zone/cosmos/gov/v1/proposals/<proposal_id>
 ```
-Paste the following template
-
-```yml
-title: Proposal to allow DappName to be enabled in Osmosis
-description: |
-            A lengthy proposal description
-            goes here  
-            we expect this to be many lines...
-deposit: 500000000uosmo
-code:
-    repo:   https://github.com/osmosis-labs/beaker/
-    rust_flags: -C link-arg=-s
-    optimizer: workspace-optimizer:0.12.6
-```
-
-```sh
-beaker wasm proposal store-code --proposal prop.yml --signer-account test1 --network testnet counter --gas 25000000uosmo --gas-limit 25000000
-```
-![store-proposal](@site/docs/assets/store-prop.png)  
-
-
-### Query proposal
-
-There are four ways to query the proposal results
-
-1. Beaker command
-```
-beaker wasm proposal query store-code --network testnet counter
-```
-
-2. Osmosisd 
-```
-osmosisd query gov tally 196
-```
-
-2. Mintstan testnet explorer
-```
-https://testnet.mintscan.io/osmosis-testnet/proposals/196
-```
-
-3. LCD Proposal endpoint
-
-```
-https://lcd-test.osmosis.zone/cosmos/gov/v1beta1/proposals/196
-```
-
-Note how the min_deposit was `500000000uosmo` that's why our prop.yml had `500000000uosmo`. If the deposit requirement is not met, then additional funds need to be sent to the proposal. 
-
-#### Proposal period 
-On the testnet the voting period is very short to allow developers to move quickly with their testing, as you can see in this case it's `3 minutes`. This means you must vote within the next 3 minutes for your proposal to pass. In mainnet the voting period is usually several days. If you take longer than 3 minutes, then you will get an error letting you know that the voting period has passed. 
-
-```
-    ├── voting_start_time: 2022-07-06T18:45:06Z
-    └── voting_end_time: 2022-07-06T18:48:06Z
-```
-
-![store-proposal](@site/docs/assets/proposal-query.png)  
-
-
-## Voting on proposal on testnet
-
-Run the following command to vote from beaker
-
-```
-beaker wasm proposal vote --option yes counter --signer-account test1 --network testnet
-```
-
-Even though the testnet is configured as permissionless, it's important to understand the voting process. We need validators to vote for your proposal in order to reach the quorum. We created a simple utility in our faucet that will allow you to request a validator with enough voting power to vote for your proposal as well. 
-
-Please visit: 
-
-[https://faucet.osmosis.zone/#/contracts](https://faucet.osmosis.zone/#/contracts)
-
-![store-proposal](@site/docs/assets/faucet-vote.png) 
-
-Great! Your proposal should have passed now!
 
 
 ### Signers

--- a/docs/build/developer-environment/cli.md
+++ b/docs/build/developer-environment/cli.md
@@ -22,41 +22,41 @@ osmosisd status
 
 ```json
 {
-  "NodeInfo": {
+  "node_info": {
     "protocol_version": {
       "p2p": "8",
       "block": "11",
-      "app": "12"
+      "app": "0"
     },
-    "id": "4017c243549b8bb4ad2b4cfe5d685aea450dcbcd",
-    "listen_addr": "209.34.206.35:26656",
+    "id": "6f6f68362b6fcb3a4a968f667df7dbbd7523072d",
+    "listen_addr": "tcp://0.0.0.0:26656",
     "network": "osmosis-1",
-    "version": "0.34.21",
+    "version": "0.38.22",
     "channels": "40202122233038606100",
-    "moniker": "artifact-rpc",
+    "moniker": "osmosis",
     "other": {
       "tx_index": "on",
       "rpc_address": "tcp://0.0.0.0:26657"
     }
   },
-  "SyncInfo": {
-    "latest_block_hash": "FBA710794C5A9C61523D7CCE78F2F51C7CD7A6C33A154C078E423859D7243E30",
-    "latest_app_hash": "EC15E54C7BF66EDC9FEF561969B756CAA58933598FCBF72FE7727DE78F0D8DCF",
-    "latest_block_height": "6335644",
-    "latest_block_time": "2022-10-07T08:45:15.929540892Z",
-    "earliest_block_hash": "38EAF21C7C4A786D73FFAADA32FD3D4B2B683AF2050B41CF5E5924D20AF4EEBC",
-    "earliest_app_hash": "808B1D7123C385D52E6A5BC544FD763D156526751DEB401DADB18C717D567DC0",
-    "earliest_block_height": "6287475",
-    "earliest_block_time": "2022-10-03T22:54:17.633996278Z",
+  "sync_info": {
+    "latest_block_hash": "5DC6FBEF446B685FEF456581B91A2A14C7B86FE2247839E920CCBDFF09788D61",
+    "latest_app_hash": "885E25FC2F464C5BBAAB20ABC7278B3E898A54B6801841D199F650502F781C02",
+    "latest_block_height": "67949994",
+    "latest_block_time": "2026-08-06T13:14:31.550833105Z",
+    "earliest_block_hash": "27B370EF5765769CAF697E3874014C8D57AD08F179E38A5F3619A82A01DF2AEC",
+    "earliest_app_hash": "C33F4FA2B66F87AF4F98BAED8E2DEA3E8FE47E67C4926A100A358EAB71AD975B",
+    "earliest_block_height": "66171492",
+    "earliest_block_time": "2026-07-12T19:59:48.446672466Z",
     "catching_up": false
   },
-  "ValidatorInfo": {
-    "Address": "369E2DCC99CD68400753812BBDF54CD5380FBAC7",
-    "PubKey": {
+  "validator_info": {
+    "address": "3BD8DD32674B0CC6552E22BEDC30FB7609A5ED4A",
+    "pub_key": {
       "type": "tendermint/PubKeyEd25519",
-      "value": "mhb68/B38wFLH/5pDgvPKNbKyKdwduIKxJySz0GV/uI="
+      "value": "2B7ZI70OV4BIz5i6W0dfTNOzcim/xo+K4t3eGXeia+o="
     },
-    "VotingPower": "0"
+    "voting_power": "0"
   }
 }
 ```
@@ -64,33 +64,50 @@ osmosisd status
 </details>
 
 ### Node configuration
+
+The client-side settings (chain id, RPC node, keyring backend) live in the `client.toml` file, which is managed with the `osmosisd config` subcommands. To view the full client configuration:
+
 ```bash
-osmosisd config
+osmosisd config view client
 ```
 Output:
-```json
-{
-	"chain-id": "osmosis-1",
-	"keyring-backend": "os",
-	"output": "text",
-	"node": "http://osmosis.artifact-staking.io:26657",
-	"broadcast-mode": "sync",
-	"grpc-concurrency": false
-}
+```toml
+# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+###############################################################################
+###                           Client Configuration                          ###
+###############################################################################
+
+# The network chain ID
+chain-id = "osmosis-1"
+# The keyring's backend, where the keys are stored (os|file|kwallet|pass|test|memory)
+keyring-backend = "os"
+# CLI output format (text|json)
+output = "text"
+# <host>:<port> to CometBFT RPC interface for this chain
+node = "tcp://localhost:26657"
+# Transaction broadcasting mode (sync|async)
+broadcast-mode = "sync"
 ```
-In this example when we install osmosisd as a client with the [installer](./osmosisd), it connects to the `http://osmosis.artifact-staking.io:26657`.
+
+To read a single value, such as the RPC node the CLI sends queries and transactions to:
+
+```bash
+osmosisd config get client node
+```
 
 ### Change node
 
-```
-osmosis config node https://rpc.osmosis.zone:443
+```bash
+osmosisd config set client node https://rpc.osmosis.zone:443
 ```
 
 ### Connect to the testnet
 
 ```bash
-osmosisd config node https://rpc.testnet.osmosis.zone:443
-osmosisd config chain-id osmo-test-5
+osmosisd config set client node https://rpc.testnet.osmosis.zone:443
+osmosisd config set client chain-id osmo-test-5
 ```
 
 To add a  new account on your local keyring
@@ -110,6 +127,6 @@ osmosisd query bank balances $MYACCOUNT
 ```
 ![](@site/docs/assets/asset_list.png)
 
-For more information about querying osmosisd via the CLI visit the [Cosmos documentation](https://hub.cosmos.network/main/hub-tutorials/gaiad.html).
+For more information about querying osmosisd via the CLI visit the [Cosmos SDK documentation](https://docs.cosmos.network/).
 
 

--- a/docs/build/developer-environment/ide-guide.md
+++ b/docs/build/developer-environment/ide-guide.md
@@ -38,7 +38,7 @@ These are the VSCode extensions that are in daily use by the teams working on Os
 1. [Go by Google](https://marketplace.visualstudio.com/items?itemName=golang.Go)
 2. [VSCode Proto 3 by zxh404](https://marketplace.visualstudio.com/items?itemName=zxh404.vscode-proto3)
 3. [Git Lens by GitKraken](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
-4. [Github Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilotvs)
+4. [Github Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot)
 
 ## Vscode configuration
 
@@ -46,8 +46,7 @@ To make your environment run tests automatically every time you save:
 
 Go to: `VSCode -> Preferences -> settings -> Extensions -> Go`
 
-* Set `Go: Lint tool` to `golint`. You can use `staticcheck` if you'd like, it can just take lots of computational resources.
-    * If you'd like to use the same configuration as Osmosis code, use `golangci-lint` .
+* Set `Go: Lint tool` to `golangci-lint`. This is the linter the Osmosis repository itself uses, configured by the `.golangci.yml` file in the repository root, so it matches what CI enforces. You can use `staticcheck` instead if you'd like, it can just take lots of computational resources.
     * You will likely be prompted to install the linter you choose, click the install button.
 * Set `Go: Format tool` to `gofumpt`
     * You will likely be prompted to install the formatter you choose, click the install button.

--- a/docs/build/developer-environment/keys/keys-cli.md
+++ b/docs/build/developer-environment/keys/keys-cli.md
@@ -6,7 +6,7 @@ description: Create, import, and manage keys with the CLI.
 
 Create, import, export and delete keys using the CLI keyring. 
 
-For this guide, The osmosis Binary is required which you can install from here.
+For this guide, the osmosisd binary is required, which you can install from [here](/build/developer-environment/osmosisd).
 
 ## Create a new key
 
@@ -20,13 +20,10 @@ You can create a new key with the name `Default` as in the following example:
 
 ```bash
 $ osmosisd keys add Default
-- name: Default
+- address: osmo1quw5r22pxy8znjtdkgqc65atrm3x5hg6vycm5n
+  name: Default
+  pubkey: '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AtQ2XW3f5D2jkF9zg7Ml..."}'
   type: local
-  address: osmo1quw5r22pxy8znjtdkgqc65atrm3x5hg6vycm5n
-  pubkey: osmopub1addwnpepqdct05khsxvtaaj0stuvayrpw0j8t6styr7vu05k3y63d5540ftuz8x6tsq
-  mnemonic: ""
-  threshold: 0
-  pubkeys: []
 
 **Important** write this mnemonic phrase in a safe place.
 It is the only way to recover your account if you ever forget your password.
@@ -74,20 +71,14 @@ Multiple keys can be created when needed. You can list all keys saved under the 
 
 ```bash
 $ osmosisd keys list
-    - name: Default
-    type: local
-    address: ## Address of "Default" ##
-    pubkey: ## Pubkey of "Default" ##
-    mnemonic: ""
-    threshold: 0
-    pubkeys: []
-  - name: Default_restore
-    type: local
-    address: ## Address of "Default_restore" ##
-    pubkey: ## Pubkey of "Default_restore" ##
-    mnemonic: ""
-    threshold: 0
-    pubkeys: []
+- address: ## Address of "Default" ##
+  name: Default
+  pubkey: ## Pubkey of "Default" ##
+  type: local
+- address: ## Address of "Default_restore" ##
+  name: Default_restore
+  pubkey: ## Pubkey of "Default_restore" ##
+  type: local
 ```
 
 </details>
@@ -105,13 +96,10 @@ You can retrieve key information by its name:
 
 ```bash
 $ osmosisd keys show Default --bech acc
-- name: Default
+- address: osmo1quw5r22pxy8znjtdkgqc65atrm3x5hg6vycm5n
+  name: Default
+  pubkey: '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AtQ2XW3f5D2jkF9zg7Ml..."}'
   type: local
-  address: osmo1quw5r22pxy8znjtdkgqc65atrm3x5hg6vycm5n
-  pubkey: osmopub1addwnpepqdct05khsxvtaaj0stuvayrpw0j8t6styr7vu05k3y63d5540ftuz8x6tsq
-  mnemonic: ""
-  threshold: 0
-  pubkeys: []
 ```
 
 </details>
@@ -121,13 +109,10 @@ $ osmosisd keys show Default --bech acc
 
 ```bash
 $ osmosisd keys show Default --bech val
-- name: Default
+- address: osmovaloper1zdlttjrqh9jsgk2l8tgn6f0kxlfy98s3prz35z
+  name: Default
+  pubkey: '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AtQ2XW3f5D2jkF9zg7Ml..."}'
   type: local
-  address: osmovaloper1zdlttjrqh9jsgk2l8tgn6f0kxlfy98s3prz35z
-  pubkey: osmovaloperpub1addwnpepq0ua07k8p3vrv5dap4pl77n4gjyyqsqrndzu0tdrr60ddhfg6ah0ck5ad5l
-  mnemonic: ""
-  threshold: 0
-  pubkeys: []
 ```
 
 </details>
@@ -137,13 +122,10 @@ $ osmosisd keys show Default --bech val
 
 ```bash
 $ osmosisd keys show Default --bech cons
-- name: Default
+- address: osmovalcons1zdlttjrqh9jsgk2l8tgn6f0kxlfy98s34pfmlc
+  name: Default
+  pubkey: '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AtQ2XW3f5D2jkF9zg7Ml..."}'
   type: local
-  address: osmovalcons1zdlttjrqh9jsgk2l8tgn6f0kxlfy98s34pfmlc
-  pubkey: osmovalconspub1addwnpepq0ua07k8p3vrv5dap4pl77n4gjyyqsqrndzu0tdrr60ddhfg6ah0ch6kdrc
-  mnemonic: ""
-  threshold: 0
-  pubkeys: []
 ```
 
 </details>
@@ -208,10 +190,10 @@ The default `os` backend stores the keys in operating system's credential sub-sy
 
 Here is a list of the corresponding password managers in different operating systems:
 - macOS (since Mac OS 8.6): [Keychain](https://support.apple.com/en-gb/guide/keychain-access/welcome/mac)
-- Windows: [Credentials Management API](https://docs.miosmosoft.com/en-us/windows/win32/secauthn/credentials-management)
+- Windows: [Credentials Management API](https://learn.microsoft.com/en-us/windows/win32/secauthn/credentials-management)
 - GNU/Linux:
   - [libsecret](https://gitlab.gnome.org/GNOME/libsecret)
-  - [kwallet](https://api.kde.org/frameworks/kwallet/html/index.html)
+  - [kwallet](https://invent.kde.org/frameworks/kwallet)
 
 ### file backend
 The `file` backend stores the encrypted keys inside the app's configuration directory. A password entry is required every time a user access it, which may also occur multiple times of repeated password prompts in one single command.

--- a/docs/build/developer-environment/keys/multisig.md
+++ b/docs/build/developer-environment/keys/multisig.md
@@ -39,7 +39,7 @@ First import the public keys of `test3` into your keyring.
 ```sh
 osmosisd keys add \
     test3 \
-    --pubkey=osmopub1addwnpepqgcxazmq6wgt2j4rdfumsfwla0zfk8e5sws3p3zg5dkm9007hmfysxas0u2
+    --pubkey='{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A0OjtIUCFJM3AobJ9HJTWKP9RZV2+WPcwVjLgsAidrZ/"}'
 ```
 
 Generate the multisig key with 2/3 threshold.
@@ -56,13 +56,10 @@ You can see its address and details:
 ```sh
 osmosisd keys show multi
 
-- name: multi
+- address: osmo1e0fx0q9meawrcq7fmma9x60gk35lpr4xk3884m
+  name: multi
+  pubkey: '{"@type":"/cosmos.crypto.multisig.LegacyAminoPubKey","threshold":2,"public_keys":[{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"ApCzSG8k7Tr4aM6e4OJRExN7cNtvH21L9azbh+uRrvt4"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Ah91erz8ChNanqLe9ea948rvAiXMCRlR5Ka7EE/c0xUK"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A0OjtIUCFJM3AobJ9HJTWKP9RZV2+WPcwVjLgsAidrZ/"}]}'
   type: multi
-  address: osmo1e0fx0q9meawrcq7fmma9x60gk35lpr4xk3884m
-  pubkey: osmopub1ytql0csgqgfzd666axrjzq3mxw59ys6yqcd3ydjvhgs0uzs6kdk5fp4t73gmkl8t6y02yfq7tvfzd666axrjzq3sd69kp5usk492x6nehqjal67ynv0nfqapzrzy3gmdk27la0kjfqfzd666axrjzq6utqt639ka2j3xkncgk65dup06t297ccljmxhvhu3rmk92u3afjuyz9dg9
-  mnemonic: ""
-  threshold: 0
-  pubkeys: []
 ```
 
 Let's add 10 OSMO to the multisig wallet:

--- a/docs/build/developer-environment/localtesting.md
+++ b/docs/build/developer-environment/localtesting.md
@@ -110,10 +110,12 @@ Running an Osmosis network with mainnet state is now as easy as setting up a sta
      On version X, run:
 
       ```bash
-      osmosisd in-place-testnet localosmosis osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj --trigger-testnet-upgrade
+      osmosisd in-place-testnet localosmosis osmo12smx2wdlyttvyzvzg54y2vnqwq2qjateuf7thj --trigger-testnet-upgrade=vXX
       ```
 
-      Where the first input is the desired chain-id of the new network and the second input is the desired validator operator address (where you vote from).
+      Where `vXX` indicates the next version that mainnet needs to be upgraded to. For example, when current mainnet state is at v26, the flag value should be `--trigger-testnet-upgrade=v27`.
+
+      The first input is the desired chain-id of the new network and the second input is the desired validator operator address (where you vote from).
       The address provided above is included in the localosmosis keyring under the name 'val'.
 
      The network will start and hit 10 blocks, at which point the upgrade will trigger and the network will halt.

--- a/docs/validate/joining-mainnet.md
+++ b/docs/validate/joining-mainnet.md
@@ -41,6 +41,12 @@ Download and place the genesis file in the osmosis config folder:
 wget -O ~/.osmosisd/config/genesis.json https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json
 ```
 
+Check that the downloaded file is a valid genesis before continuing:
+
+```bash
+osmosisd validate-genesis
+```
+
 ## Node Requirements and Cosmovisor Setup
 
 ### Go Requirement
@@ -89,7 +95,6 @@ echo "# Setup Cosmovisor" >> ~/.profile
 echo "export DAEMON_NAME=osmosisd" >> ~/.profile
 echo "export DAEMON_HOME=$HOME/.osmosisd" >> ~/.profile
 echo "export DAEMON_ALLOW_DOWNLOAD_BINARIES=false" >> ~/.profile
-echo "export DAEMON_LOG_BUFFER_SIZE=512" >> ~/.profile
 echo "export DAEMON_RESTART_AFTER_UPGRADE=true" >> ~/.profile
 echo "export UNSAFE_SKIP_BACKUP=true" >> ~/.profile
 source ~/.profile
@@ -102,7 +107,7 @@ Copy the current osmosisd binary into the cosmovisor/genesis folder:
 cp $GOPATH/bin/osmosisd ~/.osmosisd/cosmovisor/genesis/bin
 ```
 
-To check your work, ensure the version of cosmovisor and osmosisd are the same:
+To check your work, confirm that the daemon version reported by `cosmovisor version` matches the output of `osmosisd version` (the `cosmovisor version` output includes both Cosmovisor's own version and the version of the daemon binary it found):
 
 ```bash
 cosmovisor version
@@ -138,7 +143,6 @@ Environment="DAEMON_NAME=osmosisd"
 Environment="DAEMON_HOME=${HOME}/.osmosisd"
 Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
 Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
-Environment="DAEMON_LOG_BUFFER_SIZE=512"
 Environment="UNSAFE_SKIP_BACKUP=true"
 User=$USER
 ExecStart=${HOME}/go/bin/cosmovisor run start

--- a/docs/validate/node-configuration.md
+++ b/docs/validate/node-configuration.md
@@ -16,6 +16,35 @@ The keys below are stable, but peer and seed addresses rotate. Take those from t
 - **`pruning`** controls how much historical state is kept. See [Sync Options](/validate/sync-options) for pruned vs archive.
 - **API and gRPC** (`[api]`, `[grpc]`) toggle the REST/gRPC endpoints. Enable only what you serve; a validator typically serves none publicly.
 
+### Osmosis-specific `app.toml` settings
+
+`osmosisd init` writes several settings on top of the standard Cosmos SDK template.
+
+**`[osmosis-mempool]`** tunes the node's local mempool. These are CheckTx-time policies of your own node, not consensus rules:
+
+- **`max-gas-wanted-per-tx`** (default `"60000000"`): the maximum gas any single transaction may request. Applied only in the local mempool at CheckTx.
+- **`arbitrage-min-gas-fee`** (default `".1"`): the minimum gas fee any arbitrage transaction must pay, denominated in uosmo per gas. At the default, an arbitrage transaction using 1,000,000 gas costs 0.1 OSMO.
+- **`min-gas-price-for-high-gas-tx`** (default `".0025"`): the minimum gas fee for any transaction with high gas demand, denominated in uosmo per gas.
+- **`adaptive-fee-enabled`** (default `"true"`): enables the EIP-1559 style fee market logic in the mempool.
+
+**IAVL keys** (top-level, Osmosis-tuned):
+
+- **`iavl-cache-size`**: the IAVL tree cache size in number of nodes. `osmosisd` initializes it to `781250` (about 128 MB).
+- **`iavl-disable-fastnode`** (default `false`): disables the IAVL fast node index when `true`.
+- **`iavl-fastnode-module-whitelist`** (default `["lockup"]`): when populated (and fast nodes are not disabled), only the listed modules use fast nodes; when empty, all modules do.
+
+**`[wasm]`** configures the CosmWasm engine:
+
+- **`query_gas_limit`** (default `3000000`): the maximum gas a smart query contract call may use.
+- **`memory_cache_size`** (default `100`): the in-memory cache for Wasm contracts, in MiB; `0` disables it.
+- **`simulation_gas_limit`** (commented out by default): the maximum gas for a transaction simulation call; when unset, the consensus max block gas is used instead.
+
+`osmosisd init` also writes `[osmosis-sqs]`, `[osmosis-indexer]`, and `[otel]` sections for the sidecar query server, indexer, and OpenTelemetry integrations; all three are disabled by default and are not needed for an ordinary node or validator.
+
+:::note `osmosisd start` rewrites some of these values
+Unless started with `--reject-config-defaults`, `osmosisd start` overwrites a small set of keys with recommended defaults on every start: `minimum-gas-prices = "0uosmo"`, `arbitrage-min-gas-fee = "0.1"`, `max-gas-wanted-per-tx = "60000000"`, and `[wasm] memory_cache_size = 1000` in `app.toml`, plus several p2p and consensus timeouts in `config.toml` (`flush_throttle_timeout = "80ms"`, `timeout_commit = "400ms"`, `timeout_propose = "1.4s"`, `peer_gossip_sleep_duration = "50ms"`). If you deliberately set one of these keys to something else, pass the flag or your edit is silently reverted at startup.
+:::
+
 ## `config.toml`
 
 - **`persistent_peers` / `seeds`** define who your node connects to. `osmosisd init` writes the official Osmosis seeds (`seed.osmosis.zone:26656` and `seeds.polkachu.com:12556`). For the current full set of seeds and persistent peers, use the [Osmosis entry in the Cosmos chain registry](https://github.com/cosmos/chain-registry/blob/master/osmosis/chain.json) (its `peers` section), which is kept up to date by the community; peer addresses rotate, so prefer the registry over a hardcoded list.

--- a/docs/validate/relayer-guide.md
+++ b/docs/validate/relayer-guide.md
@@ -127,8 +127,10 @@ mkdir -p $HOME/hermes
 git clone https://github.com/informalsystems/hermes
 cd hermes
 git checkout v1.13.3
-cargo install ibc-relayer-cli --bin hermes --locked
+cargo install --path crates/relayer-cli --locked
 ```
+
+`cargo install --path` builds the checked-out tag; installing the `ibc-relayer-cli` crate by name would fetch a release from crates.io and ignore the checkout.
 
 Make hermes config & keys directory, copy config-template to config directory:
 ```sh
@@ -156,7 +158,7 @@ In this example, we will set `channel-141` on the cosmoshub-4 chain settings and
 id = 'cosmoshub-4'
 rpc_addr = 'http://127.0.0.1:26757'
 grpc_addr = 'http://127.0.0.1:9092'
-websocket_addr = 'ws://127.0.0.1:26757/websocket'
+event_source = { mode = 'push', url = 'ws://127.0.0.1:26757/websocket', batch_delay = '500ms' }
 rpc_timeout = '10s'
 account_prefix = 'cosmos'
 key_name = 'cosmos'
@@ -183,7 +185,7 @@ list = [
 id = 'osmosis-1'
 rpc_addr = 'http://127.0.0.1:26657'
 grpc_addr = 'http://127.0.0.1:9090'
-websocket_addr = 'ws://127.0.0.1:26657/websocket'
+event_source = { mode = 'push', url = 'ws://127.0.0.1:26657/websocket', batch_delay = '500ms' }
 rpc_timeout = '10s'
 account_prefix = 'osmo'
 key_name = 'osmosis'
@@ -305,7 +307,7 @@ hermes query packet commitments --chain cosmoshub-4 --port transfer --channel ch
 hermes query packet commitments --chain osmosis-1 --port transfer --channel channel-0
 ```
 
-Clear channel manually in both directions. Use this in case you want to clear congestion manually. Only works on hermes `v0.12.0` and higher. *You'll need to stop your Hermes daemon before using `clear packets`. This is important, otherwise the `clear packets` process will be racing with the daemeon process to access the same relayer wallet, resulting in account sequence mismatch errors.*
+Clear channel manually in both directions. Use this in case you want to clear congestion manually. *You'll need to stop your Hermes daemon before using `clear packets`. This is important, otherwise the `clear packets` process will be racing with the daemeon process to access the same relayer wallet, resulting in account sequence mismatch errors.*
 
 ```sh
 hermes clear packets --chain cosmoshub-4 --port transfer --channel channel-141

--- a/docs/validate/security.md
+++ b/docs/validate/security.md
@@ -37,6 +37,7 @@ Protect the consensus signing key. Options, in increasing robustness:
 
 - Keep `priv_validator_key.json` on the validator host with strict file permissions (baseline).
 - Use a remote signer / KMS so the key never lives on the internet-facing node. See [Using TMKMS](/validate/tmkms).
+- Use a threshold signer such as [Horcrux](https://github.com/strangelove-ventures/horcrux), which splits the key into shares across several signer hosts so no single machine holds it (see the note in [Using TMKMS](/validate/tmkms)).
 
 ## Operator account security
 

--- a/docs/validate/sync-options.md
+++ b/docs/validate/sync-options.md
@@ -20,7 +20,7 @@ Snapshot contents and state-sync RPC servers change frequently. The snapshot pro
 | **State sync** | Fetch a recent state snapshot from RPC peers and verify it against trusted block hashes | Minimal data transfer, no third-party archive needed |
 | **Genesis sync** | Replay every block from genesis | Building an archive node, or when you need full history |
 
-The `get.osmosis.zone` installer can set up a node from a snapshot; see [Install osmosisd](/validate/install-osmosisd).
+The `get.osmosis.zone` installer can set up a node from a snapshot; see [Running a Node on Mainnet](/validate/joining-mainnet).
 
 ## Pruning vs archive
 
@@ -59,7 +59,7 @@ State sync needs two things in `config.toml`: at least two trusted RPC servers f
 Public RPC endpoints that serve this purpose:
 
 - `https://rpc.osmosis.zone:443` (official)
-- `https://osmosis-rpc.polkachu.com:443` (community; Polkachu also documents a dedicated [state-sync service](https://www.polkachu.com/state_sync/osmosis))
+- `https://osmosis-rpc.polkachu.com:443` (community)
 - `https://osmosis-rpc.publicnode.com:443` (community)
 
 Endpoints change over time; confirm an endpoint responds to `/status` before relying on it.
@@ -88,6 +88,23 @@ trust_period = "168h0m0s"
 ```
 
 The snapshots themselves arrive over P2P from peers that have snapshot serving enabled; the RPC servers are only used to verify what arrives. If discovery stalls, a snapshot restore is the more predictable path.
+
+### Serving state sync
+
+The `[statesync]` section above only consumes snapshots. For your node to serve them to other state-syncing nodes, enable snapshot creation in `app.toml` under `[state-sync]`:
+
+```toml
+[state-sync]
+
+# snapshot-interval specifies the block interval at which local state sync snapshots are
+# taken (0 to disable).
+snapshot-interval = 1000
+
+# snapshot-keep-recent specifies the number of recent snapshots to keep and serve (0 to keep all).
+snapshot-keep-recent = 2
+```
+
+`snapshot-interval` defaults to `0` (no snapshots taken) and `snapshot-keep-recent` to `2`. A node with `pruning = "everything"` cannot take state sync snapshots; the configuration is rejected at startup.
 
 ## Reference
 

--- a/docs/validate/tmkms.md
+++ b/docs/validate/tmkms.md
@@ -7,6 +7,8 @@ sidebar_position: 10
 
 The Tendermint Key Management System (or TMKMS) should be used by any validator currently or intending to be in the active validator set. This application mitigates the risk of double-signing and provides high-availability to validator keys while keeping these keys on a separate physical host. While TMKMS can be used on the same machine as the validator, it is recommended to be on a separate host.
 
+TMKMS is not the only remote signer in production use. [Horcrux](https://github.com/strangelove-ventures/horcrux) splits the consensus key into threshold shares across several signer nodes, so no single host holds the whole key and the signer itself is highly available. Consider it if you need signer redundancy; this page covers TMKMS.
+
 ## Prepare TMKMS Dependencies
 
 Start by opening the node you intend to run TMKMS (not the node you validate on) and install the following dependencies:
@@ -71,13 +73,12 @@ export RUSTFLAGS=-Ctarget-feature=+aes,+ssse3
 
 ## Setup TMKMS
 
-In this example, we will be compiling from the github source code using the `--features=softsign` flag, however you may use `--features=yubihsm` if you want to use a yubikey (ledger support is not working properly at the moment, and this guide will not go into using yubihsm).
+In this example, we will be installing tmkms from crates.io using the `--features=softsign` flag, however you may use `--features=yubihsm` if you want to use a yubikey (ledger support is not working properly at the moment, and this guide will not go into using yubihsm).
 
 ```sh
-cd $HOME
-git clone https://github.com/iqlusioninc/tmkms.git
+mkdir -p $HOME/tmkms
 cd $HOME/tmkms
-cargo install tmkms --features=softsign
+cargo install tmkms --version 0.15.0 --features=softsign --locked
 tmkms init config
 tmkms softsign keygen ./config/secrets/secret_connection_key
 ```
@@ -102,7 +103,9 @@ Now, modify the `tmkms.toml` file
 nano $HOME/tmkms/config/tmkms.toml
 ```
 
-In this example, my validator has the private IP address `10.0.0.5` and we will be using port 26659 to feed the validator key to the validator. We will also be using chain_id `osmosis-1`, but if you are doing this on the testnet be sure to use `osmo-test-5` instead:
+In this example, my validator has the private IP address `10.0.0.5` and we will be using port 26659 to feed the validator key to the validator. We will also be using chain_id `osmosis-1`, but if you are doing this on the testnet be sure to use `osmo-test-5` instead.
+
+tmkms does not expand `~` or environment variables in this file, so the three paths must be absolute. `tmkms init config` already wrote them for your home directory; the example below is for a user whose home is `/home/user`:
 
 ```toml
 # Tendermint KMS configuration file
@@ -114,7 +117,7 @@ In this example, my validator has the private IP address `10.0.0.5` and we will 
 [[chain]]
 id = "osmosis-1"
 key_format = { type = "bech32", account_key_prefix = "osmopub", consensus_key_prefix = "osmovalconspub" }
-state_file = "/root/tmkms/config/state/priv_validator_state.json"
+state_file = "/home/user/tmkms/config/state/priv_validator_state.json"
 
 ## Signing Provider Configuration
 
@@ -123,14 +126,14 @@ state_file = "/root/tmkms/config/state/priv_validator_state.json"
 [[providers.softsign]]
 chain_ids = ["osmosis-1"]
 key_type = "consensus"
-path = "/root/tmkms/config/secrets/priv_validator_key"
+path = "/home/user/tmkms/config/secrets/priv_validator_key"
 
 ## Validator Configuration
 
 [[validator]]
 chain_id = "osmosis-1"
 addr = "tcp://10.0.0.5:26659"
-secret_key = "/root/tmkms/config/secrets/secret_connection_key"
+secret_key = "/home/user/tmkms/config/secrets/secret_connection_key"
 protocol_version = "v0.38"
 reconnect = true
 ```
@@ -167,19 +170,12 @@ Next, stop the validator. Move back to your VM running TMKMS and start it:
 tmkms start -c $HOME/tmkms/config/tmkms.toml
 ```
 
-You will see error logs like the following:
+tmkms loads the key and then repeatedly logs a connection-refused error, because the validator is not yet listening. This is expected at this point. An illustrative excerpt (exact formatting varies by version):
 
 ```
-2022-03-08T23:42:37.926816Z  INFO tmkms::commands::start: tmkms 0.11.0 starting up...
-2022-03-08T23:42:37.926968Z  INFO tmkms::keyring: [keyring:softsign] added consensus Ed25519 key: osmovalconspub1zcjduepq2qfkp3ahrhaafzuqglme9mares0eluj58xr6cy7c37cdmzq0eecqk0yehr
-2022-03-08T23:42:37.927216Z  INFO tmkms::connection::tcp: KMS node ID: 948f8fee83f7715f99b8b8a53d746ef00e7b0d9e
-2022-03-08T23:42:37.929454Z ERROR tmkms::client: [osmosis-1@tcp://10.0.0.5:26659] I/O error: Connection refused (os error 111)
-2022-03-08T23:42:38.929746Z  INFO tmkms::connection::tcp: KMS node ID: 948f8fee83f7715f99b8b8a53d746ef00e7b0d9e
-2022-03-08T23:42:38.931428Z ERROR tmkms::client: [osmosis-1@tcp://10.0.0.5:26659] I/O error: Connection refused (os error 111)
-2022-03-08T23:42:39.931729Z  INFO tmkms::connection::tcp: KMS node ID: 948f8fee83f7715f99b8b8a53d746ef00e7b0d9e
-2022-03-08T23:42:39.932417Z ERROR tmkms::client: [osmosis-1@tcp://10.0.0.5:26659] I/O error: Connection refused (os error 111)
-2022-03-08T23:42:40.932732Z  INFO tmkms::connection::tcp: KMS node ID: 948f8fee83f7715f99b8b8a53d746ef00e7b0d9e
-2022-03-08T23:42:40.933425Z ERROR tmkms::client: [osmosis-1@tcp://10.0.0.5:26659] I/O error: Connection refused (os error 111)
+INFO tmkms::commands::start: tmkms starting up...
+INFO tmkms::keyring: [keyring:softsign] added consensus Ed25519 key: osmovalconspub1...
+ERROR tmkms::client: [osmosis-1@tcp://10.0.0.5:26659] I/O error: Connection refused (os error 111)
 ```
 
 Now, start your osmosis validator on the validator node:
@@ -188,18 +184,12 @@ Now, start your osmosis validator on the validator node:
 osmosisd start
 ```
 
-Your TMKMS node will now show logs like the following:
+Success looks like this: tmkms connects to the validator and then logs a signed vote at each new, increasing height. An illustrative excerpt (exact formatting varies by version):
 
 ```
-2022-03-08T23:46:06.208451Z  INFO tmkms::connection::tcp: KMS node ID: 948f8fee83f7715f99b8b8a53d746ef00e7b0d9e
-2022-03-08T23:46:06.210568Z  INFO tmkms::session: [osmosis-1@tcp://10.0.0.5:26659] connected to validator successfully
-2022-03-08T23:46:06.210604Z  WARN tmkms::session: [osmosis-1@tcp://10.0.0.5:26659]: unverified validator peer ID! (ba44dd36899602e255b04e3608e5ef0fe4bc5f5b)
-2022-03-08T23:46:15.929787Z  INFO tmkms::session: [osmosis-1@tcp://10.0.0.5:26659] signed PreCommit:<nil> at h/r/s 3399910/0/2 (0 ms)
-2022-03-08T23:46:17.344579Z  INFO tmkms::session: [osmosis-1@tcp://10.0.0.5:26659] signed PreCommit:<nil> at h/r/s 3399911/0/2 (0 ms)
-2022-03-08T23:46:22.367627Z  INFO tmkms::session: [osmosis-1@tcp://10.0.0.5:26659] signed PreCommit:<nil> at h/r/s 3399912/0/2 (0 ms)
-2022-03-08T23:46:27.409777Z  INFO tmkms::session: [osmosis-1@tcp://10.0.0.5:26659] signed PreCommit:<nil> at h/r/s 3399913/0/2 (0 ms)
-2022-03-08T23:46:32.442300Z  INFO tmkms::session: [osmosis-1@tcp://10.0.0.5:26659] signed PreCommit:<nil> at h/r/s 3399914/0/2 (0 ms)
-2022-03-08T23:46:37.452162Z  INFO tmkms::session: [osmosis-1@tcp://10.0.0.5:26659] signed PreCommit:<nil> at h/r/s 3399915/0/2 (0 ms)
+INFO tmkms::session: [osmosis-1@tcp://10.0.0.5:26659] connected to validator successfully
+INFO tmkms::session: [osmosis-1@tcp://10.0.0.5:26659] signed PreCommit:<nil> at h/r/s 3399910/0/2 (0 ms)
+INFO tmkms::session: [osmosis-1@tcp://10.0.0.5:26659] signed PreCommit:<nil> at h/r/s 3399911/0/2 (0 ms)
 ```
 
 You should now be signing blocks! If you cancel the TMKMS process, you will no longer sign blocks and will stop syncing. If you restart the TMKMS process, your validator node will continue to sync from where it left off.

--- a/docs/validate/upgrades.md
+++ b/docs/validate/upgrades.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 # Chain Upgrades and Cosmovisor
 
-Osmosis upgrades through governance: a software-upgrade proposal sets an upgrade height, and at that height every node must switch to the new `osmosisd` binary. If your node is still running the old binary at the upgrade height, it halts. [Cosmovisor](https://docs.cosmos.network/main/build/tooling/cosmovisor) automates the binary swap so you do not have to be awake at the block.
+Osmosis upgrades through governance: a software-upgrade proposal sets an upgrade height, and at that height every node must switch to the new `osmosisd` binary. If your node is still running the old binary at the upgrade height, it halts. [Cosmovisor](https://docs.cosmos.network/sdk/latest/guides/upgrades/cosmovisor) automates the binary swap so you do not have to be awake at the block.
 
 Take the upgrade name, height, and binary version for each upgrade from the governance proposal and the [Osmosis releases](https://github.com/osmosis-labs/osmosis/releases) page. A release may also carry upgrade-specific instructions; read those before staging.
 
@@ -68,5 +68,5 @@ A node that misses an upgrade halts cleanly at the upgrade height, so no state r
 
 ## Reference
 
-- Cosmovisor: [Cosmos SDK docs](https://docs.cosmos.network/main/build/tooling/cosmovisor).
+- Cosmovisor: [Cosmos SDK docs](https://docs.cosmos.network/sdk/latest/guides/upgrades/cosmovisor).
 - Osmosis releases and upgrade tags: [github.com/osmosis-labs/osmosis/releases](https://github.com/osmosis-labs/osmosis/releases).


### PR DESCRIPTION
Accuracy fixes for node operators and tooling pages, verified against v31.0.2 source, the SDK 0.50 fork, and upstream releases.

## Validate
- **relayer-guide.md:** the example config used `websocket_addr`, removed in Hermes 1.5, so it hard-failed on the guide's own pinned v1.13.3; replaced with `event_source` matching the shipped template. Install now builds the checkout (`cargo install --path crates/relayer-cli --locked`) because the 1.13.3 crate version was never published. Fossil v0.12 compatibility note removed.
- **upgrades.md / joining-mainnet.md:** dead cosmovisor doc links repointed; `DAEMON_LOG_BUFFER_SIZE` (removed in cosmovisor v1.0) deleted; version-check wording fixed; genesis download now followed by `osmosisd validate-genesis` (no published checksum exists in the networks repo; the v31 command is the root-level alias, not `genesis validate`).
- **sync-options.md:** Polkachu no longer offers Osmosis state sync (404, absent from their chain list); their RPC and snapshots stay. New serving-state-sync subsection (`snapshot-interval`, `snapshot-keep-recent`, verified in the SDK fork). Installer pointer fixed.
- **tmkms.md:** config paths made absolute and consistent (tmkms does not expand `~`); install pinned via crates.io `--version 0.15.0 --locked`; 2022-era log dumps replaced; Horcrux added as the threshold-signing alternative, cross-linked from security.md.
- **node-configuration.md:** new Osmosis-specific app.toml reference (`[osmosis-mempool]` incl. `arbitrage-min-gas-fee`, IAVL keys, `[wasm]`), all values from `initAppConfig`, plus the `osmosisd start` config-rewrite behavior and `--reject-config-defaults`.

## Developer environment
- **cli.md:** the config section predated confix; every command failed on v31. Rewritten to `config get/set/view client` (verified against the SDK fork), status sample refreshed to CometBFT 0.38 output, dead gaiad tutorial link replaced.
- **keys/multisig:** `--pubkey` takes JSON since SDK 0.44; samples updated to 0.50 output shapes; broken Microsoft/kwallet links fixed; intro link added.
- **localtesting.md:** `--trigger-testnet-upgrade` requires the handler name (`=vXX`).
- **ide-guide.md:** golangci-lint (what the repo uses) replaces deprecated golint; VS Code Copilot extension id fixed.

## Beaker
- Command reference regenerated from the real v0.1.8 tag: adds `wasm execute`/`wasm query`/`beaker task` (page was missing entirely), `-a/--account-sequence`, current ts-gen flags; upstream typos fixed.
- Config defaults corrected to released v0.1.8 values and made consistent across pages, with a note on the legacy testnet hostnames.
- Legacy gov v1beta1 proposal subcommands flagged as defunct on current networks (no wasm route on the legacy router), pointing at the working wasm-proposal flow; the root Beaker page now carries the same deprecation banner as the rest of the section and drops its defunct governance walkthrough.
- LocalOsmosis references repointed to the chain repo; ts-codegen rename.

Not documented on purpose: `make localnet-start-with-state` appears in `localnet-help` but has no make rule in v31.0.2 (chain-repo Makefile gap, to be raised upstream).

`yarn build` and codespell pass.